### PR TITLE
axiom evidence hook: 公理変更時の根拠チェック強制 (#113)

### DIFF
--- a/.claude/hooks/p3-axiom-evidence-check.sh
+++ b/.claude/hooks/p3-axiom-evidence-check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# P3 Axiom Evidence Check — PreToolUse: Bash (git commit)
+#
+# 公理関連 Lean ファイルの変更時に、根拠メタデータの更新を確認する。
+# D1（構造的強制）: normative ではなく structural に保証。
+#
+# D8（均衡探索）: 段階的厳格化
+# - 1回目 → 警告
+# - 2回目以降 → ブロック
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# git commit 以外は無視
+if ! echo "$COMMAND" | grep -qE 'git\s+commit'; then
+  exit 0
+fi
+
+# 公理関連ファイルのパターン
+AXIOM_FILES='lean-formalization/Manifest/(Axioms|EmpiricalPostulates|Observable)\.lean'
+
+STAGED=$(git diff --cached --name-only 2>/dev/null)
+if ! echo "$STAGED" | grep -qE "$AXIOM_FILES"; then
+  exit 0
+fi
+
+# 公理関連ファイルの diff を取得
+AXIOM_DIFF=$(git diff --cached 2>/dev/null -- \
+  'lean-formalization/Manifest/Axioms.lean' \
+  'lean-formalization/Manifest/EmpiricalPostulates.lean' \
+  'lean-formalization/Manifest/Observable.lean')
+
+if [ -z "$AXIOM_DIFF" ]; then
+  exit 0
+fi
+
+WARNINGS=""
+
+# チェック 1: axiom 行が変更されているのに Basis が変更されていないか
+AXIOM_CHANGED=$(echo "$AXIOM_DIFF" | grep -E '^\+axiom [a-z_]' | wc -l | tr -d ' ')
+BASIS_CHANGED=$(echo "$AXIOM_DIFF" | grep -E '^\+.*Basis:' | wc -l | tr -d ' ')
+
+if [ "$AXIOM_CHANGED" -gt 0 ] && [ "$BASIS_CHANGED" -eq 0 ]; then
+  WARNINGS="${WARNINGS}  - axiom 宣言が変更されましたが Basis: が更新されていません\n"
+fi
+
+# チェック 2: 公理ファイルが変更されているのに Last validated が更新されていないか
+# [Axiom Card] ブロック内の変更かどうかを -U0 で判別するのは困難なため、
+# 公理ファイルの変更 = Last validated 更新を要求する（保守的戦略）
+VALIDATED_CHANGED=$(echo "$AXIOM_DIFF" | grep -E '^\+.*Last validated:' | wc -l | tr -d ' ')
+
+if [ "$VALIDATED_CHANGED" -eq 0 ]; then
+  WARNINGS="${WARNINGS}  - 公理ファイルが変更されましたが Last validated: が更新されていません\n"
+fi
+
+# チェック 3: Last validated が更新されている場合、日付が妥当か
+if [ "$VALIDATED_CHANGED" -gt 0 ]; then
+  TODAY=$(date +%Y-%m)
+  VALIDATED_DATE=$(echo "$AXIOM_DIFF" | grep -E '^\+.*Last validated:' | head -1 | sed 's/.*Last validated:[[:space:]]*//' | tr -d ' ')
+  if ! echo "$VALIDATED_DATE" | grep -q "^${TODAY}"; then
+    WARNINGS="${WARNINGS}  - Last validated の日付が今月 (${TODAY}) ではありません: ${VALIDATED_DATE}\n"
+  fi
+fi
+
+# 警告なしなら通過
+if [ -z "$WARNINGS" ]; then
+  exit 0
+fi
+
+# D8: 段階的厳格化
+SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null)
+STATE_FILE="/tmp/p3-axiom-evidence-warned-${SESSION}"
+
+if [ -f "$STATE_FILE" ]; then
+  echo "P3/Evidence: 公理変更コミット BLOCKED — 根拠メタデータの更新が必要です。" >&2
+  printf "%b" "$WARNINGS" >&2
+  echo "根拠を更新してから再度コミットしてください。" >&2
+  exit 2
+else
+  touch "$STATE_FILE"
+  echo "P3/Evidence: 公理関連ファイルが変更されています。以下を確認してください:" >&2
+  printf "%b" "$WARNINGS" >&2
+  echo "次回の分類なしコミットはブロックされます。" >&2
+  exit 0
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,10 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/h5-doc-lint.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/p3-axiom-evidence-check.sh"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- p3-axiom-evidence-check.sh: 公理関連 Lean ファイルの変更時に Last validated 更新を構造的に強制
- D8 段階的厳格化: 1回目警告、2回目ブロック

## Gate 判定
PASS: 4 テストケース全通過

## Test plan
- [x] 公理ファイル変更 + Last validated 未更新 → 警告
- [x] 同セッション2回目 → ブロック
- [x] 非公理コマンド → 通過
- [x] 非公理ファイルのみ → 通過

Closes #113