### PR TITLE
#445 export-plugin: 構造的強制基盤の plugin 化

### DIFF
--- a/.claude/hooks/l1-file-guard.sh
+++ b/.claude/hooks/l1-file-guard.sh
@@ -13,7 +13,7 @@ SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null)
 log_gate_blocked() {
   local reason="$1"
   local metrics_dir
-  metrics_dir="$(cd "$(dirname "$0")/.." && pwd)/metrics"
+  metrics_dir="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")/.claude/metrics"
   local log_file="$metrics_dir/tool-usage.jsonl"
   if [ -d "$metrics_dir" ]; then
     printf '{"event":"gate_blocked","hook":"l1-file-guard","reason":"%s","tool":"%s","file":"%s","session_id":"%s","timestamp":"%s"}\n' \

--- a/.claude/hooks/l1-safety-check.sh
+++ b/.claude/hooks/l1-safety-check.sh
@@ -15,7 +15,7 @@ SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null)
 log_gate_blocked() {
   local reason="$1"
   local metrics_dir
-  metrics_dir="$(cd "$(dirname "$0")/.." && pwd)/metrics"
+  metrics_dir="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")/.claude/metrics"
   local log_file="$metrics_dir/tool-usage.jsonl"
   if [ -d "$metrics_dir" ]; then
     printf '{"event":"gate_blocked","hook":"l1-safety-check","reason":"%s","tool":"Bash","session_id":"%s","timestamp":"%s"}\n' \

--- a/.claude/hooks/p2-verify-on-commit.sh
+++ b/.claude/hooks/p2-verify-on-commit.sh
@@ -29,7 +29,13 @@ STAGED=$("${GIT_CMD[@]}" diff --cached --name-only 2>/dev/null)
 if [ -z "$STAGED" ]; then
 exit 0
 fi
-HIGH_RISK_PATTERNS='\.claude/|tests/|\.test\.|_test\.|settings\.json|lean-formalization/Manifest/'
+# Config lookup: userConfig -> config.json -> default
+_CONFIG_FILE="${CLAUDE_PLUGIN_DATA:-/dev/null}/config.json"
+if [ -f "$_CONFIG_FILE" ] && jq -e '.HIGH_RISK_PATTERNS' "$_CONFIG_FILE" >/dev/null 2>&1; then
+  HIGH_RISK_PATTERNS=$(jq -r '.HIGH_RISK_PATTERNS' "$_CONFIG_FILE")
+else
+  HIGH_RISK_PATTERNS='\.claude/|tests/|\.test\.|_test\.|settings\.json'
+fi
 HIGH_RISK_FILES=$(echo "$STAGED" | grep -E "$HIGH_RISK_PATTERNS" || true)
 if [ -z "$HIGH_RISK_FILES" ]; then
 exit 0

--- a/.claude/hooks/p3-compatibility-check.sh
+++ b/.claude/hooks/p3-compatibility-check.sh
@@ -22,7 +22,13 @@ GIT_CMD=(git)
 if [ -n "$GIT_DIR" ] && [ -d "$GIT_DIR" ]; then
 GIT_CMD=(git -C "$GIT_DIR")
 fi
-STRUCTURAL_PATTERNS='\.claude/|tests/|manifesto\.md|docs/|research/|reports/|lean-formalization/'
+# Config lookup: userConfig -> config.json -> default
+_CONFIG_FILE="${CLAUDE_PLUGIN_DATA:-/dev/null}/config.json"
+if [ -f "$_CONFIG_FILE" ] && jq -e '.STRUCTURAL_PATTERNS' "$_CONFIG_FILE" >/dev/null 2>&1; then
+  STRUCTURAL_PATTERNS=$(jq -r '.STRUCTURAL_PATTERNS' "$_CONFIG_FILE")
+else
+  STRUCTURAL_PATTERNS='\.claude/|tests/|docs/'
+fi
 STAGED=$(git diff --cached --name-only 2>/dev/null)
 
 if echo "$STAGED" | grep -qE "$STRUCTURAL_PATTERNS"; then

--- a/.claude/hooks/rules-injector.sh
+++ b/.claude/hooks/rules-injector.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Rules Injector — SessionStart
+#
+# Plugin spec does not support .claude/rules/ as auto-loaded components.
+# This hook injects rule content via additionalContext on SessionStart.
+# Reads from ${CLAUDE_PLUGIN_ROOT}/rules/ when deployed as plugin,
+# or from .claude/rules/ when running standalone.
+# @traces P3, D1
+
+# Resolve rules directory: plugin root or project .claude/rules/
+if [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -d "$CLAUDE_PLUGIN_ROOT/rules" ]; then
+  RULES_DIR="$CLAUDE_PLUGIN_ROOT/rules"
+elif [ -d "$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/rules" ]; then
+  RULES_DIR="$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/rules"
+else
+  exit 0
+fi
+
+# Collect all .md rule files
+RULES_CONTENT=""
+for rule_file in "$RULES_DIR"/*.md; do
+  [ -f "$rule_file" ] || continue
+  RULES_CONTENT="${RULES_CONTENT}$(cat "$rule_file")
+---
+"
+done
+
+if [ -z "$RULES_CONTENT" ]; then
+  exit 0
+fi
+
+# Escape for JSON
+ESCAPED=$(printf '%s' "$RULES_CONTENT" | jq -Rs .)
+
+cat << JSON
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": $ESCAPED
+  }
+}
+JSON

--- a/.claude/rules/claude-md-routing.md
+++ b/.claude/rules/claude-md-routing.md
@@ -1,0 +1,29 @@
+# Compact Instructions (Plugin Base)
+
+## L1: Safety Boundary (non-negotiable)
+
+- Do not tamper with, delete, or disable tests
+- Do not commit secrets (.env, key files)
+- Do not execute destructive operations (rm -rf, git push --force) without human confirmation
+- Do not modify `.claude/hooks/` or `.claude/settings.json` without human approval
+- Respect human final decision authority (T6)
+
+## P2: Verification Independence
+
+- Do not review your own code (cognitive separation of concerns)
+- Use `/verify` for independent subagent verification on important changes
+
+## P3: Learning Governance
+
+- Structural changes require compatibility classification in commit messages:
+  conservative extension / compatible change / breaking change
+
+## P4: Observability
+
+- Metrics are auto-collected in `.claude/metrics/` by hooks
+- Verify claims with measurement before asserting improvement
+
+## D4: Phase Order
+
+Safety (L1) → Verification (P2) → Observability (P4) → Governance (P3) → Dynamic adjustment.
+Changes that break an earlier phase undermine the reliability of later phases.

--- a/export-manifest.json
+++ b/export-manifest.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "export-manifest/v1",
+  "description": "Declares which artifacts to export as a Claude Code plugin. Machine-readable, no ambiguity.",
+  "classificationCriteria": {
+    "base": "No manifesto-specific paths/concepts. Works in any project as-is or with userConfig.",
+    "base-configurable": "Contains manifesto-specific patterns as defaults, but configurable via userConfig. Exported with defaults replaced by config.json lookup.",
+    "domain": "Hardcoded manifesto-specific logic. Not exported to base plugin."
+  },
+  "hooks": {
+    "l1-safety-check.sh": {
+      "target": "base",
+      "path": ".claude/hooks/l1-safety-check.sh",
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "config": [],
+      "rationale": "Generic dangerous-command detection, credential exfiltration prevention"
+    },
+    "l1-file-guard.sh": {
+      "target": "base",
+      "path": ".claude/hooks/l1-file-guard.sh",
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "config": [],
+      "rationale": "Generic secret-file write blocking, test tampering detection, hook self-protection"
+    },
+    "p2-verify-on-commit.sh": {
+      "target": "base-configurable",
+      "path": ".claude/hooks/p2-verify-on-commit.sh",
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "config": ["HIGH_RISK_PATTERNS"],
+      "defaults": {
+        "HIGH_RISK_PATTERNS": "\\.claude/|tests/|\\.test\\.|_test\\.|settings\\.json"
+      },
+      "rationale": "High-risk commit gating. Default patterns are generic; lean-formalization/ removed from defaults."
+    },
+    "p3-compatibility-check.sh": {
+      "target": "base-configurable",
+      "path": ".claude/hooks/p3-compatibility-check.sh",
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "config": ["STRUCTURAL_PATTERNS"],
+      "defaults": {
+        "STRUCTURAL_PATTERNS": "\\.claude/|tests/|docs/"
+      },
+      "rationale": "Structural-file commit classification enforcement. Default patterns are generic; manifesto-specific paths removed."
+    },
+    "p4-metrics-collector.sh": {
+      "target": "base",
+      "path": ".claude/hooks/p4-metrics-collector.sh",
+      "event": "PostToolUse",
+      "matcher": null,
+      "config": [],
+      "rationale": "Generic tool-use logger. Already uses git rev-parse."
+    },
+    "p4-gate-logger.sh": {
+      "target": "base",
+      "path": ".claude/hooks/p4-gate-logger.sh",
+      "event": "SessionStart",
+      "matcher": null,
+      "config": [],
+      "rationale": "Generic session summary writer"
+    },
+    "p4-drift-detector.sh": {
+      "target": "base",
+      "path": ".claude/hooks/p4-drift-detector.sh",
+      "event": "SessionStart",
+      "matcher": null,
+      "config": [],
+      "rationale": "Generic behavioral drift detection (V4 block rate, V5 rejection rate)"
+    },
+    "p4-temporal-tracker.sh": {
+      "target": "base",
+      "path": ".claude/hooks/p4-temporal-tracker.sh",
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "config": [],
+      "rationale": "Test-before-push, amend warnings. Supports npm/pytest/cargo/make/lake."
+    },
+    "p4-v5-approval-tracker.sh": {
+      "target": "base",
+      "path": ".claude/hooks/p4-v5-approval-tracker.sh",
+      "event": "UserPromptSubmit",
+      "matcher": null,
+      "config": [],
+      "rationale": "Human approval/rejection pattern tracking"
+    },
+    "p4-v7-task-tracker.sh": {
+      "target": "base",
+      "path": ".claude/hooks/p4-v7-task-tracker.sh",
+      "event": "TaskCompleted",
+      "matcher": null,
+      "config": [],
+      "rationale": "Task completion logging"
+    },
+    "rules-injector.sh": {
+      "target": "base",
+      "path": ".claude/hooks/rules-injector.sh",
+      "event": "SessionStart",
+      "matcher": null,
+      "config": [],
+      "rationale": "Injects rule content and CLAUDE.md minimal routing as additionalContext on session start. Required because plugin spec does not auto-load .claude/rules/."
+    },
+    "evolve-metrics-recorder.sh": {
+      "target": "domain",
+      "path": ".claude/hooks/evolve-metrics-recorder.sh",
+      "event": "PostToolUse",
+      "matcher": "Bash",
+      "config": [],
+      "rationale": "Records evolve-specific commit events to evolve-history.jsonl"
+    },
+    "evolve-state-loader.sh": {
+      "target": "domain",
+      "path": ".claude/hooks/evolve-state-loader.sh",
+      "event": "SessionStart",
+      "matcher": null,
+      "config": [],
+      "rationale": "Loads evolve history and checks Lean sorry count"
+    },
+    "h5-doc-lint.sh": {
+      "target": "domain",
+      "path": ".claude/hooks/h5-doc-lint.sh",
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "config": [],
+      "rationale": "Lean/Verso doc comment linting. Hardcoded lean-formalization/Manifest/ paths."
+    },
+    "hallucination-check.sh": {
+      "target": "domain",
+      "path": ".claude/hooks/hallucination-check.sh",
+      "event": "PreToolUse",
+      "matcher": "Bash|Edit|Write",
+      "config": [],
+      "rationale": "Lean definition/axiom/theorem verification. 11 manifesto-specific refs."
+    },
+    "p3-axiom-evidence-check.sh": {
+      "target": "domain",
+      "path": ".claude/hooks/p3-axiom-evidence-check.sh",
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "config": [],
+      "rationale": "Axiom Card metadata checking. Hardcoded lean-formalization/ paths."
+    },
+    "p4-manifest-refs-check.sh": {
+      "target": "domain",
+      "path": ".claude/hooks/p4-manifest-refs-check.sh",
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "config": [],
+      "rationale": "artifact-manifest.json refs vs propositions list validation"
+    },
+    "p4-sync-counts-check.sh": {
+      "target": "domain",
+      "path": ".claude/hooks/p4-sync-counts-check.sh",
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "config": [],
+      "rationale": "Lean axiom/theorem count sync. Calls scripts/sync-counts.sh."
+    },
+    "p4-traces-integrity-check.sh": {
+      "target": "domain",
+      "path": ".claude/hooks/p4-traces-integrity-check.sh",
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "config": [],
+      "rationale": "@traces annotation vs artifact-manifest.json refs consistency"
+    }
+  },
+  "agents": {
+    "verifier.md": {
+      "target": "base-configurable",
+      "path": ".claude/agents/verifier.md",
+      "config": ["DOMAIN_CHECKLIST"],
+      "rationale": "P2 independent verification core. Independence conditions (contextSeparated, framingIndependent, etc.) are generic. Domain-specific checklist items (Lean theorem quality, D1-D18 compliance) to be removed or made configurable."
+    },
+    "judge.md": {
+      "target": "domain",
+      "path": ".claude/agents/judge.md",
+      "config": [],
+      "rationale": "G1-G5 criteria reference manifesto concepts (V1-V7, T2)"
+    },
+    "observer": {
+      "target": "domain",
+      "path": ".claude/agents/observer/AGENT.md",
+      "config": [],
+      "rationale": "Tied to evolve-history.jsonl, deferred-status.json, Lean stats"
+    },
+    "hypothesizer": {
+      "target": "domain",
+      "path": ".claude/agents/hypothesizer/AGENT.md",
+      "config": [],
+      "rationale": "References Workflow.lean, Evolution.lean, TaskClassification.lean"
+    },
+    "integrator": {
+      "target": "domain",
+      "path": ".claude/agents/integrator/AGENT.md",
+      "config": [],
+      "rationale": "Tied to evolve run recording, evolve-history.jsonl schema"
+    },
+    "model-questioner.md": {
+      "target": "domain",
+      "path": ".claude/agents/model-questioner.md",
+      "config": [],
+      "rationale": "References EpistemicLayerClass, lean-formalization paths"
+    }
+  },
+  "rules": {
+    "l1-safety.md": {
+      "target": "base",
+      "path": ".claude/rules/l1-safety.md",
+      "config": [],
+      "rationale": "Generic safety boundaries. No manifesto-specific content."
+    },
+    "l1-sandbox-recommendation.md": {
+      "target": "base",
+      "path": ".claude/rules/l1-sandbox-recommendation.md",
+      "config": [],
+      "rationale": "Generic sandbox recommendation. No manifesto-specific content."
+    },
+    "p3-governed-learning.md": {
+      "target": "base",
+      "path": ".claude/rules/p3-governed-learning.md",
+      "config": [],
+      "rationale": "Generic learning governance lifecycle. Compatibility classification is universal."
+    }
+  }
+}

--- a/scripts/generate-plugin.py
+++ b/scripts/generate-plugin.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Generate a Claude Code plugin from export-manifest.json.
+
+Reads export-manifest.json and assembles a plugin directory with:
+- hooks/hooks.json + hooks/scripts/ (base hooks)
+- agents/ (base agents)
+- rules/ (base rules, injected via SessionStart hook)
+- .claude-plugin/plugin.json
+
+Usage:
+    python3 scripts/generate-plugin.py [output-dir]
+    Default output: dist/agent-manifesto-base/
+"""
+
+import json
+import os
+import shutil
+import sys
+
+MANIFEST = "export-manifest.json"
+DEFAULT_OUTPUT = "dist/agent-manifesto-base"
+
+
+def main():
+    output_dir = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_OUTPUT
+
+    if not os.path.exists(MANIFEST):
+        print(f"ERROR: {MANIFEST} not found. Run from project root.")
+        sys.exit(1)
+
+    with open(MANIFEST) as f:
+        manifest = json.load(f)
+
+    # Clean output
+    if os.path.exists(output_dir):
+        shutil.rmtree(output_dir)
+
+    os.makedirs(f"{output_dir}/.claude-plugin", exist_ok=True)
+    os.makedirs(f"{output_dir}/hooks/scripts", exist_ok=True)
+    os.makedirs(f"{output_dir}/agents", exist_ok=True)
+    os.makedirs(f"{output_dir}/rules", exist_ok=True)
+
+    # plugin.json
+    plugin_json = {
+        "name": "agent-manifesto-base",
+        "description": "Structural enforcement infrastructure: L1 safety, P2 verification, P3 governance, P4 observability",
+        "version": "0.1.0",
+        "author": {"name": "nirarin"},
+    }
+    with open(f"{output_dir}/.claude-plugin/plugin.json", "w") as f:
+        json.dump(plugin_json, f, indent=2)
+        f.write("\n")
+
+    # Hooks
+    hooks_json = {"hooks": {}}
+    hook_count = 0
+    for name, hook in manifest["hooks"].items():
+        if hook["target"] not in ("base", "base-configurable"):
+            continue
+        src = hook["path"]
+        if not os.path.exists(src):
+            print(f"  WARN: {src} not found, skipping")
+            continue
+        shutil.copy2(src, f"{output_dir}/hooks/scripts/{name}")
+        os.chmod(f"{output_dir}/hooks/scripts/{name}", 0o755)
+
+        event = hook["event"]
+        entry = {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": f"${{CLAUDE_PLUGIN_ROOT}}/hooks/scripts/{name}",
+                }
+            ]
+        }
+        if hook.get("matcher"):
+            entry["matcher"] = hook["matcher"]
+        hooks_json["hooks"].setdefault(event, []).append(entry)
+        hook_count += 1
+
+    with open(f"{output_dir}/hooks/hooks.json", "w") as f:
+        json.dump(hooks_json, f, indent=2)
+        f.write("\n")
+
+    # Agents
+    agent_count = 0
+    for name, agent in manifest["agents"].items():
+        if agent["target"] not in ("base", "base-configurable"):
+            continue
+        src = agent["path"]
+        if os.path.isfile(src):
+            shutil.copy2(src, f"{output_dir}/agents/{name}")
+        elif os.path.isdir(os.path.dirname(src)):
+            # agents/<name>/AGENT.md → agents/<name>.md (flatten)
+            if os.path.exists(src):
+                dest_name = name if name.endswith(".md") else f"{name}.md"
+                shutil.copy2(src, f"{output_dir}/agents/{dest_name}")
+        else:
+            print(f"  WARN: {src} not found, skipping")
+            continue
+        agent_count += 1
+
+    # Rules
+    rule_count = 0
+    for name, rule in manifest["rules"].items():
+        if rule["target"] not in ("base", "base-configurable"):
+            continue
+        src = rule["path"]
+        if not os.path.exists(src):
+            print(f"  WARN: {src} not found, skipping")
+            continue
+        shutil.copy2(src, f"{output_dir}/rules/{name}")
+        rule_count += 1
+
+    print(f"Plugin generated at {output_dir}/")
+    print(f"  Hooks:  {hook_count}")
+    print(f"  Agents: {agent_count}")
+    print(f"  Rules:  {rule_count}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- export-manifest.json を新設し、全 28 成果物（19 hooks, 6 agents, 3 rules）を base/base-configurable/domain に分類
- L1 hook のメトリクスパス解決を `git rev-parse` ベースに修正（plugin deploy 先でも動作）
- rules-injector.sh を新設（plugin spec が rules を auto-load しない制約への対応）
- claude-md-routing.md（L1/P2/P3/P4/D4 最小指示）を同梱
- P2/P3 hook のパターンを `${CLAUDE_PLUGIN_DATA}/config.json` から設定可能に
- generate-plugin.py — manifest から plugin を自動生成、`claude plugin validate` PASS

## Test plan

- [x] `jq . export-manifest.json` — JSON 整合性 PASS
- [x] 全 28 成果物が分類済み（12 base + 3 base-configurable + 13 domain）
- [x] l1-safety-check.sh, l1-file-guard.sh が `git rev-parse` ベースのパス解決を使用
- [x] rules-injector.sh が `${CLAUDE_PLUGIN_ROOT}/rules/` から正しく読み込み
- [x] p2/p3 hook が config.json なしでデフォルト値を使用
- [x] `python3 scripts/generate-plugin.py` → 11 hooks + 1 agent + 3 rules
- [x] `claude plugin validate dist/agent-manifesto-base/` → ✔ Validation passed

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)