### PR TITLE
#166: Graph View を Verso 文書に統合

### DIFF
--- a/docs/graph-view/graph-view.html
+++ b/docs/graph-view/graph-view.html
@@ -384,9 +384,10 @@ const KIND_COLORS = {
 
 // Verso documentation URL mapping for PropositionIds
 // Base URL is configurable — set VERSO_BASE_URL before loading, or defaults to relative path
+// Auto-detect: if served from Verso output (graph-view/ subdir), parent is Verso docs
 const VERSO_BASE_URL = (typeof window.VERSO_BASE_URL !== 'undefined')
   ? window.VERSO_BASE_URL
-  : '../lean-formalization/docgen-verso/_out/html/html-single/index.html';
+  : (location.pathname.includes('/graph-view') ? '../index.html' : '../lean-formalization/docgen-verso/_out/html/html-single/index.html');
 
 const VERSO_ANCHORS = {
   T1: 'T1-Agent-Sessions-Are-Ephemeral',
@@ -494,9 +495,15 @@ let currentView = 'overview';
 
 /** Extract module name from fullName like "Manifest.EpistemicLayer.foo" → "EpistemicLayer" */
 function getModule(fullName) {
+  // Try source-map first (most accurate)
+  if (sourceMap && sourceMap[fullName]) {
+    const file = sourceMap[fullName].file; // e.g. "Manifest/EmpiricalPostulates.lean"
+    const mod = file.replace('Manifest/', '').replace('.lean', '');
+    if (SOURCE_FILES[mod]) return mod;
+  }
+  // Fallback: infer from fullName
   const parts = fullName.replace('Manifest.', '').split('.');
   if (parts.length >= 2) {
-    // Check if first part matches a known module
     if (SOURCE_FILES[parts[0]]) return parts[0];
   }
   return 'root';

--- a/lean-formalization/docgen-verso/Main.lean
+++ b/lean-formalization/docgen-verso/Main.lean
@@ -14,10 +14,20 @@ open Std (HashMap)
 
 open Docs
 
+open Verso.Output in
+def graphViewLink : Html :=
+  .tag "a"
+    #[ ("href", "/graph-view/")
+     , ("style", "position:fixed;bottom:12px;right:12px;z-index:50;padding:8px 16px;background:#16213e;color:#4ea8de;border:1px solid #0f3460;border-radius:6px;font-size:13px;text-decoration:none;font-family:monospace;")
+     , ("target", "_blank")
+    ]
+    (.text true "📊 Graph View")
+
 def config : Config where
   emitTeX := false
   emitHtmlSingle := true
   emitHtmlMulti := true
   htmlDepth := 4
+  extraContents := #[graphViewLink]
 
 def main := manualMain (%doc Docs) (config := config)

--- a/lean-formalization/docgen-verso/generate.sh
+++ b/lean-formalization/docgen-verso/generate.sh
@@ -24,6 +24,24 @@ lake build
 echo "=== Generating HTML ==="
 lake exe docs --output "$OUTPUT_DIR"
 
+echo "=== Integrating Graph View ==="
+GRAPH_SRC="$SCRIPT_DIR/../../docs/graph-view"
+if [ -d "$GRAPH_SRC" ]; then
+  for target_dir in "$OUTPUT_DIR/html-single" "$OUTPUT_DIR/html-multi"; do
+    if [ -d "$target_dir" ]; then
+      mkdir -p "$target_dir/graph-view"
+      cp "$GRAPH_SRC/graph-view.html" "$target_dir/graph-view/index.html"
+      cp "$GRAPH_SRC/depgraph.json" "$target_dir/graph-view/"
+      cp "$GRAPH_SRC/positions.json" "$target_dir/graph-view/"
+      cp "$GRAPH_SRC/source-map.json" "$target_dir/graph-view/"
+      echo "  Graph View assets copied to $target_dir/graph-view/"
+    fi
+  done
+  # Navigation link is injected via Main.lean extraContents (no sed needed)
+else
+  echo "  Warning: docs/graph-view/ not found, skipping Graph View integration"
+fi
+
 echo "=== Done ==="
 echo "Output in: $SCRIPT_DIR/$OUTPUT_DIR-multi/"
 echo "Serve with: python3 -m http.server 8000 -d $SCRIPT_DIR/$OUTPUT_DIR-multi/"


### PR DESCRIPTION
## Summary

- Verso の `extraContents` API で全ページに Graph View ナビゲーションリンクを注入
- `generate.sh` で Verso HTML 生成後に graph-view アセットを自動コピー
- Graph View の Verso Docs リンクが統合環境で正しく動作するよう自動検出を実装

Parent: #154, Closes: #166

## Test plan

- [x] `lake build` 成功（293 jobs）
- [x] `generate.sh` で Graph View アセットが html-single/graph-view/ と html-multi/graph-view/ にコピーされる
- [x] Verso 文書の全ページに「📊 Graph View」リンクが表示される
- [x] リンクから Graph View が開き、Overview (36 nodes) が表示される
- [x] Full Graph (484 nodes) に切替可能
- [x] Graph View 内の Verso Docs リンクが Verso 文書に正しく遷移する
- [x] Playwright 統合テスト 7/7 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)