### PR TITLE
V4 Goodhart 解消: L1 hooks に gate_blocked 記録追加

### DIFF
--- a/.claude/hooks/l1-file-guard.sh
+++ b/.claude/hooks/l1-file-guard.sh
@@ -6,6 +6,19 @@
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null)
+
+# V4 gate_blocked イベント記録関数
+log_gate_blocked() {
+  local reason="$1"
+  local metrics_dir
+  metrics_dir="$(cd "$(dirname "$0")/.." && pwd)/metrics"
+  local log_file="$metrics_dir/tool-usage.jsonl"
+  if [ -d "$metrics_dir" ]; then
+    printf '{"event":"gate_blocked","hook":"l1-file-guard","reason":"%s","tool":"%s","file":"%s","session_id":"%s","timestamp":"%s"}\n' \
+      "$reason" "$TOOL" "$FILE_PATH" "$SESSION_ID" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$log_file" 2>/dev/null || true
+  fi
+}
 
 if [ -z "$FILE_PATH" ]; then
   exit 0
@@ -13,6 +26,7 @@ fi
 
 # --- L1: 秘密ファイルへの書き込み ---
 if echo "$FILE_PATH" | grep -qiE '\.(env|pem|key)($|\.)|credentials|secret|id_rsa|id_ed25519'; then
+  log_gate_blocked "credential_file_write"
   echo "L1: Writing to credential/secret file blocked: $FILE_PATH" >&2
   exit 2
 fi
@@ -22,6 +36,7 @@ if echo "$FILE_PATH" | grep -qiE '(test|spec|_test\.|\.test\.)'; then
   # 編集内容を取得（Edit: new_string, Write: content）
   CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty' 2>/dev/null)
   if echo "$CONTENT" | grep -qiE '\b(skip|pending|xit|xdescribe|xtest|\.skip)\b'; then
+    log_gate_blocked "test_tampering"
     echo "L1: Test skip/disable pattern detected in test file: $FILE_PATH" >&2
     exit 2
   fi
@@ -29,6 +44,7 @@ fi
 
 # --- L1: Hook 自己保護 (parry-guard の知見) ---
 if echo "$FILE_PATH" | grep -qE '\.claude/(hooks|settings)'; then
+  log_gate_blocked "hook_self_protection"
   echo "L1: Modifying governance configuration requires human approval. File: $FILE_PATH" >&2
   exit 2
 fi

--- a/.claude/hooks/l1-safety-check.sh
+++ b/.claude/hooks/l1-safety-check.sh
@@ -8,6 +8,19 @@
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null)
+
+# V4 gate_blocked イベント記録関数
+log_gate_blocked() {
+  local reason="$1"
+  local metrics_dir
+  metrics_dir="$(cd "$(dirname "$0")/.." && pwd)/metrics"
+  local log_file="$metrics_dir/tool-usage.jsonl"
+  if [ -d "$metrics_dir" ]; then
+    printf '{"event":"gate_blocked","hook":"l1-safety-check","reason":"%s","tool":"Bash","session_id":"%s","timestamp":"%s"}\n' \
+      "$reason" "$SESSION_ID" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$log_file" 2>/dev/null || true
+  fi
+}
 
 if [ -z "$COMMAND" ]; then
   exit 0
@@ -19,30 +32,35 @@ FULL_CHECK="$COMMAND"
 
 # 破壊的ファイル操作
 if echo "$FULL_CHECK" | grep -qE 'rm\s+-(r|f|rf|fr)\s+(/|\.|\*|\$)'; then
+  log_gate_blocked "destructive_file_op"
   echo "L1: Destructive file operation blocked (rm with dangerous target)" >&2
   exit 2
 fi
 
 # 破壊的 git 操作
 if echo "$FULL_CHECK" | grep -qE 'git\s+(push\s+(-f|--force)|reset\s+--hard|clean\s+-(f|fd))'; then
+  log_gate_blocked "destructive_git_op"
   echo "L1: Destructive git operation blocked" >&2
   exit 2
 fi
 
 # 権限昇格
 if echo "$FULL_CHECK" | grep -qE '(sudo|chmod\s+777|chown\s+root)'; then
+  log_gate_blocked "privilege_escalation"
   echo "L1: Privilege escalation blocked" >&2
   exit 2
 fi
 
 # --- L1: 認証情報の外部送信 ---
 if echo "$FULL_CHECK" | grep -qE 'curl.*(-d|--data).*(TOKEN|KEY|SECRET|PASSWORD|CREDENTIAL)'; then
+  log_gate_blocked "credential_exfiltration"
   echo "L1: Potential credential exfiltration blocked" >&2
   exit 2
 fi
 
 # --- L1: プロンプトインジェクション ---
 if echo "$FULL_CHECK" | grep -qiE '(ignore previous instructions|ignore all previous|disregard your|you are now|system prompt override)'; then
+  log_gate_blocked "prompt_injection"
   echo "L1: Potential prompt injection pattern blocked" >&2
   exit 2
 fi
@@ -55,6 +73,7 @@ if echo "$FULL_CHECK" | grep -qE 'git\s+add'; then
   # git add の引数からファイルパスを抽出（簡易）
   ADD_TARGETS=$(echo "$FULL_CHECK" | sed 's/.*git add//' | tr -s ' ')
   if echo "$ADD_TARGETS" | grep -qiE "$SECRET_PATTERNS"; then
+    log_gate_blocked "staging_secret_file"
     echo "L1: Staging secret/credential file blocked" >&2
     exit 2
   fi
@@ -62,6 +81,7 @@ if echo "$FULL_CHECK" | grep -qE 'git\s+add'; then
   if echo "$ADD_TARGETS" | grep -qE '^\s*(-A|\.|--all)'; then
     STAGED=$(git diff --cached --name-only 2>/dev/null || true)
     if echo "$STAGED" | grep -qiE "$SECRET_PATTERNS"; then
+      log_gate_blocked "staging_secret_file_bulk"
       echo "L1: git add -A would stage secret files. Use specific file names." >&2
       exit 2
     fi


### PR DESCRIPTION
## Summary
- `l1-safety-check.sh` の全 7 ブロックパスに `gate_blocked` イベント記録を追加
- `l1-file-guard.sh` の全 3 ブロックパスに `gate_blocked` イベント記録を追加
- observe.sh の既存 V4 集計ロジック（`"event":"gate_blocked"` grep）が機能するようになる

## 背景
V4 が Run 7 以来 56 runs 常時 100% だった原因は、hook がブロック時にイベントを記録していなかったため。

## 設置手順
この PR のマージ後、`.claude/hooks/l1-safety-check.sh` と `.claude/hooks/l1-file-guard.sh` が更新される。settings.json の変更は不要。

## テスト計画
- [x] `echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"},"session_id":"test"}' | bash .claude/hooks/l1-safety-check.sh` → exit 2 + JSONL 記録
- [x] `echo '{"tool_name":"Edit","tool_input":{"file_path":".claude/hooks/x.sh","new_string":"x"},"session_id":"test"}' | bash .claude/hooks/l1-file-guard.sh` → exit 2 + JSONL 記録
- [x] `bash tests/test-all.sh` で既存テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)