### PR TITLE
根拠の鮮度メタデータ: Axiom Card + selfcheck 期限切れ検出 (#112)

### DIFF
--- a/lean-formalization/Manifest/Axioms.lean
+++ b/lean-formalization/Manifest/Axioms.lean
@@ -85,6 +85,9 @@ T1 is decomposed into three axioms:
     Basis: Execution of computational agents consumes finite resources and therefore terminates in finite time (related to T7).
           Reference examples: LLM session timeouts, resource consumption limits.
     Source: manifesto.md T1 "There is no memory across sessions"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom session_bounded :
   ∀ (w : World) (s : Session),
@@ -102,6 +105,9 @@ axiom session_bounded :
           State isolation across sessions is guaranteed at the execution environment level.
           Reference example: session isolation in LLM architectures.
     Source: manifesto.md T1 "There is no continuous 'self'"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom no_cross_session_memory :
   ∀ (w : World) (e1 e2 : AuditEntry),
@@ -118,6 +124,9 @@ axiom no_cross_session_memory :
           do not directly share state. Influence propagates only indirectly through structure (T2).
     Basis: Causal independence across sessions. Each instance is an independent entity.
     Source: manifesto.md T1 "Each instance is an independent entity"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom session_no_shared_state :
   ∀ (agent1 agent2 : Agent) (action1 action2 : Action)
@@ -153,6 +162,9 @@ T2 is decomposed into two axioms:
     Basis: Persistence on the file system. Structures (documents, tests, etc.)
           reside in storage outside the session.
     Source: manifesto.md T2 "The place where improvements accumulate is within structure"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom structure_persists :
   ∀ (w w' : World) (s : Session) (st : Structure),
@@ -169,6 +181,9 @@ axiom structure_persists :
           Contrast with T1: agents are ephemeral, but structure grows.
     Basis: Monotonic epoch increase guaranteed by version control systems (git).
     Source: manifesto.md T2 "Structure outlives the agent"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom structure_accumulates :
   ∀ (w w' : World),
@@ -197,6 +212,9 @@ T3 is decomposed into two axioms:
     Basis: The working memory of computational agents is physically finite.
           Reference examples: LLM token count limits, FSM state buffer sizes.
     Source: manifesto.md T3 "There is a physical upper limit on the amount of information processable at once"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom context_finite :
   ∀ (agent : Agent),
@@ -209,6 +227,9 @@ axiom context_finite :
           When context usage exceeds capacity, the action cannot be executed.
     Basis: Inability to process when working memory is exceeded is a physical constraint.
     Source: manifesto.md T3 "A constraint on the agent's cognitive space"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom context_bounds_action :
   ∀ (agent : Agent) (action : Action) (w : World),
@@ -243,6 +264,9 @@ T4 declares as an axiom that "this multiplicity can actually occur."
 
     Since `canTransition` is defined as a relation (Prop),
     it is not constrained by Lean's function determinism and can naturally express nondeterminism.
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom output_nondeterministic :
   ∃ (agent : Agent) (action : Action) (w w₁ w₂ : World),
@@ -275,6 +299,9 @@ opaque structureImproved : World → World → Prop
     Basis: Fundamental principle of control theory. Without a loop of
           measurement, comparison, and adjustment, convergence toward the goal does not occur.
     Source: manifesto.md T5 "A fundamental of control theory"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom no_improvement_without_feedback :
   ∀ (w w' : World),
@@ -307,6 +334,9 @@ def isHuman (agent : Agent) : Prop :=
           The grantedBy of all resource allocations holds a human role.
     Basis: Agreement on authority structure in human-agent collaboration.
     Source: manifesto.md T6 "Computational resources, data access, execution privileges — all are granted by humans"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom human_resource_authority :
   ∀ (w : World) (alloc : ResourceAllocation),
@@ -319,6 +349,9 @@ axiom human_resource_authority :
           For any resource allocation, there exists a transition in which a human invalidates it.
     Basis: Agreement on human final decision-making authority. Privileges can be delegated but remain revocable.
     Source: manifesto.md T6 "can be revoked by humans"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom resource_revocable :
   ∀ (w : World) (alloc : ResourceAllocation),
@@ -348,6 +381,9 @@ Time and energy.
           exists for **all** Worlds (non-vacuity, Terminology Reference §6.4).
     Basis: Physical finiteness of computational resources (CPU, memory, API quotas).
     Source: manifesto.md T7 "Resources available for task execution are finite"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom resource_finite :
   ∀ (w : World),
@@ -371,6 +407,9 @@ axiom resource_finite :
           Tasks with a precision level of 0 cannot be optimization targets (= do not constitute valid tasks).
     Basis: Structural requirement of task definitions. Tasks without a precision level cannot be optimized.
     Source: manifesto.md T8 "Whether self-imposed or externally imposed"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 12m
     Refutation condition: Not applicable (T₀) -/
 axiom task_has_precision :
   ∀ (task : Task),

--- a/lean-formalization/Manifest/EmpiricalPostulates.lean
+++ b/lean-formalization/Manifest/EmpiricalPostulates.lean
@@ -64,6 +64,9 @@ E1 is decomposed into three axioms:
     Basis: A principle repeatedly demonstrated in scientific peer review,
           financial auditing, software testing, etc.
     Source: manifesto.md E1 "Verification Requires Independence"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: If self-verification is demonstrated to have detection power
               equal to external verification (e.g., realization of complete self-awareness) -/
 axiom verification_requires_independence :
@@ -80,6 +83,9 @@ axiom verification_requires_independence :
     Basis: Due to T4 (probabilistic output), the bias of the same process
           affects both generation and evaluation, structurally degrading detection power.
     Source: manifesto.md E1 + Principles.lean e1b_from_e1a proves derivation from E1a
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: Same as the refutation condition for E1a -/
 axiom no_self_verification :
   ∀ (agent : Agent) (action : Action) (w : World),
@@ -96,6 +102,9 @@ axiom no_self_verification :
           audit firm rotation requirements, etc.
     Source: manifesto.md E1 "When a process with the same biases handles both
             generation and evaluation, detection power degrades"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: If it is demonstrated that bias correlation has no effect on detection power -/
 axiom shared_bias_reduces_detection :
   ∀ (a b : Agent) (action : Action) (w : World),
@@ -134,6 +143,9 @@ and vulnerability) becomes subject to revision.
     Basis: It has been repeatedly observed across all tools that capability enables
           both positive and negative outcomes (Terminology Reference §9.1 empirical propositions).
     Source: manifesto.md E2 "Capability Growth Is Inseparable from Risk Growth"
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: If means to increase capability while completely containing risk
               are discovered (e.g., a perfect sandbox)
 

--- a/lean-formalization/Manifest/Observable.lean
+++ b/lean-formalization/Manifest/Observable.lean
@@ -234,6 +234,9 @@ as a non-logical axiom within the formal system.
     Content: V1 (skill quality) is measurable
     Basis: with/without comparison via benchmark.json exists as a measurement procedure
     Source: Ontology.lean V1 definition
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: if it is shown that a measurement procedure for skill quality is in principle unconstructible -/
 axiom v1_measurable : Measurable skillQuality
 
@@ -242,6 +245,9 @@ axiom v1_measurable : Measurable skillQuality
     Content: V2 (context efficiency) is measurable
     Basis: the ratio of task completion rate to consumed token count exists as a measurement procedure
     Source: Ontology.lean V2 definition
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: if it is shown that a measurement procedure for context efficiency is in principle unconstructible -/
 axiom v2_measurable : Measurable contextEfficiency
 
@@ -250,6 +256,9 @@ axiom v2_measurable : Measurable contextEfficiency
     Content: V3 (output quality) is measurable
     Basis: gate pass rate and review finding count exist as measurement procedures
     Source: Ontology.lean V3 definition
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: if it is shown that a measurement procedure for output quality is in principle unconstructible -/
 axiom v3_measurable : Measurable outputQuality
 
@@ -258,6 +267,9 @@ axiom v3_measurable : Measurable outputQuality
     Content: V4 (gate pass rate) is measurable
     Basis: pass/fail statistics exist as a measurement procedure
     Source: Ontology.lean V4 definition
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: if it is shown that a measurement procedure for gate pass rate is in principle unconstructible -/
 axiom v4_measurable : Measurable gatePassRate
 
@@ -266,6 +278,9 @@ axiom v4_measurable : Measurable gatePassRate
     Content: V5 (proposal accuracy) is measurable
     Basis: human approval/rejection rate exists as a measurement procedure
     Source: Ontology.lean V5 definition
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: if it is shown that a measurement procedure for proposal accuracy is in principle unconstructible -/
 axiom v5_measurable : Measurable proposalAccuracy
 
@@ -274,6 +289,9 @@ axiom v5_measurable : Measurable proposalAccuracy
     Content: V6 (knowledge structure quality) is measurable
     Basis: context restoration speed and retirement target detection rate exist as measurement procedures
     Source: Ontology.lean V6 definition
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: if it is shown that a measurement procedure for knowledge structure quality is in principle unconstructible -/
 axiom v6_measurable : Measurable knowledgeStructureQuality
 
@@ -282,6 +300,9 @@ axiom v6_measurable : Measurable knowledgeStructureQuality
     Content: V7 (task design efficiency) is measurable
     Basis: task completion rate / consumed resource ratio exists as a measurement procedure
     Source: Ontology.lean V7 definition
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: if it is shown that a measurement procedure for task design efficiency is in principle unconstructible -/
 axiom v7_measurable : Measurable taskDesignEfficiency
 
@@ -324,6 +345,9 @@ def systemHealthy (threshold : Nat) (w : World) : Prop :=
              Indirectly observed from investment behavior (fluctuations in resource allocation)
     Basis: trust is concretized as investment behavior (resource allocation fluctuations)
     Source: manifesto.md Section 6
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: if it is shown that a measurement procedure for trust level is in principle unconstructible -/
 axiom trust_measurable :
   ∀ (agent : Agent), Measurable (trustLevel agent)
@@ -333,6 +357,9 @@ axiom trust_measurable :
     Content: degradationLevel is measurable. Computed from temporal changes in V1–V7
     Basis: if V1–V7 are Measurable, their rate of change is also computable
     Source: design of P4 (observability of degradation)
+    Adopted: 2026-03-22
+    Last validated: 2026-03-28
+    Review cycle: 6m
     Refutation condition: if it is shown that a measurement procedure for degradation level is in principle unconstructible -/
 axiom degradation_measurable : Measurable degradationLevel
 

--- a/manifest-trace
+++ b/manifest-trace
@@ -123,9 +123,9 @@ parse_lean_dependencies() {
   echo "$result"
 }
 
-# Lean の [Axiom Card] doc comment から Basis/Source/Layer を抽出
+# Lean の [Axiom Card] doc comment から Basis/Source/Layer/鮮度メタデータを抽出
 # 出力: JSON Lines — 1行1公理カード
-# {"proposition":"T1","axiom":"session_bounded","layer":"...","content":"...","basis":"...","source":"...","refutation":"...","file":"Axioms.lean"}
+# {"proposition":"T1","axiom":"session_bounded","layer":"...","basis":"...","source":"...","adopted":"2026-03-22","last_validated":"2026-03-28","review_cycle":"12m",...}
 parse_lean_evidence() {
   if [[ -n "$_EVIDENCE_CACHE" ]]; then
     echo "$_EVIDENCE_CACHE"
@@ -161,7 +161,7 @@ parse_lean_evidence() {
             result = lines[i]
             continue
           }
-          if (found && lines[i] ~ /^[[:space:]]*(Layer|Content|Basis|Source|Refutation condition):/) {
+          if (found && lines[i] ~ /^[[:space:]]*(Layer|Content|Basis|Source|Adopted|Last validated|Review cycle|Refutation condition):/) {
             found = 0
             continue
           }
@@ -197,13 +197,17 @@ parse_lean_evidence() {
         content = extract_field(card, "Content")
         basis = extract_field(card, "Basis")
         source = extract_field(card, "Source")
+        adopted = extract_field(card, "Adopted")
+        last_validated = extract_field(card, "Last validated")
+        review_cycle = extract_field(card, "Review cycle")
         refutation = extract_field(card, "Refutation condition")
         prop_id = extract_prop_id(source)
 
         if (prop_id != "") {
-          printf "{\"proposition\":\"%s\",\"axiom\":\"%s\",\"layer\":\"%s\",\"content\":\"%s\",\"basis\":\"%s\",\"source\":\"%s\",\"refutation\":\"%s\",\"file\":\"%s\"}\n", \
+          printf "{\"proposition\":\"%s\",\"axiom\":\"%s\",\"layer\":\"%s\",\"content\":\"%s\",\"basis\":\"%s\",\"source\":\"%s\",\"adopted\":\"%s\",\"last_validated\":\"%s\",\"review_cycle\":\"%s\",\"refutation\":\"%s\",\"file\":\"%s\"}\n", \
             json_escape(prop_id), json_escape(axiom_name), json_escape(layer), \
             json_escape(content), json_escape(basis), json_escape(source), \
+            json_escape(adopted), json_escape(last_validated), json_escape(review_cycle), \
             json_escape(refutation), json_escape(file)
         }
       }
@@ -634,7 +638,7 @@ cmd_json() {
           depends_on:  [$deps[] | select(.child == $pid) | .parent],
           depended_by: [$deps[] | select(.parent == $pid) | .child],
           artifacts: [$matching[] | {id, type, path, scope, enforces}],
-          evidence: [$evid[] | select(.proposition == $pid) | {axiom, layer, basis, source, refutation, file}],
+          evidence: [$evid[] | select(.proposition == $pid) | {axiom, layer, basis, source, adopted, last_validated, review_cycle, refutation, file}],
           coverage: {
             total: ($matching | length),
             by_type: $by_type,
@@ -1054,6 +1058,80 @@ cmd_selfcheck() {
     echo -e "  ${GREEN}✓ 根ノード検証 OK / 強度単調性 OK / DAG 閉路なし${NC}"
   fi
   errors=$((errors + struct_errors))
+
+  echo ""
+
+  # --- 検査 8: 根拠の鮮度チェック ---
+  # Axiom Card の Last validated + Review cycle から期限切れを検出
+  echo -e "${CYAN}検査 8: 根拠の鮮度チェック（Axiom Card 鮮度メタデータ）${NC}"
+
+  local today
+  today=$(date +%Y-%m-%d)
+
+  # evidence を JSON 配列として一括処理
+  local evidence_all
+  evidence_all=$(parse_lean_evidence | grep -v '^$' | jq -s '.')
+  local total_cards
+  total_cards=$(echo "$evidence_all" | jq 'length')
+
+  # jq で期限切れ判定: review_cycle の月数を加算して today と比較
+  # jq 内で日付計算: YYYY-MM-DD + Nm の簡易計算
+  local freshness_report
+  freshness_report=$(echo "$evidence_all" | jq -r --arg today "$today" '
+    def add_months(date_str; months):
+      (date_str | split("-")) as $parts |
+      ($parts[0] | tonumber) as $y |
+      ($parts[1] | tonumber) as $m |
+      ($parts[2]) as $d |
+      (($m - 1 + months) % 12 + 1) as $new_m |
+      ($y + (($m - 1 + months) / 12 | floor)) as $new_y |
+      "\($new_y)-\($new_m | tostring | if length < 2 then "0" + . else . end)-\($d)";
+
+    .[] |
+    if (.last_validated == "" or .last_validated == null or .review_cycle == "" or .review_cycle == null) then
+      "MISSING\t\(.proposition)/\(.axiom)"
+    else
+      (.review_cycle | gsub("m$"; "") | tonumber) as $months |
+      add_months(.last_validated; $months) as $next_review |
+      if $today > $next_review then
+        "EXPIRED\t\(.proposition)/\(.axiom)\t\(.last_validated)\t\($next_review)"
+      else
+        "OK\t\(.proposition)/\(.axiom)\t\(.last_validated)\t\($next_review)"
+      end
+    end
+  ')
+
+  local expired_count=0
+  local missing_count=0
+  local ok_count=0
+
+  while IFS=$'\t' read -r status name last_val next_rev; do
+    case "$status" in
+      EXPIRED)
+        echo -e "  ${RED}✗ ${name}${NC}: 期限切れ（last validated: ${last_val}, next review: ${next_rev}）"
+        expired_count=$((expired_count + 1))
+        ;;
+      MISSING)
+        echo -e "  ${YELLOW}⚠ ${name}${NC}: 鮮度メタデータなし"
+        missing_count=$((missing_count + 1))
+        ;;
+      OK)
+        ok_count=$((ok_count + 1))
+        ;;
+    esac
+  done <<< "$freshness_report"
+
+  if [[ "$expired_count" -eq 0 && "$missing_count" -eq 0 ]]; then
+    echo -e "  ${GREEN}✓ 全 ${total_cards} 件の Axiom Card が鮮度基準内${NC}"
+  else
+    if [[ "$missing_count" -gt 0 ]]; then
+      echo -e "  ${YELLOW}(${missing_count} 件は鮮度メタデータなし — 警告のみ)${NC}"
+    fi
+    if [[ "$expired_count" -gt 0 ]]; then
+      echo -e "  ${RED}${expired_count} 件が期限切れ — 再評価が必要${NC}"
+      errors=$((errors + expired_count))
+    fi
+  fi
 
   echo ""
 

--- a/scripts/lint-doc-comments.py
+++ b/scripts/lint-doc-comments.py
@@ -219,7 +219,8 @@ def lint_file(filepath):
 
                 # A1/A2/A3: Axiom card checks
                 if "[Axiom Card]" in doc_text:
-                    for field in ["Layer:", "Content:", "Basis:", "Source:"]:
+                    for field in ["Layer:", "Content:", "Basis:", "Source:",
+                                  "Adopted:", "Last validated:", "Review cycle:"]:
                         if field not in doc_text:
                             violations.append(Violation(
                                 filename, decl_doc_start, "A2", "warning",


### PR DESCRIPTION
## Summary
- 全 26 Axiom Card に `Adopted:` / `Last validated:` / `Review cycle:` フィールド追加
- `manifest-trace selfcheck` に検査 8（鮮度チェック）追加 — 期限切れ公理を自動検出
- `lint-doc-comments.py` A2 ルールに鮮度フィールドを必須化
- Review cycle: T₀ = 12m, Γ\T₀ = 6m

## Gate 判定
**PASS**: 鮮度スキーマ定義済み + selfcheck で期限切れ検出（テスト実証済み）

## Test plan
- [x] `manifest-trace evidence | jq '.review_cycle'` — 全カードに鮮度フィールドあり
- [x] `manifest-trace selfcheck` 検査 8 — 全 25 件が鮮度基準内
- [x] 期限切れテスト: Last validated を古い日付に変更 → 検出確認 → 復元
- [x] `python3 scripts/lint-doc-comments.py` — linter PASS

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)