### PR TITLE
Import DAG の epistemic 整列 + 低度混在判断 — Issue #46 G2/G3

### DIFF
--- a/lean-formalization/Manifest.lean
+++ b/lean-formalization/Manifest.lean
@@ -1,20 +1,23 @@
+-- Tier A: 定義的基盤
 import Manifest.Ontology
-import Manifest.Axioms
-import Manifest.EmpiricalPostulates
-import Manifest.Principles
-import Manifest.Workflow
-import Manifest.Observable
-import Manifest.ObservableDesign
+-- Tier B: 命題層（strength 降順）
+import Manifest.Axioms              -- strength 5: constraint
+import Manifest.EmpiricalPostulates -- strength 4: empiricalPostulate
+import Manifest.Principles          -- strength 3: principle
+import Manifest.Observable          -- strength 2: boundary
+import Manifest.ObservableDesign    -- strength 1: designTheorem
+import Manifest.DesignFoundation    -- strength 1: designTheorem
+-- Tier C: メタ理論・応用
 import Manifest.Meta
+import Manifest.EpistemicLayer
 import Manifest.Evolution
-import Manifest.DesignFoundation
-import Manifest.FormalDerivationSkill
+import Manifest.Workflow
 import Manifest.Terminology
 import Manifest.Procedure
+import Manifest.FormalDerivationSkill
 import Manifest.ConformanceVerification
 import Manifest.AxiomQuality
 import Manifest.EvolveSkill
-import Manifest.EpistemicLayer
 
 /-!
 # Agent Manifest — Formal Specification

--- a/lean-formalization/Manifest/ConformanceVerification.lean
+++ b/lean-formalization/Manifest/ConformanceVerification.lean
@@ -1,9 +1,9 @@
-import Manifest.Procedure
-import Manifest.Terminology
 import Manifest.Axioms
 import Manifest.EmpiricalPostulates
 import Manifest.Observable
 import Manifest.Meta
+import Manifest.Terminology
+import Manifest.Procedure
 
 /-!
 # 準拠検証: Lean 文書群の手順書・用語リファレンスへの準拠

--- a/lean-formalization/Manifest/DesignFoundation.lean
+++ b/lean-formalization/Manifest/DesignFoundation.lean
@@ -1,9 +1,9 @@
 import Manifest.Ontology
 import Manifest.Axioms
 import Manifest.EmpiricalPostulates
+import Manifest.Principles
 import Manifest.Observable
 import Manifest.ObservableDesign
-import Manifest.Principles
 
 /-!
 # Epistemic Layer: designTheorem (strength 1) — 設計開発基礎論の形式化（Γ ⊢ φ の応用）

--- a/lean-formalization/Manifest/EvolveSkill.lean
+++ b/lean-formalization/Manifest/EvolveSkill.lean
@@ -1,6 +1,6 @@
-import Manifest.Workflow
 import Manifest.Evolution
 import Manifest.DesignFoundation
+import Manifest.Workflow
 
 /-!
 # /evolve スキルの形式的評価 (Γ ⊢ φ)


### PR DESCRIPTION
## Summary

- 全モジュールの import を認識論的層の strength 降順に整列（G2 #49）
- 低度混在 4 モジュール（DesignFoundation, Principles, Meta, Procedure）を分析、全て許容と判断（G3 #50）

## 変更箇所

| ファイル | 変更内容 |
|---------|---------|
| Manifest.lean | Tier A→B(strength降順)→C にコメント付き整列 |
| DesignFoundation.lean | Principles(3) を Observable(2) の前に移動 |
| ConformanceVerification.lean | strength 降順に全 import 並べ替え |
| EvolveSkill.lean | designTheorem(1) を meta の前に移動 |

## G3 判断結果

| モジュール | 混在の性質 | 判断 |
|-----------|-----------|------|
| DesignFoundation | 構造的必然（D は T/E/P からの導出） | 許容 |
| Principles | 構造的必然（P は T/E からの定理） | 許容 |
| Meta | 混在なし（メタ理論：分類・観察のみ） | 許容 |
| Procedure | 混在なし（手続き規則：自己完結） | 許容 |

## Test plan

- [x] `lake build Manifest` 成功
- [x] `bash tests/test-all.sh` 全通過 (215/215)
- [x] axiom/theorem カウント不変 (63/316)

Closes #49
Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)