### PR TITLE
#317: valuelessChange 検出 — Level 0 接地で /evolve 自動停止

### DIFF
--- a/.claude/skills/evolve/SKILL.md
+++ b/.claude/skills/evolve/SKILL.md
@@ -253,6 +253,24 @@ jq '[.items | to_entries[] | select(.value.status == "open") | {id: .key} + .val
 前回の結果がある場合、Observer にコンテキストとして渡す。
 なければ初回実行として進む。
 
+```bash
+# Step 0c: valuelessChange 検出 — Level 0 接地（#317）
+# observe.sh の valueless_change.halt_recommended を確認
+OBSERVE_JSON=$(bash .claude/skills/evolve/scripts/observe.sh 2>/dev/null)
+HALT=$(echo "$OBSERVE_JSON" | jq -r '.valueless_change.halt_recommended // false' 2>/dev/null)
+if [ "$HALT" = "true" ]; then
+  STREAK=$(echo "$OBSERVE_JSON" | jq -r '.valueless_change.current_streak' 2>/dev/null)
+  echo "⚠️ valuelessChange 検出: 直近 ${STREAK} runs で improvements あり・v_changes 空"
+  echo "Level 0 メトリクス（V1-V7）が動いていません。/evolve を停止し人間レビューを要求します。"
+  # → 人間に報告して終了（T6: 人間の最終決定権）
+fi
+```
+
+**valuelessChange halt の判定基準（T6 パラメータ）:**
+- `current_streak >= 3`: improvements を統合したが V1-V7 delta がゼロの runs が 3 連続
+- 対処: 人間が bias(t) を見直すか、/evolve の対象範囲を調整する
+- 人間が「続行」と判断した場合は、そのまま Phase 1 に進む
+
 **未解決 deferred がある場合:**
 Observer へのプロンプトに「未解決 deferred 一覧」を明示的に含める。
 deferred 項目は改善候補の先頭に含め、通常の観察項目より優先する。

--- a/.claude/skills/evolve/scripts/observe.sh
+++ b/.claude/skills/evolve/scripts/observe.sh
@@ -1103,7 +1103,42 @@ except Exception as e:
 " 2>/dev/null || echo '{}')
 echo "  \"scope_balance\": $SCOPE_BALANCE,"
 
-# --- GAP 7: Failed Test Details (cached from earlier test run) ---
+# --- GAP 7: valuelessChange detection — improvements integrated but v_changes empty (#317) ---
+VALUELESS_CHANGE=$(python3 -c "
+import json, sys
+try:
+    history = open('$HISTORY_FILE').readlines()
+    recent = [json.loads(l) for l in history[-10:] if l.strip()]
+    consecutive_empty = 0
+    max_consecutive = 0
+    for entry in reversed(recent):
+        v = entry.get('v_changes', {})
+        has_improvements = len(entry.get('improvements', [])) > 0
+        if has_improvements and (v == {} or v is None):
+            consecutive_empty += 1
+            max_consecutive = max(max_consecutive, consecutive_empty)
+        else:
+            consecutive_empty = 0
+    # Current streak from most recent
+    current_streak = 0
+    for entry in reversed(recent):
+        v = entry.get('v_changes', {})
+        has_improvements = len(entry.get('improvements', [])) > 0
+        if has_improvements and (v == {} or v is None):
+            current_streak += 1
+        else:
+            break
+    print(json.dumps({
+        'current_streak': current_streak,
+        'max_streak_in_last_10': max_consecutive,
+        'halt_recommended': current_streak >= 3
+    }))
+except Exception as e:
+    print(json.dumps({'error': str(e)}))
+" 2>/dev/null || echo '{}')
+echo "  \"valueless_change\": $VALUELESS_CHANGE,"
+
+# --- GAP 8: Failed Test Details (cached from earlier test run) ---
 # TEST_FAILED is set earlier from the test run.
 # If tests failed, report the cached output. No re-run needed.
 if [ "${TEST_FAILED:-0}" -gt 0 ] 2>/dev/null; then


### PR DESCRIPTION
## Summary

- **observe.sh**: `valueless_change` セクション追加。「improvements を統合したが v_changes（V1-V7 delta）が空」の runs を検出。3 連続で `halt_recommended: true`
- **SKILL.md**: Step 0c に valuelessChange halt チェック追加。halt 時は人間に報告して終了（T6）

制御理論的フレ��ミング: Level 1 (プロ���ス) のメトリクスだけで自己評価せず、Level 0 (プロジェクト) のメトリクスで評価。無限後退を防ぐため新階層は作らず Level 0 に接地。

Closes #317

## Test plan

- [x] `observe.sh` が `valueless_change` を正しく出���（current_streak=1, halt=false）
- [x] 既存��スト全 PASS (320/320)
- [ ] 3 連続空 v_changes 時に halt_recommended: true になることを確認（次回 /evolve で検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)