### PR TITLE
/handoff skill: context 逼迫時のセッション引き継ぎ

### DIFF
--- a/.claude/hooks/handoff-resume-loader.sh
+++ b/.claude/hooks/handoff-resume-loader.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# @traces T1, T2, D1, D10, P4
+# SessionStart hook: inject handoff resume into LLM context via additionalContext
+# Pattern: same as p4-drift-detector.sh (proven mechanism)
+set -uo pipefail
+
+BASE="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+HANDOFF_DIR="${HANDOFF_DIR:-$BASE/.claude/handoffs}"
+RESUME_FILE="$HANDOFF_DIR/handoff-resume.md"
+
+CONTEXT=""
+
+# --- Handoff resume injection ---
+if [ -f "$RESUME_FILE" ]; then
+  # Extract git_sha from resume file
+  RESUME_SHA=$(grep -m1 '^git_sha:' "$RESUME_FILE" | sed 's/^git_sha:[[:space:]]*//')
+  CURRENT_SHA=$(cd "$BASE" && git rev-parse HEAD 2>/dev/null || echo "unknown")
+
+  RESUME_CONTENT=$(cat "$RESUME_FILE")
+
+  if [ "$RESUME_SHA" = "$CURRENT_SHA" ]; then
+    CONTEXT="[HANDOFF RESUME] Previous session state restored.\n$RESUME_CONTENT"
+  else
+    CONTEXT="[HANDOFF RESUME - SHA MISMATCH WARNING] git_sha changed since handoff (was: $RESUME_SHA, now: $CURRENT_SHA). Commits occurred after handoff — intent/progress are likely valid but file state may have changed. Verify before proceeding.\n$RESUME_CONTENT"
+  fi
+
+  # Rename to .injected to prevent double injection (D1: structural enforcement)
+  mv "$RESUME_FILE" "${RESUME_FILE}.injected" 2>/dev/null || true
+fi
+
+# --- Sorry count check (integrated from evolve-state-loader.sh) ---
+if [ -d "$BASE/lean-formalization/Manifest" ]; then
+  SORRY_COUNT=$(grep -rn "^\s*sorry\s*$\|:=\s*sorry" "$BASE/lean-formalization/Manifest/" --include="*.lean" 2>/dev/null | grep -v -- "--" | grep -v "/-" | wc -l | tr -d ' ')
+  if [ "$SORRY_COUNT" -gt 0 ] 2>/dev/null; then
+    CONTEXT="$CONTEXT\n[WARNING] $SORRY_COUNT sorry found in Lean formalization"
+  fi
+fi
+
+# --- Evolve last run (integrated from evolve-state-loader.sh) ---
+HISTORY_FILE="$BASE/.claude/metrics/evolve-history.jsonl"
+if [ -f "$HISTORY_FILE" ]; then
+  LAST_RUN=$(tail -1 "$HISTORY_FILE" 2>/dev/null)
+  if [ -n "$LAST_RUN" ]; then
+    TIMESTAMP=$(echo "$LAST_RUN" | grep -o '"timestamp":"[^"]*"' | head -1 | cut -d'"' -f4)
+    CONTEXT="$CONTEXT\n[evolve] Last run: $TIMESTAMP"
+  fi
+fi
+
+# --- Output via additionalContext if there's anything to inject ---
+if [ -n "$CONTEXT" ]; then
+  # Escape for JSON: prefer python3, fallback to basic sed
+  ESCAPED=$(printf '%b' "$CONTEXT" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))" 2>/dev/null | sed 's/^"//;s/"$//')
+  if [ -z "$ESCAPED" ]; then
+    # python3 not available: basic JSON escaping
+    ESCAPED=$(printf '%b' "$CONTEXT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g' | tr '\n' ' ')
+    echo "[handoff-resume-loader] WARNING: python3 not found, using basic escaping" >&2
+  fi
+  cat << JSON
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "$ESCAPED"
+  }
+}
+JSON
+fi
+
+exit 0
+
+# Traceability:
+# T1: handoff は T1 のインスタンス消滅を前提に設計
+# T2: handoff-resume.md に状態を永続化し次インスタンスに引き継ぐ
+# D1: .injected リネームで二重注入を構造的に防止
+# D10: エージェント消滅後も構造（handoff ログ）が残る
+# P4: sorry-count と evolve 最終実行をセッション開始時に通知

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,8 @@
       "allowWrite": [
         "./.lake/build",
         "/tmp",
-        "~/work"
+        "~/work",
+        "./.claude/handoffs"
       ]
     }
   },
@@ -42,6 +43,10 @@
       {
         "matcher": "Bash",
         "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/branch-protection.sh"
+          },
           {
             "type": "command",
             "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/l1-safety-check.sh"
@@ -143,6 +148,10 @@
           {
             "type": "command",
             "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/evolve-state-loader.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/handoff-resume-loader.sh"
           }
         ]
       }

--- a/.claude/skills/dependency-graph.yaml
+++ b/.claude/skills/dependency-graph.yaml
@@ -6,8 +6,8 @@
 #
 # Schema: .claude/skills/dependency-schema.yaml
 
-generated_at: "2026-04-12T05:55:58Z"
-skill_count: 13
+generated_at: "2026-04-12T08:05:41Z"
+skill_count: 14
 
 skills:
   adjust-action-space:
@@ -118,6 +118,22 @@ skills:
         type: soft
         phase: "Step 2"
         condition: "根拠が不明な場合"
+
+  handoff:
+    invokes: []
+    invoked_by:
+      - skill: evolve
+        phase: "Phase 1→2, 2→3, 3→4 boundary"
+        expected_output: "checkpoint JSONL entry"
+      - skill: spec-driven-workflow
+        phase: "Phase 0→1, 1→2, 2→3, 3→4 boundary"
+        expected_output: "checkpoint JSONL entry"
+      - skill: brownfield
+        phase: "Phase 0→1, 1→2 boundary"
+        expected_output: "checkpoint JSONL entry"
+      - skill: formal-derivation
+        phase: "Phase 1→2, 2→3, 3→4 boundary"
+        expected_output: "checkpoint JSONL entry"
 
   instantiate-model:
     invokes:
@@ -349,7 +365,7 @@ edges:
 
 # Summary
 summary:
-  total_skills: 13
+  total_skills: 14
   total_edges: 32
   hard_edges: 17
   soft_edges: 15

--- a/.claude/skills/evolve/SKILL.md
+++ b/.claude/skills/evolve/SKILL.md
@@ -572,6 +572,8 @@ for each observation in t6_items:
 
 end for
 
+**Checkpoint**: Phase 1 完了時に `/handoff` Layer 1 checkpoint を `.claude/handoffs/checkpoints.jsonl` に記録する。
+
 ## Phase 2: Hypothesizer 並列バッチ
 
 Agent tool を複数同時に使用（1 つの response 内で N 個起動）:
@@ -618,6 +620,8 @@ Agent tool を複数同時に使用（1 つの response 内で N 個起動）:
   - 新規外部ツール・ライブラリの導入
   - 既存の Lean 形式化に影響する構造変更
   呼び出しは推奨であり強制ではない。research スキルの独立性を保つ。
+
+**Checkpoint**: Phase 2 完了時に `/handoff` Layer 1 checkpoint を記録する。
 
 ## Phase 3: Verifier 並列バッチ
 
@@ -830,6 +834,8 @@ unaddressable 減点 → 行き先判定
   ├─ Yes（同一 Run 内） → deferred に記録、理由を evolve-history.jsonl に追記
   └─ No（スコープ外） → gh issue create で起票、evolve-history.jsonl に issue # を記録
 ```
+
+**Checkpoint**: Phase 3 完了時に `/handoff` Layer 1 checkpoint を記録する。
 
 ### Step 4: Integrator エージェントの起動
 

--- a/.claude/skills/formal-derivation/SKILL.md
+++ b/.claude/skills/formal-derivation/SKILL.md
@@ -245,6 +245,8 @@ export PATH="$HOME/.elan/bin:$PATH" && lake build <target>
 
 この段階でのエラーは主に型の不整合（定義的拡大で対処）。
 
+**Checkpoint**: Phase 1 完了時に `/handoff` Layer 1 checkpoint を `.claude/handoffs/checkpoints.jsonl` に記録する。
+
 ### Phase 2: Γ ⊢ φ の導出の構成
 
 **入力:** コンパイルが通る Lean ファイル（φ に sorry が残存）
@@ -283,6 +285,8 @@ theorem ineq : a.strength > b.strength := by
 
 各導出の構成後に `lake build` を実行する。
 コンパイルが通らない場合は Phase 3（修正ループ）に入る。
+
+**Checkpoint**: Phase 2 完了時に `/handoff` Layer 1 checkpoint を記録する。
 
 ### Phase 3: 修正ループ
 
@@ -367,6 +371,8 @@ Procedure.lean が保持規則を形式的に定義済み:
 **Γ ⊬ φ の判定:**
 - Γ ⊢ ¬φ が導出可能（反例の構成的証拠）
 - Γ が無矛盾でない（Γ ⊢ ⊥ が導出可能）
+
+**Checkpoint**: Phase 3 完了時に `/handoff` Layer 1 checkpoint を記録する。
 
 ### Phase 4: 監査
 

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: handoff
+user-invocable: true
+description: >
+  context 逼迫時にスキル実行状態を永続化し、次セッションで LLM が正確に再開できる
+  resumption prompt を生成する。T1（一時性）+ T2（永続性）の運用インスタンス。
+  Layer 1: フェーズ境界での deterministic checkpoint。
+  Layer 2: judgmental な状態統合 + resumption prompt 生成。
+  「handoff」「引き継ぎ」「context 逼迫」「セッション切り替え」で起動。
+dependencies:
+  invokes: []
+  invoked_by:
+    - skill: evolve
+      phase: "Phase 1→2, 2→3, 3→4 boundary"
+      expected_output: "checkpoint JSONL entry"
+    - skill: spec-driven-workflow
+      phase: "Phase 0→1, 1→2, 2→3, 3→4 boundary"
+      expected_output: "checkpoint JSONL entry"
+    - skill: brownfield
+      phase: "Phase 0→1, 1→2 boundary"
+      expected_output: "checkpoint JSONL entry"
+    - skill: formal-derivation
+      phase: "Phase 1→2, 2→3, 3→4 boundary"
+      expected_output: "checkpoint JSONL entry"
+---
+<!-- @traces T1, T2, D1, D10, P4 -->
+
+# /handoff — セッション引き継ぎスキル
+
+> **Portability: platform-generic** — checkpoint/resume の概念は Claude Code 固有ではなく、
+> 任意の LLM ハーネスに適用可能。hook 実装のみが Claude Code 固有。
+
+> 一時的なインスタンスは消滅する。しかし構造に状態を書き込むことで、
+> 次のインスタンスが正確に作業を再開できる。— T1 + T2
+
+## 設計根拠
+
+### 先行研究
+
+| 手法 | 出典 | 本スキルでの採用 |
+|------|------|----------------|
+| Anchored Iterative Summarization | Factory.ai | 構造化セクション（intent, progress, next_steps）で情報損失を防止 |
+| 70% 閾値ハード停止 | claude-code-session-kit | フェーズ境界での自動 checkpoint（劣化前に切る） |
+| Typed dict checkpoint | LangGraph | JSONL スキーマで typed state を永続化 |
+| 3 層圧縮 | LangChain Deep Agents | Layer 1 (checkpoint) + Layer 2 (handoff summary) の 2 層構造 |
+
+### マニフェスト公理系との対応
+
+| 概念 | 公理系 | 本スキルでの使い方 |
+|------|--------|-----------------|
+| インスタンス消滅 | T1 一時性 | handoff はインスタンス消滅を前提に設計 |
+| 構造への書き込み | T2 永続性 | checkpoint/resume を永続ファイルに記録 |
+| 二重注入防止 | D1 構造的強制 | .injected リネームで LLM 判断に依存しない |
+| 構造永続性 | D10 | エージェント消滅後もログが残る |
+| 状態の可視化 | P4 可観測性 | sorry-count, evolve last run をセッション開始時に通知 |
+
+## タスク自動化分類
+
+| ステップ | 分類 | 推奨実装手段 | 備考 |
+|---|---|---|---|
+| Layer 1: Checkpoint 書き込み | **deterministic** | JSONL append | スキーマ固定、フェーズ境界で機械的実行 |
+| Layer 2: 状態統合 | **judgmental** | LLM | intent, progress, next_steps の要約は創造的行為 |
+| Layer 2: JSONL 書き込み | **deterministic** | JSONL append | スキーマ固定 |
+| Layer 2: handoff-resume.md 生成 | **judgmental** | LLM | LLM が読んで再開できるフォーマットの生成 |
+| SessionStart: resume 注入 | **deterministic** | hook (bash) | additionalContext パターン、p4-drift-detector.sh と同一 |
+| SessionStart: .injected リネーム | **deterministic** | hook (bash) | mv コマンド、D1 構造的強制 |
+| SessionStart: sorry-count | **deterministic** | hook (bash) | grep + wc、evolve-state-loader.sh から統合 |
+
+## 2 層アーキテクチャ
+
+### Layer 1: Checkpoint (deterministic)
+
+各スキルのフェーズ境界で自動的に状態を記録する。
+
+**トリガー**: 対象スキルの SKILL.md に埋め込まれた checkpoint 指示
+**出力先**: `.claude/handoffs/checkpoints.jsonl`
+**スキーマ**:
+```json
+{
+  "timestamp": "2026-04-12T10:00:00Z",
+  "skill": "evolve",
+  "phase": "Phase 2",
+  "git_sha": "abc1234",
+  "completed": ["Phase 1: Observer"],
+  "remaining": ["Phase 3: Verifier", "Phase 4: Integrator"],
+  "blocked": null
+}
+```
+
+**対象スキルとチェックポイント境界**:
+
+| スキル | 境界 |
+|--------|------|
+| evolve | Phase 1→2, 2→3, 3→4（Observer/Hypothesizer/Verifier/Integrator 間） |
+| spec-driven-workflow | Phase 0→1, 1→2, 2→3, 3→4（設計/テスト/実装/検証 間） |
+| brownfield | Phase 0→1, 1→2（観察→構築→検証） |
+| formal-derivation | Phase 1→2, 2→3, 3→4（形式化→検証→監査） |
+
+### Layer 2: Handoff (judgmental + manual)
+
+context 逼迫時に、checkpoint と現在の会話状態を統合して resumption prompt を生成する。
+
+**トリガー**: `/handoff`（人間/LLM 起動）
+**入力**: checkpoints.jsonl + 現在の会話状態
+**出力先**:
+- `.claude/handoffs/handoff-<timestamp>.jsonl` — 永続ログ
+- `.claude/handoffs/handoff-resume.md` — 次セッション注入用
+
+**JSONL スキーマ**:
+```json
+{
+  "timestamp": "2026-04-12T10:30:00Z",
+  "skill": "spec-driven-workflow",
+  "phase": "Phase 2",
+  "git_sha": "def5678",
+  "intent": "handoff skill の実装。spec-driven-workflow Phase 2 (TDD) 実行中",
+  "progress": {
+    "done": ["Phase 0: 設計 v4 確定", "Phase 1: テスト計画 24 tests"],
+    "remaining": ["Phase 2: 残りの実装", "Phase 3: 検証"]
+  },
+  "next_steps": [
+    "SKILL.md の作成",
+    "4 スキルへの checkpoint 参照追加",
+    "テスト全 PASS の確認"
+  ],
+  "files_modified": [
+    ".claude/hooks/handoff-resume-loader.sh",
+    "tests/phase5/test-handoff-structural.sh"
+  ],
+  "blocked": null,
+  "decisions": "additionalContext JSON パターンを採用（p4-drift-detector.sh と同一）"
+}
+```
+
+**handoff-resume.md のフォーマット**:
+```markdown
+# Handoff Resume
+git_sha: <current HEAD>
+skill: <running skill>
+phase: <current phase>
+intent: <what the user originally asked for>
+
+## Progress
+### Done
+- <completed items>
+
+### Remaining
+- <remaining items>
+
+## Next Steps
+1. <concrete next action>
+2. <concrete next action>
+
+## Files Modified
+- <path>
+
+## Key Decisions
+- <decision with rationale>
+```
+
+### 次セッション起動（handoff-resume-loader.sh）
+
+SessionStart hook が以下を実行:
+
+1. `.claude/handoffs/handoff-resume.md` の存在を確認（なければ noop）
+2. `git_sha` と `git rev-parse HEAD` を比較
+3. 一致 → `additionalContext` で注入
+4. 不一致 → warn 付きで注入（intent/progress は有効、ファイル状態は要確認）
+5. 注入後 → `.injected` にリネーム（D1: 二重注入の構造的防止）
+6. sorry-count チェック（evolve-state-loader.sh から統合）
+
+**既知の制限**: 複数 Claude Code ウィンドウの同時起動で race condition が理論上発生する。
+通常使用（1 ウィンドウ）では問題なし。
+
+### 退役
+
+- LLM が再開完了後に `handoff-resume.md` を削除（ベストエフォート）
+- 構造的には `.injected` リネームで二重注入を防止済み
+- `.claude/handoffs/handoff-<timestamp>.jsonl` は永続ログとして残る
+
+## /handoff 実行手順
+
+1. **checkpoint 読み込み** — `checkpoints.jsonl` の最新エントリを確認
+2. **状態統合** — checkpoint + 現在の会話状態から以下を抽出:
+   - intent: ユーザーの元の要求
+   - progress: 完了/未完了
+   - next_steps: 具体的な次のアクション
+   - files_modified: 変更したファイル
+   - decisions: 重要な設計判断（オプション）
+3. **JSONL 書き込み** — `handoff-<timestamp>.jsonl` に永続記録
+4. **resume.md 生成** — 上記フォーマットで `handoff-resume.md` を書き込み
+5. **確認** — 生成した resume.md の内容をユーザーに表示
+
+## Lean 形式化との対応
+
+| スキルの概念 | Lean ファイル | 定理/定義 |
+|------------|-------------|----------|
+| T1 一時性 | Axioms.lean | `session_bounded` |
+| T2 永続性 | Axioms.lean | `structure_persists` |
+| D1 構造的強制 | DesignFoundation.lean | `StructuralEnforcement` |
+| D10 構造永続性 | DesignFoundation.lean | `agent_temporary_structure_permanent` |
+
+## Traceability
+
+| 命題 | このスキルとの関係 |
+|------|-------------------|
+| T1 | セッション消滅を前提に、状態を構造に書き込む設計 |
+| T2 | handoff-resume.md と checkpoints.jsonl が構造として永続する |
+| D1 | .injected リネームで二重注入を構造的に防止（LLM 判断に依存しない） |
+| D10 | エージェント消滅後も handoff ログが残り、次インスタンスが参照可能 |
+| P4 | sorry-count と evolve last run をセッション開始時に自動通知 |

--- a/.claude/skills/spec-driven-workflow/SKILL.md
+++ b/.claude/skills/spec-driven-workflow/SKILL.md
@@ -208,6 +208,8 @@ MANIFESTO_ROOT=$(bash .claude/skills/shared/resolve-manifesto-root.sh 2>/dev/nul
 - [ ] 全 axiom に Axiom Card（Layer / Basis / Refutation condition）がある
 - [ ] 保存拡大性: 新規 axiom が T₀ と矛盾しないことを確認
 
+**Checkpoint**: Phase 0 完了時に `/handoff` Layer 1 checkpoint を `.claude/handoffs/checkpoints.jsonl` に記録する。
+
 ---
 
 ### Phase 1: テスト計画 — 命題からのテスト導出
@@ -249,6 +251,8 @@ MANIFESTO_ROOT=$(bash .claude/skills/shared/resolve-manifesto-root.sh 2>/dev/nul
 - [ ] 高強度命題（T/E、strength ≥ 4）は複数テストでカバー
 - [ ] テスト命名が Phase.Axis.Seq 規則に従う
 
+**Checkpoint**: Phase 1 完了時に `/handoff` Layer 1 checkpoint を記録する。
+
 ---
 
 ### Phase 2: 実装 — テスト駆動で成果物を構築
@@ -287,6 +291,8 @@ MANIFESTO_ROOT=$(bash .claude/skills/shared/resolve-manifesto-root.sh 2>/dev/nul
 - [ ] 全テストが PASS
 - [ ] `artifact-manifest.json` の refs が正確
 - [ ] `manifest-trace coverage` でカバレッジギャップなし
+
+**Checkpoint**: Phase 2 完了時に `/handoff` Layer 1 checkpoint を記録する。
 
 ---
 

--- a/tests/phase5/test-handoff-behavioral.sh
+++ b/tests/phase5/test-handoff-behavioral.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# @traces T1, T2, D1, D10, P4
+# Behavioral tests for handoff-resume-loader.sh hook
+set -uo pipefail
+PASS=0; FAIL=0
+BASE="$(git rev-parse --show-toplevel 2>/dev/null || echo /Users/nirarin/work/agent-manifesto)"
+HOOK="$BASE/.claude/hooks/handoff-resume-loader.sh"
+
+echo "=== Phase 5: Handoff Behavioral Tests ==="
+
+check() {
+  local name="$1" cond="$2"
+  echo -n "$name... "
+  if eval "$cond"; then echo "PASS"; PASS=$((PASS+1)); else echo "FAIL"; FAIL=$((FAIL+1)); fi
+}
+
+# Precondition: hook must exist (structural test S-HO.5 covers this)
+check "B-HO.0 handoff-resume-loader.sh exists" \
+  "[ -x '$HOOK' ]"
+
+# --- Setup: create temp handoffs dir for testing ---
+TEST_HANDOFFS="${TMPDIR:-/tmp}/handoff-test-$$"
+mkdir -p "$TEST_HANDOFFS"
+CURRENT_SHA=$(cd "$BASE" && git rev-parse HEAD 2>/dev/null || echo "abc123")
+trap "rm -rf '$TEST_HANDOFFS'" EXIT
+
+# --- B-HO.1: No resume file → no output, exit 0 ---
+check "B-HO.1 No resume file exits cleanly" \
+  "HANDOFF_DIR='$TEST_HANDOFFS' bash '$HOOK' >/dev/null 2>&1; [ \$? -eq 0 ]"
+
+# --- B-HO.2: Resume file with matching sha → additionalContext output ---
+cat > "$TEST_HANDOFFS/handoff-resume.md" << EOF
+# Handoff Resume
+git_sha: $CURRENT_SHA
+skill: evolve
+phase: Phase 2
+intent: Testing handoff mechanism
+next_steps:
+- Complete Phase 3 verification
+EOF
+
+check "B-HO.2 Matching sha produces additionalContext" \
+  "HANDOFF_DIR='$TEST_HANDOFFS' GIT_DIR='$BASE/.git' bash '$HOOK' 2>/dev/null | grep -q 'additionalContext'"
+
+# --- B-HO.3: Resume file with mismatched sha → warn in output ---
+cat > "$TEST_HANDOFFS/handoff-resume.md" << EOF
+# Handoff Resume
+git_sha: 0000000000000000000000000000000000000000
+skill: evolve
+phase: Phase 2
+intent: Testing stale detection
+EOF
+
+check "B-HO.3 Mismatched sha produces warn" \
+  "HANDOFF_DIR='$TEST_HANDOFFS' GIT_DIR='$BASE/.git' bash '$HOOK' 2>/dev/null | grep -qi 'warn\|mismatch'"
+
+# --- B-HO.4: After injection, file is renamed to .injected ---
+cat > "$TEST_HANDOFFS/handoff-resume.md" << EOF
+# Handoff Resume
+git_sha: $CURRENT_SHA
+skill: test
+phase: Phase 1
+intent: Test rename
+EOF
+
+HANDOFF_DIR="$TEST_HANDOFFS" GIT_DIR="$BASE/.git" bash "$HOOK" >/dev/null 2>&1
+check "B-HO.4 Resume file renamed to .injected after injection" \
+  "[ -f '$TEST_HANDOFFS/handoff-resume.md.injected' ] && [ ! -f '$TEST_HANDOFFS/handoff-resume.md' ]"
+
+# --- B-HO.5: .injected file is not re-injected ---
+# At this point only .injected exists, no .md — hook may still output evolve/sorry info
+# but must NOT contain HANDOFF RESUME
+check "B-HO.5 No re-injection of .injected file" \
+  "OUTPUT=\$(HANDOFF_DIR='$TEST_HANDOFFS' GIT_DIR='$BASE/.git' bash '$HOOK' 2>/dev/null); ! echo \"\$OUTPUT\" | grep -q 'HANDOFF RESUME'"
+
+# --- B-HO.6: Output is valid JSON when additionalContext is produced ---
+cat > "$TEST_HANDOFFS/handoff-resume.md" << EOF
+# Handoff Resume
+git_sha: $CURRENT_SHA
+skill: test-json
+phase: Phase 1
+intent: Validate JSON output
+EOF
+
+check "B-HO.6 Hook output is valid JSON" \
+  "OUTPUT=\$(HANDOFF_DIR='$TEST_HANDOFFS' GIT_DIR='$BASE/.git' bash '$HOOK' 2>/dev/null); echo \"\$OUTPUT\" | python3 -m json.tool >/dev/null 2>&1"
+
+# --- B-HO.7: sorry-count integration ---
+check "B-HO.7 Sorry count logic present in hook" \
+  "grep -q 'sorry' '$HOOK'"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/phase5/test-handoff-structural.sh
+++ b/tests/phase5/test-handoff-structural.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# @traces T1, T2, D1, D10, P4
+# Structural tests for handoff skill
+set -uo pipefail
+PASS=0; FAIL=0
+BASE="$(git rev-parse --show-toplevel 2>/dev/null || echo /Users/nirarin/work/agent-manifesto)"
+
+echo "=== Phase 5: Handoff Structural Tests ==="
+
+check() {
+  local name="$1" cond="$2"
+  echo -n "$name... "
+  if eval "$cond"; then echo "PASS"; PASS=$((PASS+1)); else echo "FAIL"; FAIL=$((FAIL+1)); fi
+}
+
+# --- Layer 1: Checkpoint infrastructure ---
+
+check "S-HO.1 handoffs directory exists" \
+  "[ -d '$BASE/.claude/handoffs' ]"
+
+check "S-HO.2 handoff SKILL.md exists" \
+  "[ -f '$BASE/.claude/skills/handoff/SKILL.md' ]"
+
+check "S-HO.3 SKILL.md has user-invocable: true" \
+  "grep -q 'user-invocable: true' '$BASE/.claude/skills/handoff/SKILL.md'"
+
+check "S-HO.4 SKILL.md traces T1 and T2" \
+  "grep -q '@traces.*T1.*T2\|@traces.*T2.*T1' '$BASE/.claude/skills/handoff/SKILL.md'"
+
+# --- Layer 2: SessionStart hook ---
+
+check "S-HO.5 handoff-resume-loader.sh exists and is executable" \
+  "[ -x '$BASE/.claude/hooks/handoff-resume-loader.sh' ]"
+
+check "S-HO.6 hook registered in settings.json SessionStart" \
+  "grep -q 'handoff-resume-loader' '$BASE/.claude/settings.json'"
+
+check "S-HO.7 hook uses additionalContext JSON pattern" \
+  "grep -q 'additionalContext' '$BASE/.claude/hooks/handoff-resume-loader.sh'"
+
+check "S-HO.8 hook uses hookSpecificOutput pattern" \
+  "grep -q 'hookSpecificOutput' '$BASE/.claude/hooks/handoff-resume-loader.sh'"
+
+# --- sorry-count integration ---
+
+check "S-HO.9 hook includes sorry-count check" \
+  "grep -q 'sorry' '$BASE/.claude/hooks/handoff-resume-loader.sh'"
+
+# --- L1 integration ---
+
+check "S-HO.10 handoffs/ not in l1-file-guard protected paths" \
+  "! grep -q 'handoffs' '$BASE/.claude/hooks/l1-file-guard.sh'"
+
+# --- sandbox integration ---
+
+check "S-HO.11 handoffs in sandbox allowWrite" \
+  "grep -q 'handoffs\|\.claude/handoffs' '$BASE/.claude/settings.json'"
+
+# --- dependency graph ---
+
+check "S-HO.12 handoff in dependency-graph.yaml" \
+  "grep -q 'handoff' '$BASE/.claude/skills/dependency-graph.yaml'"
+
+# --- checkpoint embedding in target skills ---
+
+check "S-HO.13 evolve SKILL.md references checkpoint" \
+  "grep -qi 'checkpoint\|handoff' '$BASE/.claude/skills/evolve/SKILL.md'"
+
+check "S-HO.14 spec-driven-workflow SKILL.md references checkpoint" \
+  "grep -qi 'checkpoint\|handoff' '$BASE/.claude/skills/spec-driven-workflow/SKILL.md'"
+
+check "S-HO.15 brownfield SKILL.md references checkpoint" \
+  "grep -qi 'checkpoint\|handoff' '$BASE/.claude/skills/brownfield/SKILL.md'"
+
+check "S-HO.16 formal-derivation SKILL.md references checkpoint" \
+  "grep -qi 'checkpoint\|handoff' '$BASE/.claude/skills/formal-derivation/SKILL.md'"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- Context 逼迫時にスキル実行状態を永続化し、次セッションで LLM が正確に作業再開できる `/handoff` スキルを実装
- 2 層アーキテクチャ: Layer 1 (deterministic checkpoint at phase boundaries) + Layer 2 (judgmental handoff summary)
- SessionStart hook (`handoff-resume-loader.sh`) が `additionalContext` で前セッションの状態を自動注入
- `spec-driven-workflow` に検証ループ (Step 2b: addressable/unaddressable 分類 + max 2 loopback) を追加

## Changes
- `.claude/skills/handoff/SKILL.md` — 新規スキル定義 (T1+T2, 先行研究ベース)
- `.claude/hooks/handoff-resume-loader.sh` — SessionStart hook (additionalContext, sorry-count 統合, python3 fallback)
- `.claude/handoffs/.gitkeep` — checkpoint/handoff 格納ディレクトリ
- `.claude/settings.json` — hook 登録 + sandbox allowWrite
- `.claude/skills/dependency-graph.yaml` — 14 skills に更新
- 4 スキルに checkpoint 指示追加 (evolve, spec-driven-workflow, brownfield, formal-derivation)
- `spec-driven-workflow` Phase 3 Step 2b: 検証ループ追加
- `tests/phase5/test-handoff-{structural,behavioral}.sh` — 24 tests

## Test plan
- [x] `test-handoff-structural.sh`: 16/16 PASS (SKILL.md, hook, settings, depgraph, 4 skill checkpoint refs)
- [x] `test-handoff-behavioral.sh`: 8/8 PASS (sha match/mismatch, .injected rename, no re-injection, valid JSON)
- [x] `test-all.sh`: 667 passed, 0 failed (no regression)
- [x] P2 独立検証: 3 ラウンド (FAIL→FAIL→PASS), addressable 全解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)