### PR TITLE
hook-hallucination-detection: WARN mode PoC + install script

### DIFF
--- a/.claude/hooks/hallucination-check.sh
+++ b/.claude/hooks/hallucination-check.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# PoC: Hallucination Detection Hook — PreToolUse: Edit, Write
+#
+# Lean 定義名・数値引用のリアルタイム事実検証。
+# .md ファイルへの Edit/Write 時に、引用された Lean 定義名と
+# 数値（axiom/theorem/test count）の実在を検証する。
+#
+# Mode:
+#   WARN  — stderr に警告を出すが exit 0（ブロックしない）
+#   BLOCK — exit 2 でブロック
+#
+# 現在は WARN モードで動作（PoC フェーズ）。
+
+# Note: hooks must NOT use set -e (non-zero grep exits would crash the hook)
+# Exit codes: 0 = allow, 2 = block. Any other exit = error.
+set -u
+
+MODE="${HALLUCINATION_HOOK_MODE:-WARN}"
+# 本番配置: .claude/hooks/ → PROJECT_ROOT は ../..
+# PoC/テスト: PROJECT_ROOT を環境変数で上書き可能
+if [ -n "${HALLUCINATION_HOOK_PROJECT_ROOT:-}" ]; then
+  PROJECT_ROOT="$HALLUCINATION_HOOK_PROJECT_ROOT"
+else
+  PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+fi
+LEAN_DIR="$PROJECT_ROOT/lean-formalization"
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Edit/Write 以外は無視
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# .md ファイルのみ検査（.lean は Lean コンパイラが検証）
+if ! echo "$FILE_PATH" | grep -qE '\.md$'; then
+  exit 0
+fi
+
+# 編集内容を取得
+CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty' 2>/dev/null)
+if [ -z "$CONTENT" ]; then
+  exit 0
+fi
+
+WARNINGS=""
+
+# --- Check 1: Lean 定義名の実在検証 ---
+# バッククォート内の Lean 定義名パターンを抽出
+# パターン: `snake_case_name` で、Lean の定義名に見えるもの
+# 除外: 短すぎるもの (3文字以下)、明らかなコマンド/パス、日本語
+LEAN_NAMES=$(echo "$CONTENT" | grep -oE '`[a-z][a-z0-9_]+[a-z0-9]`' | tr -d '`' | sort -u | while read -r name; do
+  # 3文字以下は除外
+  [ ${#name} -le 3 ] && continue
+  # 明らかなコマンド名・パスを除外
+  echo "$name" | grep -qE '^(bash|grep|test|echo|exit|null|true|false|jq|sed|awk|wc|cat|head|tail|sort|uniq|find|git|lake|lean|cd|ls|rm|cp|mv|mkdir|chmod|diff|curl|wget|npm|bun|bunx|python)$' && continue
+  # ファイルパスの一部を除外
+  echo "$name" | grep -qE '(\.sh|\.json|\.md|\.lean|\.jsonl)' && continue
+  echo "$name"
+done)
+
+if [ -n "$LEAN_NAMES" ]; then
+  # Lean ファイルから全定義名を取得（キャッシュ考慮）
+  CACHE_FILE="/tmp/lean-definitions-cache.txt"
+  CACHE_AGE=300  # 5分
+
+  if [ -f "$CACHE_FILE" ] && [ "$(find "$CACHE_FILE" -mmin -5 2>/dev/null)" ]; then
+    LEAN_DEFS=$(cat "$CACHE_FILE")
+  else
+    LEAN_DEFS=$(grep -rhE '^(theorem|axiom|def|lemma|instance|class|structure|opaque|inductive) [a-zA-Z_][a-zA-Z0-9_]*' \
+      "$LEAN_DIR"/Manifest/*.lean 2>/dev/null | \
+      sed -E 's/^(theorem|axiom|def|lemma|instance|class|structure|opaque|inductive) ([a-zA-Z_][a-zA-Z0-9_]*).*/\2/' | \
+      sort -u)
+    echo "$LEAN_DEFS" > "$CACHE_FILE" 2>/dev/null || true
+  fi
+
+  # 各名前を検証
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    # Lean 定義名のように見えるもの（snake_case でアンダースコアを含む）
+    if echo "$name" | grep -qE '_'; then
+      # Lean 定義として検証
+      if ! echo "$LEAN_DEFS" | grep -qxF "$name"; then
+        # SKILL.md/CLAUDE.md の既知セクション名やフィールド名は除外
+        echo "$name" | grep -qE '^(failure_type|failure_subtype|tool_name|tool_input|file_path|new_string|session_id|tool_use_id|pass_count|fail_count|pass_rate|cost_per_improvement|session_cost|improvements_count|conservative_extension|compatible_change|breaking_change|action_space|proxy_classification|test_pass_rate|fix_ratio|deferred_open|deferred_status|hypothesis_table_stats|evolve_cost_efficiency|total_improvements|definition_note|last_updated_run|opened_in_run|resolved_in_run)$' && continue
+        WARNINGS="${WARNINGS}Lean definition '${name}' not found in formalization.\n"
+      fi
+    fi
+  done <<< "$LEAN_NAMES"
+fi
+
+# --- Check 2: 数値引用の検証 ---
+# "N axioms" / "N theorems" / "N tests" パターンを検出
+check_count() {
+  local pattern="$1"
+  local actual="$2"
+  local label="$3"
+
+  local claimed
+  claimed=$(echo "$CONTENT" | grep -oE "[0-9]+ ${pattern}" | head -1 | grep -oE '^[0-9]+')
+  if [ -n "$claimed" ] && [ "$claimed" != "$actual" ]; then
+    WARNINGS="${WARNINGS}${label} count mismatch: claimed ${claimed}, actual ${actual}.\n"
+  fi
+}
+
+# 実際の値を取得
+if [ -d "$LEAN_DIR/Manifest" ]; then
+  ACTUAL_AXIOMS=$(grep -r "^axiom [a-z]" "$LEAN_DIR"/Manifest/ --include="*.lean" 2>/dev/null | wc -l | tr -d ' ')
+  ACTUAL_THEOREMS=$(grep -r "^theorem " "$LEAN_DIR"/Manifest/ --include="*.lean" 2>/dev/null | wc -l | tr -d ' ')
+fi
+# テスト数: test-all.sh の結果から抽出（全実行は重いため、JSONL の最新値を使用）
+ACTUAL_TESTS=$(tail -1 "$PROJECT_ROOT/.claude/metrics/evolve-history.jsonl" 2>/dev/null | jq -r '.tests.passed // empty' 2>/dev/null)
+if [ -z "$ACTUAL_TESTS" ]; then
+  ACTUAL_TESTS=$(grep -rc "^test_" "$PROJECT_ROOT/tests/"*.sh 2>/dev/null | awk -F: '{s+=$2}END{print s}')
+fi
+
+check_count "axioms?" "${ACTUAL_AXIOMS:-}" "Axiom"
+check_count "theorems?" "${ACTUAL_THEOREMS:-}" "Theorem"
+check_count "tests" "${ACTUAL_TESTS:-}" "Test"
+
+# --- 結果出力 ---
+if [ -n "$WARNINGS" ]; then
+  if [ "$MODE" = "BLOCK" ]; then
+    printf "Hallucination detected:\n%b" "$WARNINGS" >&2
+    exit 2
+  else
+    # WARN モード: stderr に出力するが exit 0
+    printf "[hallucination-hook WARN] %b" "$WARNINGS" >&2
+    exit 0
+  fi
+fi
+
+exit 0

--- a/install-hallucination-hook.sh
+++ b/install-hallucination-hook.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# hook-hallucination-detection 設置スクリプト
+#
+# 実行方法:
+#   bash install-hallucination-hook.sh
+#
+# このスクリプトは以下を行う:
+# 1. .claude/hooks/hallucination-check.sh をコピー
+# 2. .claude/settings.json に PreToolUse hook を登録（WARN モード）
+# 3. deferred-status.json を更新
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+# worktree から実行する場合、メインリポジトリの位置を推定
+if echo "$PROJECT_ROOT" | grep -q '.claude/worktrees'; then
+  MAIN_ROOT="$(echo "$PROJECT_ROOT" | sed 's|/.claude/worktrees/.*||')"
+else
+  MAIN_ROOT="$PROJECT_ROOT"
+fi
+
+echo "=== hook-hallucination-detection 設置 ==="
+echo "メインリポジトリ: $MAIN_ROOT"
+echo ""
+
+# Step 1: Hook スクリプトをコピー
+HOOK_SRC="$PROJECT_ROOT/.claude/hooks/hallucination-check.sh"
+HOOK_DST="$MAIN_ROOT/.claude/hooks/hallucination-check.sh"
+
+if [ ! -f "$HOOK_SRC" ]; then
+  echo "ERROR: ソースファイルが見つかりません: $HOOK_SRC" >&2
+  exit 1
+fi
+
+cp "$HOOK_SRC" "$HOOK_DST"
+chmod +x "$HOOK_DST"
+echo "1. Hook スクリプトをコピーしました: $HOOK_DST"
+
+# Step 2: settings.json に登録
+SETTINGS="$MAIN_ROOT/.claude/settings.json"
+if [ ! -f "$SETTINGS" ]; then
+  echo "ERROR: settings.json が見つかりません: $SETTINGS" >&2
+  exit 1
+fi
+
+# 既に登録されているか確認
+if grep -q 'hallucination-check' "$SETTINGS"; then
+  echo "2. settings.json に既に登録済み（スキップ）"
+else
+  # PreToolUse の Edit/Write matcher に追加
+  # jq で安全に追加
+  TEMP_SETTINGS=$(mktemp)
+  jq '.hooks.PreToolUse += [{
+    "matcher": "Edit",
+    "hooks": ["bash .claude/hooks/hallucination-check.sh"]
+  }, {
+    "matcher": "Write",
+    "hooks": ["bash .claude/hooks/hallucination-check.sh"]
+  }]' "$SETTINGS" > "$TEMP_SETTINGS"
+  mv "$TEMP_SETTINGS" "$SETTINGS"
+  echo "2. settings.json に PreToolUse hook を登録しました（Edit, Write matcher）"
+fi
+
+# Step 3: deferred-status.json を更新
+DEFERRED="$MAIN_ROOT/.claude/metrics/deferred-status.json"
+if [ -f "$DEFERRED" ]; then
+  TEMP_DEFERRED=$(mktemp)
+  jq '.items["hook-hallucination-detection"].status = "resolved" |
+      .items["hook-hallucination-detection"].resolved_in_run = 63 |
+      .items["hook-hallucination-detection"].note = "WARN mode で導入。G1 PASS (13/13, 0.051s), G2 FAIL (検出率3-6%), 全体 CONDITIONAL。#70 参照。" |
+      .last_updated_run = 63' "$DEFERRED" > "$TEMP_DEFERRED"
+  mv "$TEMP_DEFERRED" "$DEFERRED"
+  echo "3. deferred-status.json を更新しました（hook-hallucination-detection → resolved）"
+fi
+
+echo ""
+echo "=== 設置完了 ==="
+echo ""
+echo "確認手順:"
+echo "  1. git diff .claude/settings.json で登録内容を確認"
+echo "  2. echo '{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"/tmp/t.md\",\"new_string\":\"99 axioms\"}}' | bash .claude/hooks/hallucination-check.sh"
+echo "  3. WARN メッセージが stderr に出力されることを確認"
+echo ""
+echo "BLOCK モードへの昇格:"
+echo "  環境変数 HALLUCINATION_HOOK_MODE=BLOCK を設定"

--- a/poc-hallucination-hook.sh
+++ b/poc-hallucination-hook.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# PoC: Hallucination Detection Hook — PreToolUse: Edit, Write
+#
+# Lean 定義名・数値引用のリアルタイム事実検証。
+# .md ファイルへの Edit/Write 時に、引用された Lean 定義名と
+# 数値（axiom/theorem/test count）の実在を検証する。
+#
+# Mode:
+#   WARN  — stderr に警告を出すが exit 0（ブロックしない）
+#   BLOCK — exit 2 でブロック
+#
+# 現在は WARN モードで動作（PoC フェーズ）。
+
+# Note: hooks must NOT use set -e (non-zero grep exits would crash the hook)
+# Exit codes: 0 = allow, 2 = block. Any other exit = error.
+set -u
+
+MODE="${HALLUCINATION_HOOK_MODE:-WARN}"
+# 本番配置: .claude/hooks/ → PROJECT_ROOT は ../..
+# PoC/テスト: PROJECT_ROOT を環境変数で上書き可能
+if [ -n "${HALLUCINATION_HOOK_PROJECT_ROOT:-}" ]; then
+  PROJECT_ROOT="$HALLUCINATION_HOOK_PROJECT_ROOT"
+else
+  PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+fi
+LEAN_DIR="$PROJECT_ROOT/lean-formalization"
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Edit/Write 以外は無視
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# .md ファイルのみ検査（.lean は Lean コンパイラが検証）
+if ! echo "$FILE_PATH" | grep -qE '\.md$'; then
+  exit 0
+fi
+
+# 編集内容を取得
+CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty' 2>/dev/null)
+if [ -z "$CONTENT" ]; then
+  exit 0
+fi
+
+WARNINGS=""
+
+# --- Check 1: Lean 定義名の実在検証 ---
+# バッククォート内の Lean 定義名パターンを抽出
+# パターン: `snake_case_name` で、Lean の定義名に見えるもの
+# 除外: 短すぎるもの (3文字以下)、明らかなコマンド/パス、日本語
+LEAN_NAMES=$(echo "$CONTENT" | grep -oE '`[a-z][a-z0-9_]+[a-z0-9]`' | tr -d '`' | sort -u | while read -r name; do
+  # 3文字以下は除外
+  [ ${#name} -le 3 ] && continue
+  # 明らかなコマンド名・パスを除外
+  echo "$name" | grep -qE '^(bash|grep|test|echo|exit|null|true|false|jq|sed|awk|wc|cat|head|tail|sort|uniq|find|git|lake|lean|cd|ls|rm|cp|mv|mkdir|chmod|diff|curl|wget|npm|bun|bunx|python)$' && continue
+  # ファイルパスの一部を除外
+  echo "$name" | grep -qE '(\.sh|\.json|\.md|\.lean|\.jsonl)' && continue
+  echo "$name"
+done)
+
+if [ -n "$LEAN_NAMES" ]; then
+  # Lean ファイルから全定義名を取得（キャッシュ考慮）
+  CACHE_FILE="/tmp/lean-definitions-cache.txt"
+  CACHE_AGE=300  # 5分
+
+  if [ -f "$CACHE_FILE" ] && [ "$(find "$CACHE_FILE" -mmin -5 2>/dev/null)" ]; then
+    LEAN_DEFS=$(cat "$CACHE_FILE")
+  else
+    LEAN_DEFS=$(grep -rhE '^(theorem|axiom|def|lemma|instance|class|structure|opaque|inductive) [a-zA-Z_][a-zA-Z0-9_]*' \
+      "$LEAN_DIR"/Manifest/*.lean 2>/dev/null | \
+      sed -E 's/^(theorem|axiom|def|lemma|instance|class|structure|opaque|inductive) ([a-zA-Z_][a-zA-Z0-9_]*).*/\2/' | \
+      sort -u)
+    echo "$LEAN_DEFS" > "$CACHE_FILE" 2>/dev/null || true
+  fi
+
+  # 各名前を検証
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    # Lean 定義名のように見えるもの（snake_case でアンダースコアを含む）
+    if echo "$name" | grep -qE '_'; then
+      # Lean 定義として検証
+      if ! echo "$LEAN_DEFS" | grep -qxF "$name"; then
+        # SKILL.md/CLAUDE.md の既知セクション名やフィールド名は除外
+        echo "$name" | grep -qE '^(failure_type|failure_subtype|tool_name|tool_input|file_path|new_string|session_id|tool_use_id|pass_count|fail_count|pass_rate|cost_per_improvement|session_cost|improvements_count|conservative_extension|compatible_change|breaking_change|action_space|proxy_classification|test_pass_rate|fix_ratio|deferred_open|deferred_status|hypothesis_table_stats|evolve_cost_efficiency|total_improvements|definition_note|last_updated_run|opened_in_run|resolved_in_run)$' && continue
+        WARNINGS="${WARNINGS}Lean definition '${name}' not found in formalization.\n"
+      fi
+    fi
+  done <<< "$LEAN_NAMES"
+fi
+
+# --- Check 2: 数値引用の検証 ---
+# "N axioms" / "N theorems" / "N tests" パターンを検出
+check_count() {
+  local pattern="$1"
+  local actual="$2"
+  local label="$3"
+
+  local claimed
+  claimed=$(echo "$CONTENT" | grep -oE "[0-9]+ ${pattern}" | head -1 | grep -oE '^[0-9]+')
+  if [ -n "$claimed" ] && [ "$claimed" != "$actual" ]; then
+    WARNINGS="${WARNINGS}${label} count mismatch: claimed ${claimed}, actual ${actual}.\n"
+  fi
+}
+
+# 実際の値を取得
+if [ -d "$LEAN_DIR/Manifest" ]; then
+  ACTUAL_AXIOMS=$(grep -r "^axiom [a-z]" "$LEAN_DIR"/Manifest/ --include="*.lean" 2>/dev/null | wc -l | tr -d ' ')
+  ACTUAL_THEOREMS=$(grep -r "^theorem " "$LEAN_DIR"/Manifest/ --include="*.lean" 2>/dev/null | wc -l | tr -d ' ')
+fi
+# テスト数: test-all.sh の結果から抽出（全実行は重いため、JSONL の最新値を使用）
+ACTUAL_TESTS=$(tail -1 "$PROJECT_ROOT/.claude/metrics/evolve-history.jsonl" 2>/dev/null | jq -r '.tests.passed // empty' 2>/dev/null)
+if [ -z "$ACTUAL_TESTS" ]; then
+  ACTUAL_TESTS=$(grep -rc "^test_" "$PROJECT_ROOT/tests/"*.sh 2>/dev/null | awk -F: '{s+=$2}END{print s}')
+fi
+
+check_count "axioms?" "${ACTUAL_AXIOMS:-}" "Axiom"
+check_count "theorems?" "${ACTUAL_THEOREMS:-}" "Theorem"
+check_count "tests" "${ACTUAL_TESTS:-}" "Test"
+
+# --- 結果出力 ---
+if [ -n "$WARNINGS" ]; then
+  if [ "$MODE" = "BLOCK" ]; then
+    printf "Hallucination detected:\n%b" "$WARNINGS" >&2
+    exit 2
+  else
+    # WARN モード: stderr に出力するが exit 0
+    printf "[hallucination-hook WARN] %b" "$WARNINGS" >&2
+    exit 0
+  fi
+fi
+
+exit 0

--- a/run-poc-validation.sh
+++ b/run-poc-validation.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# PoC Hook のバリデーションスイート
+# G1: 技術的実現可能性 / G2: 検出率 / G3: false positive
+
+set -euo pipefail
+
+HOOK="$(dirname "$0")/poc-hallucination-hook.sh"
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+export HALLUCINATION_HOOK_MODE=WARN
+# PoC はプロジェクトルートを明示指定
+export HALLUCINATION_HOOK_PROJECT_ROOT="/Users/nirarin/work/agent-manifesto"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+run_check() {
+  local desc="$1"
+  local input="$2"
+  local expect_warn="$3"  # "yes" or "no"
+
+  TOTAL=$((TOTAL + 1))
+  local stderr_output
+  stderr_output=$(echo "$input" | bash "$HOOK" 2>&1 >/dev/null || true)
+
+  if [ "$expect_warn" = "yes" ]; then
+    if [ -n "$stderr_output" ]; then
+      PASS=$((PASS + 1))
+      echo "  PASS: $desc"
+    else
+      FAIL=$((FAIL + 1))
+      echo "  FAIL: $desc (expected warning, got none)"
+    fi
+  else
+    if [ -n "$stderr_output" ]; then
+      FAIL=$((FAIL + 1))
+      echo "  FAIL: $desc (unexpected warning: $stderr_output)"
+    else
+      PASS=$((PASS + 1))
+      echo "  PASS: $desc"
+    fi
+  fi
+}
+
+echo "=== G1: 技術的実現可能性 ==="
+echo ""
+echo "--- True Positive Checks (should warn) ---"
+
+# TP1: 存在しない Lean 定義名
+run_check "TP1: non-existent Lean def" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"The theorem `fake_nonexistent_theorem` proves safety."}}' \
+  "yes"
+
+# TP2: 間違った axiom count
+run_check "TP2: wrong axiom count" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"Currently we have 99 axioms in the formalization."}}' \
+  "yes"
+
+# TP3: 間違った theorem count
+run_check "TP3: wrong theorem count" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"The project contains 500 theorems."}}' \
+  "yes"
+
+# TP4: 存在しない定義名（実際の名前に似せた偽名）
+run_check "TP4: plausible but fake Lean def" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"See `stasis_always_healthy` in Evolution.lean."}}' \
+  "yes"
+
+echo ""
+echo "--- True Negative Checks (should NOT warn) ---"
+
+# TN1: 存在する Lean 定義名 (camelCase — アンダースコアなし、検査対象外)
+run_check "TN1: real Lean def stasisUnhealthy (camelCase)" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"The axiom `stasisUnhealthy` formalizes this."}}' \
+  "no"
+
+# TN2: 正しい axiom count
+run_check "TN2: correct axiom count" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"Currently we have 63 axioms."}}' \
+  "no"
+
+# TN3: 正しい theorem count
+run_check "TN3: correct theorem count" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"The project contains 288 theorems."}}' \
+  "no"
+
+# TN4: .lean ファイルへの書き込み（検査対象外）
+run_check "TN4: .lean file (not checked)" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/code.lean","new_string":"theorem fake_thing : True := trivial"}}' \
+  "no"
+
+# TN5: 一般的なコマンド名（除外対象）
+run_check "TN5: excluded command names" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"Run `bash` and `grep` for results."}}' \
+  "no"
+
+# TN6: JSON フィールド名（除外対象）
+run_check "TN6: excluded field names" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"The `failure_type` and `failure_subtype` fields track errors."}}' \
+  "no"
+
+# TN7: 存在する定義名 (snake_case)
+run_check "TN7: real Lean def breaking_change_dominates" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"See `breaking_change_dominates` in Evolution.lean."}}' \
+  "no"
+
+# TN8: 数値が含まれるが count パターンではない
+run_check "TN8: number without count pattern" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"Run 63 completed with 4 improvements."}}' \
+  "no"
+
+echo ""
+echo "--- Performance Check ---"
+
+LARGE_CONTENT="The manifesto defines stasisUnhealthy and breaking_change_dominates as core theorems. We also reference integration_requires_verification and feedback_precedes_improvement. There are 63 axioms and 288 theorems in total. The validPhaseTransition function governs phase transitions. Some fake_hallucinated_name might appear."
+
+START_TIME=$(python3 -c 'import time; print(time.time())')
+echo '{"tool_name":"Edit","tool_input":{"file_path":"'"$PROJECT_ROOT"'/doc.md","new_string":"'"$LARGE_CONTENT"'"}}' | bash "$HOOK" 2>/dev/null || true
+END_TIME=$(python3 -c 'import time; print(time.time())')
+ELAPSED=$(python3 -c "print(f'{$END_TIME - $START_TIME:.3f}')")
+echo "  Execution time: ${ELAPSED}s (target: < 2s)"
+if python3 -c "import sys; sys.exit(0 if $END_TIME - $START_TIME < 2.0 else 1)"; then
+  echo "  PASS: Performance within target"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Performance exceeds target"
+  FAIL=$((FAIL + 1))
+fi
+TOTAL=$((TOTAL + 1))
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS / $TOTAL"
+echo "FAIL: $FAIL / $TOTAL"
+echo "Pass rate: $(python3 -c "print(f'{$PASS/$TOTAL*100:.1f}%')")"


### PR DESCRIPTION
## Summary
- Research #70 の成果物: Lean 定義名・数値引用のリアルタイム事実検証 hook
- G1 PASS (13/13, 0.051s) / G2 FAIL (検出率 3-6%) / 全体 CONDITIONAL
- WARN モードで導入推奨（BLOCK はFP率計測後）

## 設置手順
```bash
bash install-hallucination-hook.sh
```

## 検証内容
- **Check 1**: `.md` ファイルへの Edit/Write 時に、backtick 内の Lean 定義名の実在を検証
- **Check 2**: `N axioms` / `N theorems` / `N tests` パターンの数値を実際値と照合

## テスト計画
- [ ] `bash run-poc-validation.sh` で 13/13 PASS を確認
- [ ] 通常の Edit/Write で false positive が発生しないことを確認

## Related
- Closes #70, #71, #72, #73
- Resolves deferred `hook-hallucination-detection` (Run 54〜)

🤖 Generated with [Claude Code](https://claude.com/claude-code)