### PR TITLE
/trace Skill 強化 + /evolve Observer 統合 (#107)

### DIFF
--- a/.claude/skills/evolve/scripts/observe.sh
+++ b/.claude/skills/evolve/scripts/observe.sh
@@ -686,6 +686,34 @@ echo "    \"header\": {\"max_run\": $MAX_RUN, \"total_entries\": $TOTAL_ENTRIES}
 echo "    \"h1_verifier\": {\"pass\": $H1_PASS, \"fail\": $H1_FAIL, \"total\": $H1_TOTAL, \"pass_rate_percent\": $H1_PASS_RATE},"
 echo "    \"h4_compatibility\": {\"conservative_extension\": $H4_CONSERVATIVE, \"compatible_change\": $H4_COMPATIBLE, \"breaking_change\": $H4_BREAKING, \"other\": $H4_OTHER, \"total\": $H4_TOTAL},"
 echo "    \"h5_valid_uuids\": $H5_VALID_UUIDS"
-echo "  }"
+echo "  },"
+
+# --- manifest-trace 指標 ---
+if [ -x "$BASE/manifest-trace" ]; then
+  TRACE_JSON=$("$BASE/manifest-trace" json 2>/dev/null || echo "{}")
+  TRACE_COVERED=$(echo "$TRACE_JSON" | jq '.summary.covered // 0' 2>/dev/null || echo "0")
+  TRACE_UNCOVERED=$(echo "$TRACE_JSON" | jq '.summary.uncovered | length // 0' 2>/dev/null || echo "0")
+  TRACE_WEAK=$(echo "$TRACE_JSON" | jq '.summary.weak | length // 0' 2>/dev/null || echo "0")
+  TRACE_TOTAL=$(echo "$TRACE_JSON" | jq '.meta.total_propositions // 0' 2>/dev/null || echo "0")
+  TRACE_ARTIFACTS=$(echo "$TRACE_JSON" | jq '.meta.total_artifacts // 0' 2>/dev/null || echo "0")
+  TRACE_WITH_EVIDENCE=$(echo "$TRACE_JSON" | jq '.summary.with_evidence | length // 0' 2>/dev/null || echo "0")
+  TRACE_WITHOUT_EVIDENCE=$(echo "$TRACE_JSON" | jq '.summary.without_evidence | length // 0' 2>/dev/null || echo "0")
+  # 深さ別カバレッジ
+  TRACE_S5=$(echo "$TRACE_JSON" | jq '[.propositions[] | select(.strength == 5 and .coverage.total > 0)] | length' 2>/dev/null || echo "0")
+  TRACE_S5_T=$(echo "$TRACE_JSON" | jq '[.propositions[] | select(.strength == 5)] | length' 2>/dev/null || echo "0")
+  TRACE_S4=$(echo "$TRACE_JSON" | jq '[.propositions[] | select(.strength == 4 and .coverage.total > 0)] | length' 2>/dev/null || echo "0")
+  TRACE_S4_T=$(echo "$TRACE_JSON" | jq '[.propositions[] | select(.strength == 4)] | length' 2>/dev/null || echo "0")
+  TRACE_S3=$(echo "$TRACE_JSON" | jq '[.propositions[] | select(.strength == 3 and .coverage.total > 0)] | length' 2>/dev/null || echo "0")
+  TRACE_S3_T=$(echo "$TRACE_JSON" | jq '[.propositions[] | select(.strength == 3)] | length' 2>/dev/null || echo "0")
+  echo "  \"manifest_trace\": {"
+  echo "    \"version\": $(echo "$TRACE_JSON" | jq '.meta.version // "unknown"' 2>/dev/null || echo '\"unknown\"'),"
+  echo "    \"coverage\": {\"covered\": $TRACE_COVERED, \"uncovered\": $TRACE_UNCOVERED, \"weak\": $TRACE_WEAK, \"total\": $TRACE_TOTAL},"
+  echo "    \"artifacts\": $TRACE_ARTIFACTS,"
+  echo "    \"evidence\": {\"with\": $TRACE_WITH_EVIDENCE, \"without\": $TRACE_WITHOUT_EVIDENCE},"
+  echo "    \"by_strength\": {\"s5\": \"${TRACE_S5}/${TRACE_S5_T}\", \"s4\": \"${TRACE_S4}/${TRACE_S4_T}\", \"s3\": \"${TRACE_S3}/${TRACE_S3_T}\"}"
+  echo "  }"
+else
+  echo "  \"manifest_trace\": null"
+fi
 
 echo "}"

--- a/.claude/skills/trace/SKILL.md
+++ b/.claude/skills/trace/SKILL.md
@@ -66,11 +66,95 @@ description: >
 2. 必要な場合は `/evolve` の Observer フェーズで改善候補として報告
 3. 実装する場合は `artifact-manifest.json` にメタデータを追加
 
+### Step 4: JSON 構造的分析
+
+`manifest-trace json` の出力を jq で解析し、定量的な洞察を得る。
+
+#### 4a. 深さ別カバレッジ（strength 5→1）
+
+```bash
+./manifest-trace json | jq '
+  [.propositions[] | {s: .strength, covered: (.coverage.total > 0)}]
+  | group_by(.s) | map({
+      strength: .[0].s,
+      total: length,
+      covered: [.[] | select(.covered)] | length
+    })
+  | sort_by(-.strength)
+  | .[] | "\(.strength): \(.covered)/\(.total)"
+'
+```
+
+#### 4b. 根拠カバレッジ（evidence）
+
+```bash
+./manifest-trace json | jq '{
+  with_evidence: .summary.with_evidence | length,
+  without_evidence: .summary.without_evidence | length,
+  without_list: .summary.without_evidence
+}'
+```
+
+#### 4c. テストなし命題の優先順位（D13 伝播を考慮）
+
+依存者が多い命題ほど優先度高（変更の影響が広い）:
+
+```bash
+./manifest-trace json | jq '
+  [.propositions[]
+   | select(.coverage.has_test == false and .coverage.total > 0)
+   | {id, dependents: (.depended_by | length), strength}]
+  | sort_by(-.dependents, -.strength)
+'
+```
+
+#### 4d. 孤立ノード検出
+
+depends_on も depended_by も空の命題（半順序に接続されていない）:
+
+```bash
+./manifest-trace json | jq '
+  [.propositions[]
+   | select((.depends_on | length == 0) and (.depended_by | length == 0))
+   | .id]
+'
+```
+
+#### 4e. 依存チェーンの完全性
+
+trunk（根ノード）から leaf まで、カバレッジギャップのない経路が存在するか:
+
+```bash
+./manifest-trace json | jq '
+  .summary as $s |
+  {
+    roots: ($s.roots | length),
+    leaves: ($s.leaves | length),
+    uncovered_on_path: [.propositions[]
+      | select((.depends_on | length > 0) and (.depended_by | length > 0) and .coverage.total == 0)
+      | .id]
+  }
+'
+```
+
+### Step 5: 改善提案テンプレート
+
+json 分析結果から改善提案を生成する:
+
+| 検出パターン | 改善提案 |
+|------------|---------|
+| uncovered + strength ≥ 3 | 「{id} に hook/skill を追加すべき（高強度命題の未実装）」 |
+| has_test == false + dependents ≥ 3 | 「{id} のテスト追加を優先（D13 伝播で {n} 命題に影響）」 |
+| has_evidence == false + T/E 層 | 「{id} に Axiom Card が必要（根拠の欠落）」 |
+| 孤立ノード | 「{id} の依存関係を Ontology.lean で定義すべき」 |
+| 鮮度期限切れ | 「{id} の根拠を再評価すべき（Last validated 期限超過）」 |
+
 ## データソース
 
 - `artifact-manifest.json` — 全成果物→公理マッピング（単一真実源）
 - `lean-formalization/Manifest/Ontology.lean` — 命題間依存定義
 - `lean-formalization/Manifest/DesignFoundation.lean` — D13 影響波及
+- `lean-formalization/Manifest/{Axioms,EmpiricalPostulates,Observable}.lean` — Axiom Card（根拠 + 鮮度）
 
 ## 注意事項
 


### PR DESCRIPTION
## Summary
- SKILL.md に json 構造的分析手順 (Step 4a-4e: 深さ別カバレッジ、根拠カバレッジ、D13 優先順位、孤立ノード検出、依存チェーン完全性) + 改善提案テンプレート (5 パターン) を追加
- observe.sh に manifest-trace json の自動取得を統合 (coverage, evidence, by_strength)

## Gate 判定
PASS: 全 jq クエリ動作確認済み + observe.sh 出力正常

## Test plan
- [x] 5 種類の jq クエリが正常出力
- [x] observe.sh の manifest_trace セクションが正常な JSON を出力

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)