### PR TITLE
#235: sync-hypothesis-table.sh — SKILL.md 仮説テーブル自動同期

### DIFF
--- a/.claude/skills/evolve/SKILL.md
+++ b/.claude/skills/evolve/SKILL.md
@@ -812,14 +812,14 @@ compatible change または breaking change に該当しうる。
 
 以下は本スキルの設計における反証可能な仮説:
 
-| 仮説 | 反証条件 | 現状評価（94回実行データ、Run 95 で更新。observe.sh 自動集計） |
+| 仮説 | 反証条件 | 現状評価（95回実行データ、Run 95 で更新。observe.sh 自動集計） |
 |------|----------|----------------------|
-| H1: Agent Teams が学習ライフサイクルの自然なモデル化 | Teams の協調オーバーヘッドが改善効果を上回る | 未反証。96回 success / 1回 partial / 3回 observation。Verifier pass rate: 全期間 323/422 PASS（76%） |
+| H1: Agent Teams が学習ライフサイクルの自然なモデル化 | Teams の協調オーバーヘッドが改善効果を上回る | 未反証。97回 success / 1回 partial / 3回 observation。Verifier pass rate: 全期間 327/427 PASS（76%） |
 | H2: 4 エージェント分離が最適粒度 | より少ないエージェントで同等品質が達成される | 部分的に検証可能。agent-consolidation-4to2 は run 15 で P2 違反により abandoned。H2 の反証には至っていない |
 | H3: AxiomQuality.lean の指標で改善を計測可能 | Goodhart's Law により指標が改善を捉えない | 支持傾向。axioms=51、theorems=392。compression 7.68x（768%）。V4 blocked=0（Run 65 semantic 変更: session_id=unknown 除外）。旧 blocked=9 は unknown セッション混入値。blocked_excluded は動的値（observe.sh で確認可能） |
-| H4: conservative extension 優先が最適戦略 | conservative extension が蓄積し複雑度を増す | 支持傾向。全期間373改善統合（220 conservative extension, 150 compatible change, 1 breaking change, 2 other）。D4 フェーズ順序違反なし |
-| H5: 1 セッション 1 evolve 実行が適切な頻度 | より高頻度/低頻度が適切 | 未反証。33 データポイント（runs 39, 41, 42, 45, 46, 47, 49, 50, 58, 60, 61, 62, 63, 72, 73, 74, 75, 77, 78, 79, 80, 81, 84, 86, 87, 87b, 88, 89, 90, 91, 92, 93, 94）。session cost: mean 8.43 USD, median 6.73 USD, range 0.15-24.52 USD。コスト分布は bimodal 化（前半 16 runs mean 4.31 USD、後半 17 runs mean 12.31 USD）。セッション粒度は維持されているが、コスト増大傾向の要因分析が必要 |
-| H6: /evolve のコスト効率は経時的に改善する | cost/improvement が 10 runs 以上で単調増加 | 反証的証拠あり。33 データポイント: CPI mean 2.34 USD/improvement, median 1.62 USD (range 0.02-6.96 USD)。前半 16 runs CPI mean 1.11 USD → 後半 17 runs CPI mean 3.49 USD（214% 増加）。Run 77 以降のコスト増大が顕著（model 変更・タスク複雑度上昇が寄与要因の候補）。反証条件「10 runs 以上で単調増加」は後半 17 runs で成立しており、仮説の見直しが必要 |
+| H4: conservative extension 優先が最適戦略 | conservative extension が蓄積し複雑度を増す | 支持傾向。全期間377改善統合（221 conservative extension, 153 compatible change, 1 breaking change, 2 other）。D4 フェーズ順序違反なし |
+| H5: 1 セッション 1 evolve 実行が適切な頻度 | より高頻度/低頻度が適切 | 未反証。34 データポイント（runs 39, 41, 42, 45, 46, 47, 49, 50, 58, 60, 61, 62, 63, 72, 73, 74, 75, 77, 78, 79, 80, 81, 84, 86, 87, 87b, 88, 89, 90, 91, 92, 93, 94）。session cost: mean 8.54 USD, median 7.26 USD, range 0.15-24.52 USD。コスト分布は bimodal 化（前半 16 runs mean 4.31 USD、後半 17 runs mean 12.31 USD）。セッション粒度は維持されているが、コスト増大傾向の要因分析が必要 |
+| H6: /evolve のコスト効率は経時的に改善する | cost/improvement が 10 runs 以上で単調増加 | 反証的証拠あり。34 データポイント: CPI mean 2.36 USD/improvement, median 1.72 USD (range 0.03-6.96 USD)。前半 16 runs CPI mean 1.11 USD → 後半 17 runs CPI mean 3.49 USD（214% 増加）。Run 77 以降のコスト増大が顕著（model 変更・タスク複雑度上昇が寄与要因の候補）。反証条件「10 runs 以上で単調増加」は後半 17 runs で成立しており、仮説の見直しが必要 |
 
 これらの仮説は evolve の実行を通じて検証・更新される。
 

--- a/scripts/sync-hypothesis-table.sh
+++ b/scripts/sync-hypothesis-table.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# sync-hypothesis-table.sh — SKILL.md 仮説テーブルの deterministic な数値を
+# evolve-history.jsonl から自動同期する。
+# 評価文言（"未反証", "支持傾向" 等）は judgmental であり、更新しない。
+#
+# Usage:
+#   bash scripts/sync-hypothesis-table.sh [--dry-run]
+#
+# Options:
+#   --dry-run   変更を適用せず差分のみ表示
+#
+# 依存: python3, jq
+# G4 (#235) / Parent: #230
+
+set -euo pipefail
+
+BASE="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL="$BASE/.claude/skills/evolve/SKILL.md"
+HISTORY="$BASE/.claude/metrics/evolve-history.jsonl"
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+fi
+
+if [[ ! -f "$SKILL" ]]; then
+  echo "ERROR: SKILL.md not found: $SKILL" >&2
+  exit 1
+fi
+if [[ ! -f "$HISTORY" ]]; then
+  echo "ERROR: evolve-history.jsonl not found: $HISTORY" >&2
+  exit 1
+fi
+
+# --- Compute all deterministic stats from evolve-history.jsonl ---
+UPDATED=$(python3 << 'PYEOF'
+import json, re, sys, os
+
+base = os.environ.get("BASE", ".")
+skill_path = os.path.join(base, ".claude/skills/evolve/SKILL.md")
+history_path = os.path.join(base, ".claude/metrics/evolve-history.jsonl")
+
+# --- Parse evolve-history.jsonl ---
+success = partial = observation = 0
+ver_pass = ver_fail = 0
+max_run = 0
+ce = cc = bc = other = 0
+costs = []
+cpi_vals = []
+total_improvements = 0
+
+with open(history_path) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except Exception:
+            continue
+
+        # Run outcomes (H1)
+        r = rec.get("result", "")
+        if r == "success":
+            success += 1
+        elif r == "partial":
+            partial += 1
+        elif r == "observation":
+            observation += 1
+
+        # Max run number
+        run = rec.get("run")
+        if isinstance(run, (int, float)) and run > max_run:
+            max_run = int(run)
+
+        # Verifier stats (H1)
+        vp = (rec.get("phases") or {}).get("verifier") or {}
+        ver_pass += vp.get("pass_count") or 0
+        ver_fail += vp.get("fail_count") or 0
+
+        # Compatibility classes (H4)
+        imps = rec.get("improvements", [])
+        if isinstance(imps, list):
+            total_improvements += len(imps)
+            for imp in imps:
+                compat = (imp.get("compatibility") or "").strip()
+                if "conservative extension" in compat:
+                    ce += 1
+                elif "compatible change" in compat:
+                    cc += 1
+                elif "breaking change" in compat:
+                    bc += 1
+                else:
+                    other += 1
+
+        # Cost stats (H5/H6)
+        cost = rec.get("cost") or {}
+        if cost.get("session_cost_usd") is not None:
+            costs.append(cost["session_cost_usd"])
+            if cost.get("cost_per_improvement_usd") is not None:
+                cpi_vals.append(cost["cost_per_improvement_usd"])
+
+# Derived values
+ver_total = ver_pass + ver_fail
+ver_rate = (ver_pass * 100 // ver_total) if ver_total > 0 else 0
+h4_total = ce + cc + bc + other
+data_points = len(costs)
+mean_cost = round(sum(costs) / len(costs), 2) if costs else 0
+median_cost = round(sorted(costs)[len(costs) // 2], 2) if costs else 0
+min_cost = round(min(costs), 2) if costs else 0
+max_cost = round(max(costs), 2) if costs else 0
+mean_cpi = round(sum(cpi_vals) / len(cpi_vals), 2) if cpi_vals else 0
+median_cpi = round(sorted(cpi_vals)[len(cpi_vals) // 2], 2) if cpi_vals else 0
+min_cpi = round(min(cpi_vals), 2) if cpi_vals else 0
+max_cpi = round(max(cpi_vals), 2) if cpi_vals else 0
+
+# --- Read and update SKILL.md ---
+with open(skill_path) as f:
+    content = f.read()
+
+original = content
+
+# Header: "N回実行データ、Run M で更新"
+content = re.sub(
+    r'\d+回実行データ、Run \d+ で更新',
+    f'{max_run}回実行データ、Run {max_run} で更新',
+    content
+)
+
+# H1: "N回 success / N回 partial / N回 observation"
+content = re.sub(
+    r'(\d+)回 success / (\d+)回 partial / (\d+)回 observation',
+    f'{success}回 success / {partial}回 partial / {observation}回 observation',
+    content
+)
+
+# H1: "全期間 N/N PASS（N%）"
+content = re.sub(
+    r'全期間 \d+/\d+ PASS（\d+%）',
+    f'全期間 {ver_pass}/{ver_total} PASS（{ver_rate}%）',
+    content
+)
+
+# H4: "全期間N改善統合（N conservative extension, N compatible change, N breaking change, N other）"
+content = re.sub(
+    r'全期間\d+改善統合（\d+ conservative extension, \d+ compatible change, \d+ breaking change, \d+ other）',
+    f'全期間{h4_total}改善統合（{ce} conservative extension, {cc} compatible change, {bc} breaking change, {other} other）',
+    content
+)
+
+# H5: data points count
+content = re.sub(
+    r'(\| H5:.*?未反証。)\d+ データポイント',
+    lambda m: f'{m.group(1)}{data_points} データポイント',
+    content
+)
+
+# H5: session cost stats "mean N USD, median N USD, range N-N USD"
+content = re.sub(
+    r'session cost: mean [\d.]+ USD, median [\d.]+ USD, range [\d.]+-[\d.]+ USD',
+    f'session cost: mean {mean_cost} USD, median {median_cost} USD, range {min_cost}-{max_cost} USD',
+    content
+)
+
+# H6: data points count
+content = re.sub(
+    r'(\| H6:.*?)\d+ データポイント',
+    lambda m: f'{m.group(1)}{len(cpi_vals)} データポイント',
+    content
+)
+
+# H6: "CPI mean N USD/improvement, median N USD"
+content = re.sub(
+    r'CPI mean [\d.]+ USD/improvement, median [\d.]+ USD \(range [\d.]+-[\d.]+ USD\)',
+    f'CPI mean {mean_cpi} USD/improvement, median {median_cpi} USD (range {min_cpi}-{max_cpi} USD)',
+    content
+)
+
+if content == original:
+    print("NO_CHANGE")
+else:
+    print(content, end="")
+PYEOF
+)
+
+if [[ "$UPDATED" == "NO_CHANGE" ]]; then
+  echo "No changes needed — SKILL.md is already up to date."
+  exit 0
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "--- Dry run: showing diff ---"
+  diff <(cat "$SKILL") <(echo "$UPDATED") || true
+  echo "--- End dry run ---"
+else
+  echo "$UPDATED" > "$SKILL"
+  echo "SKILL.md hypothesis table updated successfully."
+fi


### PR DESCRIPTION
## Summary
- `scripts/sync-hypothesis-table.sh` を追加: evolve-history.jsonl から SKILL.md 仮説テーブルの deterministic 数値を自動同期
- H1 (run outcomes, verifier stats), H4 (互換性分類), H5 (cost stats), H6 (CPI stats) を更新
- 評価文言（"未反証", "支持傾向" 等）は judgmental として変更しない

## Gate 判定 (G4 #235)
- **PASS**: Section 18 drift test PASS する更新を生成
- 全テスト 530 passed, 0 failed

## Test plan
- [x] `--dry-run` で差分確認
- [x] 適用後 Section 18 drift test PASS
- [x] 全テストスイート 530/530 PASS

Parent: #230
Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)