### PR TITLE
#319: Verifier に設計レビューモード追加

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -42,6 +42,37 @@ For high risk: this agent can satisfy 3 conditions when hook-invoked (contextSep
 When reviewing critical-risk changes (L1, safety, permissions), always state:
 "EVALUATOR INDEPENDENCE NOT MET: This review is by the same model family. Human review required for critical risk."
 
+## Review Modes
+
+This agent operates in one of two modes, specified in the prompt:
+
+| Mode | When | What is verified |
+|------|------|-----------------|
+| **implementation** (default) | Phase 4 (post-implementation) or /verify | File diffs exist and are correct |
+| **design** | Phase 2-3 (pre-implementation) | Logical soundness of the proposal |
+
+If the prompt contains `review_mode: design`, use Design Review Mode.
+Otherwise, use Implementation Review Mode (default).
+
+### Design Review Mode
+
+For proposals that describe *what to change* without actual file diffs:
+
+1. Read referenced files to understand current state
+2. Evaluate the **design**, not the presence of implementation:
+   - Logical consistency: Does the proposal contradict existing behavior?
+   - Type compatibility: Are referenced types/definitions correct? (Grep to verify)
+   - Scope accuracy: Are all affected files identified?
+   - Test plan validity: Are test criteria observable and falsifiable?
+   - Manifest compliance: Does the design align with D1-D18?
+   - Feasibility: Can the described changes be implemented as specified?
+3. Do NOT fail because "implementation is absent" — that is expected in design mode
+4. FAIL only for: logical errors, incorrect assumptions about existing code, missing affected files, infeasible changes
+
+Output format is the same as Implementation Review Mode.
+
+### Implementation Review Mode (default)
+
 ## Review Process
 
 1. Read the files specified in the task

--- a/.claude/skills/evolve/SKILL.md
+++ b/.claude/skills/evolve/SKILL.md
@@ -467,11 +467,16 @@ Loopback フェーズでは PASS_LIST が確定済みであるため、依存関
 
 **Verifier への入力（各提案）:**
 ```
+review_mode: [implementation|design]
 検証対象: [改善案のタイトルと内容]
 変更対象ファイル: [ファイルリスト]
 互換性分類: [分類]
 テスト計画: [テスト計画]
 ```
+
+**review_mode の選択基準:**
+- `design`: Hypothesizer の提案が設計（何を変えるか）のみで、実装（ファイル差分）を含まない場合
+- `implementation`: Integrator が実装した後の検証、または /verify での手動検証
 
 **重要（P2 準拠）:**
 - Hypothesizer の思考過程を Verifier に渡さない（コンテキスト分離）


### PR DESCRIPTION
## Summary

- Verifier に `design` / `implementation` の 2 レビューモードを定義
- `design` モード: 設計段階の提案を論理的整合性・型互換性・テスト計画の妥当性で評価。「実装が存在しない」での FAIL を防止
- `implementation` モード (default): 従来通りファイル差分を検証
- SKILL.md の Phase 3 Verifier 入力に `review_mode` フィールドを追加

Closes #319

## Test plan

- [x] 既存テスト全 PASS (537/537)
- [ ] 次回 /evolve で design モードが正しく動作することを確認
- [x] review_mode 未指定時は implementation にフォールバック（後方互換）

🤖 Generated with [Claude Code](https://claude.com/claude-code)