### PR TITLE
manifest-trace: plugin scope — 外部トレーサビリティ突合 (#106)

### DIFF
--- a/.claude/skills/package-plugin/SKILL.md
+++ b/.claude/skills/package-plugin/SKILL.md
@@ -46,9 +46,55 @@ bash .claude/skills/package-plugin/scripts/package.sh {{args}}
 7. README.md を自動生成（コンポーネント数を自動カウント）
 8. 検証: JSON 妥当性、参照整合性、絶対パスの不在
 
+## artifact-manifest.json テンプレート
+
+パッケージに `artifact-manifest.json` テンプレートを同梱する。
+外部プロジェクトが `manifest-trace --manifest=<path>` で突合に使用する。
+
+テンプレートは本リポジトリの `artifact-manifest.json` から propositions を継承し、
+パッケージに含まれるコンポーネントを artifacts として登録する:
+
+```json
+{
+  "version": "0.2.0",
+  "parent": "agent-manifesto",
+  "scopes": ["plugin"],
+  "propositions": ["T1", "T2", ...],
+  "artifacts": [
+    {
+      "id": "plugin-hook:<name>",
+      "type": "hook",
+      "path": ".claude/hooks/<name>.sh",
+      "refs": ["L1", "T6"],
+      "scope": "plugin"
+    }
+  ]
+}
+```
+
+### 生成ルール
+
+1. `propositions` は本リポジトリの全 36 命題をコピー
+2. `artifacts` はパッケージに含まれる各コンポーネントから自動生成:
+   - hook → `plugin-hook:<name>` (refs は hook 内のコメントから抽出、なければ空)
+   - rule → `plugin-rule:<name>` (refs は rule 内の命題 ID から抽出)
+   - skill → `plugin-skill:<name>`
+   - agent → `plugin-agent:<name>`
+3. `scope` は全て `"plugin"`
+4. refs の自動抽出: ファイル内の `T[0-9]+|E[0-9]+|P[0-9]+|L[0-9]+|D[0-9]+` パターン
+
+### manifest-trace との突合
+
+```bash
+# 外部プロジェクトで実行
+manifest-trace --manifest=path/to/plugin/artifact-manifest.json coverage
+manifest-trace --manifest=path/to/plugin/artifact-manifest.json --scope=plugin health
+```
+
 ## D9 自己適用
 
 このスキル自身の更新:
 - .claude/ に新しいコンポーネント種別が追加された場合、scripts/package.sh を更新
 - plugin.json のスキーマが変わった場合、スクリプトの生成部分を更新
 - 新しい検証項目が必要になった場合、スクリプトの検証セクションに追加
+- artifact-manifest.json のスキーマが変わった場合、テンプレート生成を更新

--- a/.claude/skills/package-plugin/scripts/package.sh
+++ b/.claude/skills/package-plugin/scripts/package.sh
@@ -159,6 +159,52 @@ Add to your project's \`.gitignore\`:
 README
 echo "README.md generated"
 
+# --- artifact-manifest.json テンプレート生成 ---
+echo ""
+echo "=== Generating artifact-manifest.json ==="
+
+# 本体の propositions を継承
+PROPOSITIONS=$(jq -r '.propositions' "$BASE/artifact-manifest.json" 2>/dev/null || echo '[]')
+
+# パッケージ内のコンポーネントから artifacts を自動生成
+PLUGIN_ARTIFACTS="[]"
+
+# hooks → plugin-hook:<name>
+for hook_file in "$DEST"/hooks/*.sh; do
+  [ -f "$hook_file" ] || continue
+  name=$(basename "$hook_file" .sh)
+  # ファイル内の命題 ID (T1, E1, P2 等) を refs として抽出
+  refs=$(grep -oE '[TEPLVD][0-9]+' "$hook_file" 2>/dev/null | sort -u | jq -R . | jq -s . || echo '[]')
+  PLUGIN_ARTIFACTS=$(echo "$PLUGIN_ARTIFACTS" | jq --arg id "plugin-hook:$name" --arg path ".claude/hooks/$name.sh" --argjson refs "$refs" \
+    '. + [{"id": $id, "type": "hook", "path": $path, "refs": $refs, "scope": "plugin"}]')
+done
+
+# rules → plugin-rule:<name>
+for rule_file in "$DEST"/rules/*.md; do
+  [ -f "$rule_file" ] || continue
+  name=$(basename "$rule_file" .md)
+  refs=$(grep -oE '[TEPLVD][0-9]+' "$rule_file" 2>/dev/null | sort -u | jq -R . | jq -s . || echo '[]')
+  PLUGIN_ARTIFACTS=$(echo "$PLUGIN_ARTIFACTS" | jq --arg id "plugin-rule:$name" --arg path ".claude/rules/$name.md" --argjson refs "$refs" \
+    '. + [{"id": $id, "type": "rule", "path": $path, "refs": $refs, "scope": "plugin"}]')
+done
+
+# agents → plugin-agent:<name>
+for agent_file in "$DEST"/agents/*.md "$DEST"/agents/*/AGENT.md; do
+  [ -f "$agent_file" ] || continue
+  name=$(basename "$(dirname "$agent_file")" 2>/dev/null)
+  [ "$name" = "agents" ] && name=$(basename "$agent_file" .md)
+  refs=$(grep -oE '[TEPLVD][0-9]+' "$agent_file" 2>/dev/null | sort -u | jq -R . | jq -s . || echo '[]')
+  PLUGIN_ARTIFACTS=$(echo "$PLUGIN_ARTIFACTS" | jq --arg id "plugin-agent:$name" --arg path ".claude/agents/$name" --argjson refs "$refs" \
+    '. + [{"id": $id, "type": "agent", "path": $path, "refs": $refs, "scope": "plugin"}]')
+done
+
+jq -n --argjson props "$PROPOSITIONS" --argjson arts "$PLUGIN_ARTIFACTS" \
+  '{version: "0.2.0", parent: "agent-manifesto", scopes: ["plugin"], propositions: $props, artifacts: $arts}' \
+  > "$DEST/artifact-manifest.json"
+
+ARTIFACT_COUNT=$(echo "$PLUGIN_ARTIFACTS" | jq 'length')
+echo "artifact-manifest.json generated ($ARTIFACT_COUNT artifacts)"
+
 # --- Verification ---
 echo ""
 echo "=== Verification ==="
@@ -175,6 +221,17 @@ REFERENCED=$(jq -r '.. | .command? // empty' "$DEST/hooks/hooks.json" | grep -o 
 for script in $REFERENCED; do
   [ -x "$DEST/hooks/$script" ] && echo "✓ $script exists" || { echo "✗ $script missing"; ERRORS=$((ERRORS+1)); }
 done
+
+# artifact-manifest.json valid
+jq . "$DEST/artifact-manifest.json" > /dev/null 2>&1 && echo "✓ artifact-manifest.json valid" || { echo "✗ artifact-manifest.json invalid"; ERRORS=$((ERRORS+1)); }
+
+# artifact-manifest.json refs grounded in propositions
+BAD_REFS=$(jq -r '[.artifacts[].refs[]] | unique | .[] | select(. as $r | ['"$PROPOSITIONS"'[] | select(. == $r)] | length == 0)' "$DEST/artifact-manifest.json" 2>/dev/null)
+if [ -z "$BAD_REFS" ]; then
+  echo "✓ All refs grounded in propositions"
+else
+  echo "✗ Ungrounded refs: $BAD_REFS"; ERRORS=$((ERRORS+1))
+fi
 
 # No absolute paths
 if grep -r '/Users/' "$DEST/hooks/" --include="*.json" --include="*.sh" > /dev/null 2>&1; then

--- a/manifest-trace
+++ b/manifest-trace
@@ -34,6 +34,8 @@ NC='\033[0m'
 # --- scope フィルタ ---
 # --scope=implementation,config のように指定。未指定時は全 scope
 SCOPE_FILTER=""
+# --manifest=<path> で外部 manifest を指定。未指定時は本リポジトリの manifest
+EXTERNAL_MANIFEST=""
 
 parse_global_opts() {
   local args=()
@@ -41,6 +43,12 @@ parse_global_opts() {
     case "$arg" in
       --scope=*)
         SCOPE_FILTER="${arg#--scope=}"
+        ;;
+      --manifest=*)
+        EXTERNAL_MANIFEST="${arg#--manifest=}"
+        if [[ ! -f "$EXTERNAL_MANIFEST" ]]; then
+          die "外部 manifest が見つかりません: $EXTERNAL_MANIFEST"
+        fi
         ;;
       *)
         args+=("$arg")
@@ -50,33 +58,52 @@ parse_global_opts() {
   REMAINING_ARGS=("${args[@]}")
 }
 
+# 使用する manifest ファイルのリストを返す（本体 + 外部）
+manifest_files() {
+  echo "$MANIFEST"
+  [[ -n "$EXTERNAL_MANIFEST" ]] && echo "$EXTERNAL_MANIFEST"
+}
+
+# 全 manifest から成果物を統合して取得
+merged_artifacts() {
+  local result="[]"
+  while IFS= read -r mfile; do
+    local arts
+    arts=$(jq '[.artifacts[] | select(._comment == null)]' "$mfile" 2>/dev/null || echo "[]")
+    result=$(echo "$result" "$arts" | jq -s '.[0] + .[1]')
+  done < <(manifest_files)
+  echo "$result"
+}
+
 # scope フィルタ付きで成果物を jq フィルタ
 # 引数: 追加の jq フィルタ（省略可）
 artifacts_jq() {
   local extra_filter="${1:-.}"
+  local all_arts
+  all_arts=$(merged_artifacts)
   if [[ -z "$SCOPE_FILTER" ]]; then
-    jq -r "[.artifacts[] | select(._comment == null)] | map(select(${extra_filter}))" "$MANIFEST"
+    echo "$all_arts" | jq -r "map(select(${extra_filter}))"
   else
     # カンマ区切りの scope を jq 配列に変換
     local scope_array
     scope_array=$(echo "$SCOPE_FILTER" | tr ',' '\n' | jq -R . | jq -s .)
-    jq -r --argjson scopes "$scope_array" \
-      "[.artifacts[] | select(._comment == null) | select(.scope as \$s | \$scopes | index(\$s))] | map(select(${extra_filter}))" \
-      "$MANIFEST"
+    echo "$all_arts" | jq -r --argjson scopes "$scope_array" \
+      "[.[] | select(.scope as \$s | \$scopes | index(\$s))] | map(select(${extra_filter}))"
   fi
 }
 
 # scope フィルタ付きで成果物を行出力
 artifacts_lines() {
   local format="${1:-.id}"
+  local all_arts
+  all_arts=$(merged_artifacts)
   if [[ -z "$SCOPE_FILTER" ]]; then
-    jq -r ".artifacts[] | select(._comment == null) | ${format}" "$MANIFEST"
+    echo "$all_arts" | jq -r ".[] | ${format}"
   else
     local scope_array
     scope_array=$(echo "$SCOPE_FILTER" | tr ',' '\n' | jq -R . | jq -s .)
-    jq -r --argjson scopes "$scope_array" \
-      ".artifacts[] | select(._comment == null) | select(.scope as \$s | \$scopes | index(\$s)) | ${format}" \
-      "$MANIFEST"
+    echo "$all_arts" | jq -r --argjson scopes "$scope_array" \
+      ".[] | select(.scope as \$s | \$scopes | index(\$s)) | ${format}"
   fi
 }
 
@@ -220,10 +247,10 @@ all_propositions() {
   jq -r '.propositions[]' "$MANIFEST"
 }
 
-# 成果物から refs を取得
+# 成果物から refs を取得（本体 + 外部 manifest）
 artifact_refs() {
   local artifact_id="$1"
-  jq -r --arg id "$artifact_id" '.artifacts[] | select(.id == $id) | .refs[]' "$MANIFEST"
+  merged_artifacts | jq -r --arg id "$artifact_id" '.[] | select(.id == $id) | .refs[]'
 }
 
 # --- サブコマンド ---
@@ -1057,6 +1084,39 @@ cmd_selfcheck() {
 
   echo ""
 
+  # --- 検査 9: 外部 manifest 検証（--manifest 指定時のみ） ---
+  if [[ -n "$EXTERNAL_MANIFEST" ]]; then
+    echo -e "${CYAN}検査 9: 外部 manifest 検証（${EXTERNAL_MANIFEST}）${NC}"
+
+    # 9a: propositions が本体の Lean と同期しているか
+    local ext_props
+    ext_props=$(jq -r '.propositions[]' "$EXTERNAL_MANIFEST" 2>/dev/null | sort)
+    local bad_props
+    bad_props=$(comm -23 <(echo "$ext_props") <(echo "$lean_ids"))
+    if [[ -n "$bad_props" ]]; then
+      echo -e "  ${RED}✗ 外部 manifest に Lean にない命題:${NC}"
+      echo "$bad_props" | while read -r id; do echo "    - $id"; done
+      errors=$((errors + $(echo "$bad_props" | wc -l | tr -d ' ')))
+    else
+      echo -e "  ${GREEN}✓ propositions が Lean PropositionId に接地${NC}"
+    fi
+
+    # 9b: refs が propositions に含まれるか
+    local ext_refs
+    ext_refs=$(jq -r '[.artifacts[].refs[]] | unique | .[]' "$EXTERNAL_MANIFEST" 2>/dev/null | sort)
+    local bad_refs
+    bad_refs=$(comm -23 <(echo "$ext_refs") <(echo "$lean_ids"))
+    if [[ -n "$bad_refs" ]]; then
+      echo -e "  ${RED}✗ 外部 manifest の refs に Lean にない命題:${NC}"
+      echo "$bad_refs" | while read -r id; do echo "    - $id"; done
+      errors=$((errors + $(echo "$bad_refs" | wc -l | tr -d ' ')))
+    else
+      echo -e "  ${GREEN}✓ refs が Lean PropositionId に接地${NC}"
+    fi
+
+    echo ""
+  fi
+
   # --- 総合判定 ---
   if [[ "$errors" -eq 0 ]]; then
     echo -e "${BOLD}${GREEN}selfcheck PASS: 全検査合格${NC}"
@@ -1103,11 +1163,14 @@ case "${1:-help}" in
     echo "                   config          settings.json 等"
     echo "                   document        CLAUDE.md, README.md, docs/ 等"
     echo "                   data            .claude/metrics/*.jsonl 等"
+    echo "  --manifest=PATH  外部 artifact-manifest.json を追加で読み込む"
+    echo "                   本体と外部の成果物を統合してレポート"
     echo ""
     echo "例:"
     echo "  manifest-trace --scope=implementation coverage"
     echo "  manifest-trace --scope=implementation,config health"
     echo "  manifest-trace coverage   # 全スコープ"
+    echo "  manifest-trace --manifest=/path/to/plugin/artifact-manifest.json coverage"
     ;;
   *)
     die "不明なサブコマンド: $1（manifest-trace help を参照）"


### PR DESCRIPTION
## Summary
- `--manifest=<path>` オプション: 外部 artifact-manifest.json の成果物を本体と統合してレポート
- `/package-plugin` に artifact-manifest.json テンプレート自動生成を追加（refs 自動抽出）
- selfcheck 検査 9: 外部 manifest の propositions/refs が Lean PropositionId に接地しているか検証

## Test plan
- [x] `--manifest=<path> json` — 本体 66 + 外部 2 = 68 artifacts
- [x] `--manifest=<path> --scope=plugin coverage` — plugin のみのレポート
- [x] `--manifest=<path> selfcheck` — 検査 9 正常 PASS
- [x] 不正な外部 manifest → 検査 9 でエラー検出
- [x] `--manifest` なし — 既存機能 regression なし

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)