### PR TITLE
#514: handoff branch-aware scoping

### DIFF
--- a/.claude/hooks/handoff-resume-loader.sh
+++ b/.claude/hooks/handoff-resume-loader.sh
@@ -2,30 +2,64 @@
 # @traces T1, T2, D1, D10, P4
 # SessionStart hook: inject handoff resume into LLM context via additionalContext
 # Pattern: same as p4-drift-detector.sh (proven mechanism)
+# #514: branch-aware scoped file selection + branch matching
 set -uo pipefail
 
 BASE="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 HANDOFF_DIR="${HANDOFF_DIR:-$BASE/.claude/handoffs}"
-RESUME_FILE="$HANDOFF_DIR/handoff-resume.md"
+
+# --- Scoped file selection (#514 G2) ---
+# 1. Try branch-scoped file: handoff-resume-<branch>.md (slash→hyphen)
+# 2. Fallback to handoff-resume.md (backward compat)
+CURRENT_BRANCH=$(cd "$BASE" && git branch --show-current 2>/dev/null || echo "")
+SCOPED_NAME=""
+if [ -n "$CURRENT_BRANCH" ]; then
+  SCOPED_NAME=$(echo "$CURRENT_BRANCH" | sed 's|/|-|g')
+fi
+
+RESUME_FILE=""
+if [ -n "$SCOPED_NAME" ] && [ -f "$HANDOFF_DIR/handoff-resume-${SCOPED_NAME}.md" ]; then
+  RESUME_FILE="$HANDOFF_DIR/handoff-resume-${SCOPED_NAME}.md"
+elif [ -f "$HANDOFF_DIR/handoff-resume.md" ]; then
+  RESUME_FILE="$HANDOFF_DIR/handoff-resume.md"
+fi
 
 CONTEXT=""
 
 # --- Handoff resume injection ---
-if [ -f "$RESUME_FILE" ]; then
-  # Extract git_sha from resume file
-  RESUME_SHA=$(grep -m1 '^git_sha:' "$RESUME_FILE" | sed 's/^git_sha:[[:space:]]*//')
-  CURRENT_SHA=$(cd "$BASE" && git rev-parse HEAD 2>/dev/null || echo "unknown")
+if [ -n "$RESUME_FILE" ]; then
+  # Extract branch from resume file (#514 G1: branch matching)
+  RESUME_BRANCH=$(grep -m1 '^branch:' "$RESUME_FILE" | sed 's/^branch:[[:space:]]*//')
 
-  RESUME_CONTENT=$(cat "$RESUME_FILE")
-
-  if [ "$RESUME_SHA" = "$CURRENT_SHA" ]; then
-    CONTEXT="[HANDOFF RESUME] Previous session state restored.\n$RESUME_CONTENT"
-  else
-    CONTEXT="[HANDOFF RESUME - SHA MISMATCH WARNING] git_sha changed since handoff (was: $RESUME_SHA, now: $CURRENT_SHA). Commits occurred after handoff — intent/progress are likely valid but file state may have changed. Verify before proceeding.\n$RESUME_CONTENT"
+  # Branch matching: skip injection if branch mismatch
+  SKIP_INJECTION=false
+  if [ -n "$RESUME_BRANCH" ] && [ "$RESUME_BRANCH" != "null" ]; then
+    if [ -n "$CURRENT_BRANCH" ] && [ "$RESUME_BRANCH" != "$CURRENT_BRANCH" ]; then
+      echo "[HANDOFF] skipped: for branch $RESUME_BRANCH, current is $CURRENT_BRANCH" >&2
+      SKIP_INJECTION=true
+    fi
+    # If current is detached HEAD (empty), allow injection (conservative)
   fi
+  # If RESUME_BRANCH is empty or "null", allow injection (backward compat / detached HEAD)
 
-  # Rename to .injected to prevent double injection (D1: structural enforcement)
-  mv "$RESUME_FILE" "${RESUME_FILE}.injected" 2>/dev/null || true
+  if [ "$SKIP_INJECTION" = false ]; then
+    # Extract git_sha from resume file
+    RESUME_SHA=$(grep -m1 '^git_sha:' "$RESUME_FILE" | sed 's/^git_sha:[[:space:]]*//')
+    CURRENT_SHA=$(cd "$BASE" && git rev-parse HEAD 2>/dev/null || echo "unknown")
+
+    RESUME_CONTENT=$(cat "$RESUME_FILE")
+
+    if [ "$RESUME_SHA" = "$CURRENT_SHA" ]; then
+      CONTEXT="[HANDOFF RESUME] Previous session state restored.\n$RESUME_CONTENT"
+    else
+      CONTEXT="[HANDOFF RESUME - SHA MISMATCH WARNING] git_sha changed since handoff (was: $RESUME_SHA, now: $CURRENT_SHA). Commits occurred after handoff — intent/progress are likely valid but file state may have changed. Verify before proceeding.\n$RESUME_CONTENT"
+    fi
+
+    # Rename to .injected to prevent double injection (D1: structural enforcement)
+    if ! mv "$RESUME_FILE" "${RESUME_FILE}.injected" 2>/dev/null; then
+      echo "[HANDOFF] WARNING: failed to rename $RESUME_FILE to .injected" >&2
+    fi
+  fi
 fi
 
 # --- Sorry count check (integrated from evolve-state-loader.sh) ---

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -81,11 +81,15 @@ dependencies:
   "skill": "evolve",
   "phase": "Phase 2",
   "git_sha": "abc1234",
+  "branch": "research/514-handoff-scoping",
   "completed": ["Phase 1: Observer"],
   "remaining": ["Phase 3: Verifier", "Phase 4: Integrator"],
   "blocked": null
 }
 ```
+
+**`branch` フィールド** (#514 G3): `git branch --show-current` の出力。
+detached HEAD の場合は `null`。未設定の既存エントリは `null` と同等に扱う（後方互換）。
 
 **対象スキルとチェックポイント境界**:
 
@@ -104,7 +108,9 @@ context 逼迫時に、checkpoint と現在の会話状態を統合して resump
 **入力**: checkpoints.jsonl + 現在の会話状態
 **出力先**:
 - `.claude/handoffs/handoff-<timestamp>.jsonl` — 永続ログ
-- `.claude/handoffs/handoff-resume.md` — 次セッション注入用
+- `.claude/handoffs/handoff-resume-<scope>.md` — 次セッション注入用 (#514 G2)
+  - `<scope>` = ブランチ名（slash→hyphen 変換。例: `research/514-x` → `handoff-resume-research-514-x.md`）
+  - detached HEAD の場合は `handoff-resume.md`（スコープなし、後方互換）
 
 **JSONL スキーマ**:
 ```json
@@ -113,6 +119,7 @@ context 逼迫時に、checkpoint と現在の会話状態を統合して resump
   "skill": "spec-driven-workflow",
   "phase": "Phase 2",
   "git_sha": "def5678",
+  "branch": "feature/handoff-impl",
   "intent": "handoff skill の実装。spec-driven-workflow Phase 2 (TDD) 実行中",
   "progress": {
     "done": ["Phase 0: 設計 v4 確定", "Phase 1: テスト計画 24 tests"],
@@ -136,6 +143,7 @@ context 逼迫時に、checkpoint と現在の会話状態を統合して resump
 ```markdown
 # Handoff Resume
 git_sha: <current HEAD>
+branch: <current branch or null>
 skill: <running skill>
 phase: <current phase>
 intent: <what the user originally asked for>
@@ -162,19 +170,29 @@ intent: <what the user originally asked for>
 
 SessionStart hook が以下を実行:
 
-1. `.claude/handoffs/handoff-resume.md` の存在を確認（なければ noop）
-2. `git_sha` と `git rev-parse HEAD` を比較
-3. 一致 → `additionalContext` で注入
-4. 不一致 → warn 付きで注入（intent/progress は有効、ファイル状態は要確認）
-5. 注入後 → `.injected` にリネーム（D1: 二重注入の構造的防止）
-6. sorry-count チェック（evolve-state-loader.sh から統合）
+1. `.claude/handoffs/handoff-resume*.md` からスコープに合致するファイルを選択 (#514 G2):
+   a. `handoff-resume-<current-branch>.md` が存在すれば選択（完全一致）
+   b. なければ `handoff-resume.md`（旧形式フォールバック）
+   c. どちらもなければ noop
+2. `branch` フィールドと `git branch --show-current` を比較 (#514 G1):
+   a. `branch` 未設定（旧形式） → 後方互換: SHA 照合のみで注入
+   b. `branch` が `null`（detached HEAD で書き込み） → 任意のブランチにマッチ
+   c. ブランチ一致 → `git_sha` 照合へ進む
+   d. ブランチ不一致 → 注入をスキップ。stderr に `[HANDOFF] skipped: for branch <X>, current is <Y>` を出力
+3. `git_sha` と `git rev-parse HEAD` を比較
+4. 一致 → `additionalContext` で注入
+5. 不一致 → warn 付きで注入（intent/progress は有効、ファイル状態は要確認）
+6. 注入後 → `.injected` にリネーム（D1: 二重注入の構造的防止）。
+   リネーム失敗時は stderr に警告を出力（`|| true` ではなく明示的エラーログ）
+7. sorry-count チェック（evolve-state-loader.sh から統合）
 
-**既知の制限**: 複数 Claude Code ウィンドウの同時起動で race condition が理論上発生する。
-通常使用（1 ウィンドウ）では問題なし。
+**既知の制限**:
+- 複数 Claude Code ウィンドウの同時起動で race condition が理論上発生する。通常使用（1 ウィンドウ）では問題なし。
+- ブランチ名の slash→hyphen 変換で理論上の衝突あり（`a/b-c` と `a-b/c`）。メタデータ照合（Step 2c）が defense in depth として機能。
 
 ### 退役
 
-- LLM が再開完了後に `handoff-resume.md` を削除（ベストエフォート）
+- LLM が再開完了後に `handoff-resume-<scope>.md`（または `handoff-resume.md`）を削除（ベストエフォート）
 - 構造的には `.injected` リネームで二重注入を防止済み
 - `.claude/handoffs/handoff-<timestamp>.jsonl` は永続ログとして残る
 
@@ -188,7 +206,11 @@ SessionStart hook が以下を実行:
    - files_modified: 変更したファイル
    - decisions: 重要な設計判断（オプション）
 3. **JSONL 書き込み** — `handoff-<timestamp>.jsonl` に永続記録
-4. **resume.md 生成** — 上記フォーマットで `handoff-resume.md` を書き込み
+4. **resume.md 生成** — 上記フォーマットで書き込み。
+   - ファイル名: `BRANCH=$(git branch --show-current)` を取得し、
+     ブランチがあれば `handoff-resume-$(echo "$BRANCH" | sed 's|/|-|g').md`、
+     なければ `handoff-resume.md`（detached HEAD フォールバック）
+   - `branch` フィールド: `${BRANCH:-null}` の出力を使用
 5. **確認** — 生成した resume.md の内容をユーザーに表示
 
 ## Lean 形式化との対応

--- a/tests/phase5/test-handoff-behavioral.sh
+++ b/tests/phase5/test-handoff-behavioral.sh
@@ -89,6 +89,99 @@ check "B-HO.6 Hook output is valid JSON" \
 check "B-HO.7 Sorry count logic present in hook" \
   "grep -q 'sorry' '$HOOK'"
 
+# --- B-HO.8: Branch match → injection allowed (#514 G1) ---
+rm -f "$TEST_HANDOFFS"/handoff-resume*.md "$TEST_HANDOFFS"/handoff-resume*.injected
+CURRENT_BRANCH=$(cd "$BASE" && git branch --show-current 2>/dev/null || echo "main")
+cat > "$TEST_HANDOFFS/handoff-resume.md" << EOF
+# Handoff Resume
+git_sha: $CURRENT_SHA
+branch: $CURRENT_BRANCH
+skill: test
+phase: Phase 1
+intent: Test branch match
+EOF
+
+check "B-HO.8 Branch match allows injection" \
+  "HANDOFF_DIR='$TEST_HANDOFFS' bash '$HOOK' 2>/dev/null | grep -q 'HANDOFF RESUME'"
+
+# --- B-HO.9: Branch mismatch → injection skipped (#514 G1) ---
+rm -f "$TEST_HANDOFFS"/handoff-resume*.md "$TEST_HANDOFFS"/handoff-resume*.injected
+cat > "$TEST_HANDOFFS/handoff-resume.md" << EOF
+# Handoff Resume
+git_sha: $CURRENT_SHA
+branch: nonexistent-branch-xyz
+skill: test
+phase: Phase 1
+intent: Test branch mismatch
+EOF
+
+check "B-HO.9 Branch mismatch skips injection" \
+  "OUTPUT=\$(HANDOFF_DIR='$TEST_HANDOFFS' bash '$HOOK' 2>/dev/null); ! echo \"\$OUTPUT\" | grep -q 'HANDOFF RESUME'"
+
+# --- B-HO.10: Absent branch field → backward compat injection (#514 G1) ---
+rm -f "$TEST_HANDOFFS"/handoff-resume*.md "$TEST_HANDOFFS"/handoff-resume*.injected
+cat > "$TEST_HANDOFFS/handoff-resume.md" << EOF
+# Handoff Resume
+git_sha: $CURRENT_SHA
+skill: test
+phase: Phase 1
+intent: Test no branch field (old format)
+EOF
+
+check "B-HO.10 Absent branch field allows injection (backward compat)" \
+  "HANDOFF_DIR='$TEST_HANDOFFS' bash '$HOOK' 2>/dev/null | grep -q 'HANDOFF RESUME'"
+
+# --- B-HO.11: branch: null → injection allowed (#514 G1) ---
+rm -f "$TEST_HANDOFFS"/handoff-resume*.md "$TEST_HANDOFFS"/handoff-resume*.injected
+cat > "$TEST_HANDOFFS/handoff-resume.md" << EOF
+# Handoff Resume
+git_sha: $CURRENT_SHA
+branch: null
+skill: test
+phase: Phase 1
+intent: Test null branch (detached HEAD)
+EOF
+
+check "B-HO.11 branch: null allows injection" \
+  "HANDOFF_DIR='$TEST_HANDOFFS' bash '$HOOK' 2>/dev/null | grep -q 'HANDOFF RESUME'"
+
+# --- B-HO.12: Scoped file selected over fallback (#514 G2) ---
+rm -f "$TEST_HANDOFFS"/handoff-resume*.md "$TEST_HANDOFFS"/handoff-resume*.injected
+SCOPED_FILE="handoff-resume-$(echo "$CURRENT_BRANCH" | sed 's|/|-|g').md"
+cat > "$TEST_HANDOFFS/$SCOPED_FILE" << EOF
+# Handoff Resume
+git_sha: $CURRENT_SHA
+branch: $CURRENT_BRANCH
+skill: scoped-test
+phase: Phase 1
+intent: SCOPED file
+EOF
+cat > "$TEST_HANDOFFS/handoff-resume.md" << EOF
+# Handoff Resume
+git_sha: $CURRENT_SHA
+branch: other-branch
+skill: fallback-test
+phase: Phase 1
+intent: FALLBACK file
+EOF
+
+check "B-HO.12 Scoped file selected over fallback" \
+  "HANDOFF_DIR='$TEST_HANDOFFS' bash '$HOOK' 2>/dev/null | grep -q 'SCOPED file'"
+
+# --- B-HO.13: Fallback used when no scoped file (#514 G2) ---
+rm -f "$TEST_HANDOFFS"/handoff-resume*.md "$TEST_HANDOFFS"/handoff-resume*.injected
+cat > "$TEST_HANDOFFS/handoff-resume.md" << EOF
+# Handoff Resume
+git_sha: $CURRENT_SHA
+branch: $CURRENT_BRANCH
+skill: fallback-test
+phase: Phase 1
+intent: FALLBACK used
+EOF
+
+check "B-HO.13 Fallback file used when no scoped file exists" \
+  "HANDOFF_DIR='$TEST_HANDOFFS' bash '$HOOK' 2>/dev/null | grep -q 'FALLBACK used'"
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Add `branch` field to handoff checkpoint (Layer 1) and resume (Layer 2) schemas
- Implement scoped file selection in SessionStart hook: `handoff-resume-<branch>.md` with fallback to `handoff-resume.md`
- Add branch matching to prevent cross-branch handoff injection (skip + stderr log on mismatch)
- Replace `mv || true` with explicit error logging for D1 structural enforcement
- 6 new behavioral tests (B-HO.8-13) covering branch match/mismatch/null/scoped/fallback

Closes #514, #515, #516, #517

## Test plan

- [x] B-HO.8: Branch match allows injection
- [x] B-HO.9: Branch mismatch skips injection
- [x] B-HO.10: Absent branch field allows injection (backward compat)
- [x] B-HO.11: branch: null allows injection (detached HEAD)
- [x] B-HO.12: Scoped file selected over fallback
- [x] B-HO.13: Fallback file used when no scoped file exists
- [x] Full suite: 672 passed, 1 failed (lake build sandbox — pre-existing worktree issue)
- [x] Verifier: 3 rounds → PASS
- [x] Judge: 4.8/5.0, addressable deductions = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)