### PR TITLE
fix: brownfield 収束基準改善 + ClaudeCodeCLI 条件付き公理系 (#521, #525)

### DIFF
--- a/.claude/skills/brownfield/SKILL.md
+++ b/.claude/skills/brownfield/SKILL.md
@@ -319,13 +319,47 @@ bash .claude/skills/brownfield/convergence.sh check <observations-dir> --mode ph
 
 ```
 増分率 = decisions_found / cumulative_total
-収束条件: 増分率 < 0.05（5% 未満）
+収束条件: 2 回連続で増分率 < 0.03（3% 未満）
 ```
 
-- 収束した + philosophy iteration 2+ → Phase 1.5 へ
-- 収束した + philosophy なし → Phase 2 へ
+**根拠** (#525): capture-recapture (Lincoln-Petersen) 推定により、この条件は
+推定総 PD 数の 95%+ をカバーした状態に対応する。
+2 回連続を要求することで、偶然の低 rate による早期停止（false convergence）を防ぐ。
+ECC (N_est=323, 302 observed) と Claude Code CLI (N_est=299, 276 observed) の
+2 プロジェクトで検証済み。
+
+- 2 回連続 < 0.03 達成 → **validation iteration** を実行（Step 3.5）
+- validation も < 0.03 → 収束確定。Phase 1.5 or Phase 2 へ
+- validation が >= 0.03 → 偽収束。Step 2 に戻る
 - 未収束 → 次の分解単位で Step 2 を反復
 - 10 反復超過 → 強制終了。未観察の分解単位を記録して Phase 2 へ
+
+### Step 3.5: Validation Iteration（探索バイアス除去）
+
+2 回連続 rate < 0.03 を達成した後、探索プロンプトのバイアスが rate を
+人工的に下げていないことを確認する。
+
+**問題**: 探索プロンプトでスコープ制限やカウント上限を指定すると、
+`found` が探索戦略の関数になり、残存情報量を反映しなくなる (#525)。
+
+**Validation iteration のルール**:
+1. スコープ制限なし（「全コードベースを探索しろ」）
+2. カウント上限なし（「見つかるだけ報告しろ」）
+3. 既存 PD の全リストを提供してデデュプ
+4. `convergence.sh add-detailed ... --validation` で登録
+
+```bash
+# Validation iteration の実行
+bash convergence.sh add-detailed <dir> <N> "validation" /tmp/pds-validation.json --validation
+
+# 確認
+bash convergence.sh check <dir>
+# → CONVERGED (validation PASS) or UNCONVERGED
+```
+
+**判定**:
+- validation rate < 0.03 → `CONVERGED` — 真の収束
+- validation rate >= 0.03 → `UNCONVERGED` — 偽収束。directed iteration を継続
 
 ## Phase 1.5: ワークフロー思想の統合（#479）
 

--- a/.claude/skills/brownfield/convergence.sh
+++ b/.claude/skills/brownfield/convergence.sh
@@ -2,12 +2,13 @@
 # brownfield-convergence.sh — Phase 1 収束判定スクリプト
 # 使い方:
 #   bash convergence.sh add <observations-dir> <iteration> <unit> <decisions_found>
-#   bash convergence.sh add-detailed <observations-dir> <iteration> <unit> <pd-details.json> [--mode philosophy]
+#   bash convergence.sh add-detailed <observations-dir> <iteration> <unit> <pd-details.json> [--mode philosophy] [--validation]
 #   bash convergence.sh check <observations-dir> [--mode philosophy]
 #   bash convergence.sh status <observations-dir> [--mode philosophy]
 #
 # observations-dir に JSON ファイルを蓄積し、収束を判定する。
-# 収束条件: 増分率 (decisions_found / cumulative_total) < 0.05
+# 収束条件: 2 回連続で増分率 < 0.03 (capture-recapture 推定で 95%+ coverage に対応)
+# 根拠: #525 — ECC/ClaudeCodeCLI の capture-recapture 分析で確立
 #
 # add-detailed: PD 詳細 JSON ファイルを受け取り、iteration ファイルに埋め込む (#457)
 #   pd-details.json 形式: [{"id":"PD-001","content":"...","source":"code_analysis","confidence":"high"}]
@@ -157,6 +158,15 @@ add_detailed_observation() {
 
   local iter_file="$dir/${prefix}iteration-${iteration}.json"
 
+  # --validation フラグの検出
+  local is_validation="false"
+  for arg in "$@"; do
+    if [ "$arg" = "--validation" ]; then
+      is_validation="true"
+      break
+    fi
+  done
+
   if [ "$mode" = "normal" ]; then
     jq -n \
       --argjson iteration "$iteration" \
@@ -166,6 +176,7 @@ add_detailed_observation() {
       --argjson found "$found" \
       --argjson cumulative "$cumulative" \
       --arg rate "$rate" \
+      --argjson validation "$is_validation" \
       '{
         iteration: $iteration,
         unit: $unit,
@@ -173,7 +184,8 @@ add_detailed_observation() {
         platform_decisions: $pds,
         decisions_found: $found,
         cumulative_total: $cumulative,
-        incremental_rate: ($rate | tonumber)
+        incremental_rate: ($rate | tonumber),
+        validation: $validation
       }' > "$iter_file"
   else
     jq -n \
@@ -213,28 +225,63 @@ check_convergence() {
     exit 1
   fi
 
-  # 最新の iteration を取得
-  local latest
-  latest=$(ls "$dir"/${prefix}iteration-*.json 2>/dev/null | sed 's/.*iteration-\([0-9]*\)\.json/\1 &/' | sort -n -k1 | sed 's/^[0-9]* //' | tail -1)
+  # 最新 2 件の iteration を取得 (2 consecutive check)
+  local files
+  files=$(ls "$dir"/${prefix}iteration-*.json 2>/dev/null | sed 's/.*iteration-\([0-9]*\)\.json/\1 &/' | sort -n -k1 | sed 's/^[0-9]* //')
 
-  if [ -z "$latest" ]; then
+  if [ -z "$files" ]; then
     echo "UNCONVERGED [${mode}]: No observations recorded"
     exit 1
   fi
 
+  local latest
+  latest=$(echo "$files" | tail -1)
   local rate
   rate=$(jq -r '.incremental_rate' "$latest")
   local iteration
   iteration=$(jq -r '.iteration' "$latest")
 
+  local file_count
+  file_count=$(echo "$files" | wc -l | tr -d ' ')
+
+  # 収束条件: 2 回連続で rate < 0.03
+  # 根拠: capture-recapture 推定で 95%+ coverage (#525)
+  local threshold="0.03"
+
+  if [ "$file_count" -lt 2 ]; then
+    echo "UNCONVERGED [${mode}]: iteration=${iteration}, rate=${rate} (need 2+ iterations for 2-consecutive check, threshold: ${threshold})"
+    exit 1
+  fi
+
+  local prev_latest
+  prev_latest=$(echo "$files" | tail -2 | head -1)
+  local prev_rate
+  prev_rate=$(jq -r '.incremental_rate' "$prev_latest")
+  local prev_iteration
+  prev_iteration=$(jq -r '.iteration' "$prev_latest")
+
   # bc: 1 = condition true, 0 = false
-  local converged
-  converged=$(echo "$rate < 0.05" | bc -l)
-  if [ "$converged" = "1" ]; then
-    echo "CONVERGED [${mode}]: iteration=${iteration}, rate=${rate} (threshold: 0.05)"
-    exit 0
+  local curr_below prev_below
+  curr_below=$(echo "$rate < $threshold" | bc -l)
+  prev_below=$(echo "$prev_rate < $threshold" | bc -l)
+
+  # validation iteration の有無を確認
+  local latest_is_validation
+  latest_is_validation=$(jq -r '.validation // false' "$latest")
+
+  if [ "$curr_below" = "1" ] && [ "$prev_below" = "1" ]; then
+    if [ "$latest_is_validation" = "true" ]; then
+      echo "CONVERGED [${mode}]: validation PASS — iter ${prev_iteration} (rate=${prev_rate}) + validation iter ${iteration} (rate=${rate}) < ${threshold}"
+      exit 0
+    else
+      echo "CONVERGED_PENDING_VALIDATION [${mode}]: 2 consecutive < ${threshold} — iter ${prev_iteration} (rate=${prev_rate}) + iter ${iteration} (rate=${rate}). Run a validation iteration (--validation) with no scope restriction to confirm."
+      exit 2
+    fi
+  elif [ "$curr_below" = "1" ]; then
+    echo "UNCONVERGED [${mode}]: iteration=${iteration}, rate=${rate} < ${threshold} but prev iter ${prev_iteration} rate=${prev_rate} >= ${threshold} (need 2 consecutive)"
+    exit 1
   else
-    echo "UNCONVERGED [${mode}]: iteration=${iteration}, rate=${rate} (threshold: 0.05)"
+    echo "UNCONVERGED [${mode}]: iteration=${iteration}, rate=${rate} (threshold: ${threshold}, need 2 consecutive)"
     exit 1
   fi
 }

--- a/lean-formalization/Manifest/Models/Instances/ClaudeCodeCLI/ConditionalAxiomSystem.lean
+++ b/lean-formalization/Manifest/Models/Instances/ClaudeCodeCLI/ConditionalAxiomSystem.lean
@@ -1,0 +1,268 @@
+/-!
+# 条件付き公理体系（スタンドアロン生成）
+
+このファイルは generate-conditional-axiom-system.sh によって
+ModelSpec JSON から自動生成されました。独自の PropositionId を含みます。
+
+手動で編集しないでください。
+
+## 層構造
+
+- **safety** (ord=0): Non-negotiable safety constraints: path validation, injection prevention, TOCTOU protection, sandbox enforcement, secret scanning [PD-006, PD-007, PD-008, PD-010, PD-011, PD-012, PD-014, PD-042, PD-043, PD-044, PD-108, PD-109, PD-110, PD-112, PD-113, PD-122, PD-131, PD-136, PD-137, PD-265, PD-275, PD-276, PD-310, PD-317, PD-321, PD-347, PD-400, PD-424, PD-454, PD-558]
+- **permission** (ord=1): Configurable permission system: modes, rule cascade, classifier, enterprise policy, audit trail [PD-005, PD-100, PD-101, PD-104, PD-105, PD-106, PD-115, PD-116, PD-118, PD-120, PD-126, PD-134, PD-138, PD-153, PD-170, PD-182, PD-208, PD-237, PD-290, PD-550]
+- **tool** (ord=2): Core tool interface, validation, execution model, result handling, concurrency safety [PD-001, PD-002, PD-003, PD-016, PD-019, PD-020, PD-021, PD-024, PD-026, PD-027, PD-028, PD-030, PD-034, PD-035, PD-036, PD-038, PD-039, PD-178, PD-280, PD-343, PD-361, PD-367, PD-368, PD-369, PD-380, PD-381, PD-472, PD-519, PD-556]
+- **orchestration** (ord=3): Multi-agent teams, worktree isolation, task lifecycle, plan mode governance [PD-050, PD-052, PD-054, PD-055, PD-056, PD-057, PD-059, PD-061, PD-062, PD-065, PD-067, PD-069, PD-070, PD-071, PD-350, PD-391, PD-402, PD-403, PD-407, PD-408, PD-505]
+- **conversation** (ord=4): Query loop, state management, compaction, context composition, settings cascade [PD-169, PD-174, PD-175, PD-200, PD-202, PD-203, PD-204, PD-205, PD-213, PD-229, PD-234, PD-240, PD-261, PD-281, PD-340, PD-345, PD-349, PD-362, PD-363, PD-365, PD-366, PD-374, PD-375, PD-392, PD-393, PD-396, PD-397, PD-405, PD-406, PD-455, PD-500, PD-502, PD-503, PD-504, PD-507, PD-530, PD-543, PD-546, PD-552, PD-590]
+- **extension** (ord=5): Plugin system, hooks, MCP integration, skills, commands, output styles [PD-150, PD-155, PD-159, PD-160, PD-161, PD-163, PD-185, PD-186, PD-250, PD-251, PD-271, PD-272, PD-285, PD-288, PD-289, PD-294, PD-370, PD-371, PD-372, PD-373, PD-376, PD-377, PD-390, PD-394, PD-395, PD-401, PD-506, PD-549, PD-557]
+- **observability** (ord=6): Memory consolidation, telemetry, cost tracking, analytics, diagnostics [PD-032, PD-166, PD-209, PD-210, PD-211, PD-228, PD-264, PD-277, PD-341, PD-342, PD-344, PD-346, PD-364, PD-410, PD-434, PD-435, PD-508, PD-513, PD-522, PD-523, PD-534, PD-542]
+-/
+
+namespace Manifest.Models.Instances.ClaudeCodeCLI
+
+-- ============================================================
+-- 0. PropositionId (プロジェクト固有)
+-- ============================================================
+
+/-- プロジェクト固有の命題識別子。 -/
+inductive PropositionId where
+  | denyShortCircuit
+  | multiLayerSecurity
+  | pathTraversalDetection
+  | uncPathBlocking
+  | dangerousPathProtection
+  | toctouPrevention
+  | sandboxEnforcement
+  | secretScanning
+  | bashAstParsing
+  | permissionModes
+  | ruleCascade
+  | denyWins
+  | autoModeClassifier
+  | enterprisePolicy
+  | permissionAuditTrail
+  | hookPermissionOverride
+  | toolInterface
+  | failClosedDefaults
+  | deterministicValidation
+  | resultBounding
+  | bashBackgrounding
+  | featureGatedTools
+  | hierarchicalTeams
+  | executionBackends
+  | fileMailbox
+  | planApprovalGate
+  | worktreeIsolation
+  | shutdownProtocol
+  | taskDependencyTracking
+  | immutableAppState
+  | queryLoopRecovery
+  | multiLayerCompaction
+  | cacheSafeForking
+  | layeredSystemPrompt
+  | settingsCascade
+  | gracefulShutdown
+  | pluginArchitecture
+  | hookSystem
+  | mcpTransportAbstraction
+  | mcpConfigCascade
+  | commandAggregation
+  | skillExecution
+  | pluginDependencyResolution
+  | autoMemoryTaxonomy
+  | dreamConsolidation
+  | costTracking
+  | telemetrySpans
+  | queryCorrelation
+  | analyticsSinks
+  | deepLinkValidation
+  | unicodeSanitization
+  | ruleShadowingDetection
+  | toolSearchStrategy
+  | toolResultPairing
+  | perToolPersistence
+  | toolPoolDedup
+  | sessionResume
+  | cronSchedulerLock
+  | apiResilience
+  | contextOverflowRecovery
+  | asyncConcurrencyPrimitives
+  | startupSequence
+  | rateLimitManagement
+  | voiceModeGating
+  | cronTaskLifecycle
+  | marketplaceReconciliation
+  | proxyAndPreconnect
+  | activityTracking
+  | advisorCostTracking
+  | eventUploading
+  deriving BEq, Repr, DecidableEq
+
+/-- 命題の直接依存先。 -/
+def PropositionId.dependencies : PropositionId → List PropositionId
+  | .denyShortCircuit => []
+  | .multiLayerSecurity => []
+  | .pathTraversalDetection => []
+  | .uncPathBlocking => []
+  | .dangerousPathProtection => []
+  | .toctouPrevention => []
+  | .sandboxEnforcement => []
+  | .secretScanning => []
+  | .bashAstParsing => []
+  | .permissionModes => []
+  | .ruleCascade => []
+  | .denyWins => [.ruleCascade]
+  | .autoModeClassifier => [.permissionModes]
+  | .enterprisePolicy => [.ruleCascade]
+  | .permissionAuditTrail => [.denyWins]
+  | .hookPermissionOverride => [.denyWins]
+  | .toolInterface => []
+  | .failClosedDefaults => [.toolInterface]
+  | .deterministicValidation => [.toolInterface]
+  | .resultBounding => [.toolInterface]
+  | .bashBackgrounding => [.toolInterface]
+  | .featureGatedTools => [.toolInterface]
+  | .hierarchicalTeams => []
+  | .executionBackends => [.hierarchicalTeams]
+  | .fileMailbox => [.hierarchicalTeams]
+  | .planApprovalGate => [.hierarchicalTeams]
+  | .worktreeIsolation => [.hierarchicalTeams]
+  | .shutdownProtocol => [.fileMailbox]
+  | .taskDependencyTracking => [.hierarchicalTeams]
+  | .immutableAppState => []
+  | .queryLoopRecovery => [.immutableAppState]
+  | .multiLayerCompaction => [.queryLoopRecovery]
+  | .cacheSafeForking => [.queryLoopRecovery]
+  | .layeredSystemPrompt => [.immutableAppState]
+  | .settingsCascade => []
+  | .gracefulShutdown => []
+  | .pluginArchitecture => []
+  | .hookSystem => []
+  | .mcpTransportAbstraction => []
+  | .mcpConfigCascade => [.mcpTransportAbstraction]
+  | .commandAggregation => []
+  | .skillExecution => [.pluginArchitecture]
+  | .pluginDependencyResolution => [.pluginArchitecture]
+  | .autoMemoryTaxonomy => []
+  | .dreamConsolidation => [.autoMemoryTaxonomy]
+  | .costTracking => []
+  | .telemetrySpans => []
+  | .queryCorrelation => []
+  | .analyticsSinks => [.telemetrySpans]
+  | .deepLinkValidation => []
+  | .unicodeSanitization => []
+  | .ruleShadowingDetection => [.denyWins]
+  | .toolSearchStrategy => [.failClosedDefaults]
+  | .toolResultPairing => [.deterministicValidation]
+  | .perToolPersistence => [.resultBounding]
+  | .toolPoolDedup => []
+  | .sessionResume => [.worktreeIsolation]
+  | .cronSchedulerLock => []
+  | .apiResilience => [.queryLoopRecovery]
+  | .contextOverflowRecovery => [.queryLoopRecovery]
+  | .asyncConcurrencyPrimitives => []
+  | .startupSequence => []
+  | .rateLimitManagement => []
+  | .voiceModeGating => [.pluginArchitecture]
+  | .cronTaskLifecycle => []
+  | .marketplaceReconciliation => [.pluginDependencyResolution]
+  | .proxyAndPreconnect => []
+  | .activityTracking => []
+  | .advisorCostTracking => [.costTracking]
+  | .eventUploading => [.analyticsSinks]
+
+/-- 命題が別の命題に直接依存する。 -/
+def propositionDependsOn (a b : PropositionId) : Bool :=
+  a.dependencies.contains b
+
+-- ============================================================
+-- 1. ConcreteLayer inductive
+-- ============================================================
+
+/-- 認識論的層。 -/
+inductive ConcreteLayer where
+  /-- Non-negotiable safety constraints: path validation, injection prevention, TOCTOU protection, sandbox enforcement, secret scanning (ord=0) -/
+  | safety
+  /-- Configurable permission system: modes, rule cascade, classifier, enterprise policy, audit trail (ord=1) -/
+  | permission
+  /-- Core tool interface, validation, execution model, result handling, concurrency safety (ord=2) -/
+  | tool
+  /-- Multi-agent teams, worktree isolation, task lifecycle, plan mode governance (ord=3) -/
+  | orchestration
+  /-- Query loop, state management, compaction, context composition, settings cascade (ord=4) -/
+  | conversation
+  /-- Plugin system, hooks, MCP integration, skills, commands, output styles (ord=5) -/
+  | extension
+  /-- Memory consolidation, telemetry, cost tracking, analytics, diagnostics (ord=6) -/
+  | observability
+  deriving BEq, Repr, DecidableEq
+
+-- ============================================================
+-- 2. EpistemicLayerClass instance
+-- ============================================================
+
+/-- ConcreteLayer の順序値。 -/
+def ConcreteLayer.ord : ConcreteLayer → Nat
+  | .safety => 0
+  | .permission => 1
+  | .tool => 2
+  | .orchestration => 3
+  | .conversation => 4
+  | .extension => 5
+  | .observability => 6
+
+/-- 認識論的層構造の typeclass（スタンドアロン版）。 -/
+class EpistemicLayerClass (α : Type) where
+  ord : α → Nat
+  bottom : α
+  nontrivial : ∃ (a b : α), ord a ≠ ord b
+  ord_injective : ∀ (a b : α), ord a = ord b → a = b
+  ord_bounded : ∃ (n : Nat), ∀ (a : α), ord a ≤ n
+  bottom_minimum : ∀ (a : α), ord bottom ≤ ord a
+
+instance : EpistemicLayerClass ConcreteLayer where
+  ord := ConcreteLayer.ord
+  bottom := .safety
+  nontrivial := ⟨.observability, .safety, by simp [ConcreteLayer.ord]⟩
+  ord_injective := by
+    intro a b; cases a <;> cases b <;> simp [ConcreteLayer.ord]
+  ord_bounded := ⟨6, fun a => by cases a <;> simp [ConcreteLayer.ord]⟩
+  bottom_minimum := fun a => by cases a <;> simp [ConcreteLayer.ord]
+
+-- ============================================================
+-- 3. classify
+-- ============================================================
+
+/-- 全命題の層分類。 -/
+def classify : PropositionId → ConcreteLayer
+  -- safety
+  | .denyShortCircuit | .multiLayerSecurity | .pathTraversalDetection | .uncPathBlocking | .dangerousPathProtection | .toctouPrevention | .sandboxEnforcement | .secretScanning | .bashAstParsing | .deepLinkValidation | .unicodeSanitization => .safety
+  -- permission
+  | .permissionModes | .ruleCascade | .denyWins | .autoModeClassifier | .enterprisePolicy | .permissionAuditTrail | .hookPermissionOverride | .ruleShadowingDetection => .permission
+  -- tool
+  | .toolInterface | .failClosedDefaults | .deterministicValidation | .resultBounding | .bashBackgrounding | .featureGatedTools | .toolSearchStrategy | .toolResultPairing | .perToolPersistence | .toolPoolDedup => .tool
+  -- orchestration
+  | .hierarchicalTeams | .executionBackends | .fileMailbox | .planApprovalGate | .worktreeIsolation | .shutdownProtocol | .taskDependencyTracking | .sessionResume | .cronSchedulerLock => .orchestration
+  -- conversation
+  | .immutableAppState | .queryLoopRecovery | .multiLayerCompaction | .cacheSafeForking | .layeredSystemPrompt | .settingsCascade | .gracefulShutdown | .apiResilience | .contextOverflowRecovery | .asyncConcurrencyPrimitives | .startupSequence => .conversation
+  -- extension
+  | .pluginArchitecture | .hookSystem | .mcpTransportAbstraction | .mcpConfigCascade | .commandAggregation | .skillExecution | .pluginDependencyResolution | .rateLimitManagement | .voiceModeGating | .cronTaskLifecycle | .marketplaceReconciliation => .extension
+  -- observability
+  | .autoMemoryTaxonomy | .dreamConsolidation | .costTracking | .telemetrySpans | .queryCorrelation | .analyticsSinks | .proxyAndPreconnect | .activityTracking | .advisorCostTracking | .eventUploading => .observability
+
+-- ============================================================
+-- 4. 証明
+-- ============================================================
+
+/-- classify は依存関係の単調性を尊重する。 -/
+theorem classify_monotone :
+    ∀ (a b : PropositionId),
+      propositionDependsOn a b = true →
+      ConcreteLayer.ord (classify b) ≥ ConcreteLayer.ord (classify a) := by
+  intro a b h; cases a <;> cases b <;> revert h <;> native_decide
+
+/-- classify は全域関数。 -/
+theorem classify_total :
+    ∀ (p : PropositionId), ∃ (l : ConcreteLayer), classify p = l :=
+  fun p => ⟨classify p, rfl⟩
+
+end Manifest.Models.Instances.ClaudeCodeCLI

--- a/tests/phase3/test-convergence-behavioral.sh
+++ b/tests/phase3/test-convergence-behavioral.sh
@@ -107,18 +107,52 @@ OUT=$(bash "$CONV" status "$D4" 2>&1)
 LINES=$(echo "$OUT" | grep "Iteration" | wc -l | tr -d ' ')
 if [ "$LINES" = "1" ]; then echo "PASS"; PASS=$((PASS+1)); else echo "FAIL ($LINES iterations shown)"; FAIL=$((FAIL+1)); fi
 
-# --- Convergence detection ---
+# --- Convergence detection (2 consecutive < 0.03 + validation) ---
 
-# C.15: convergence detected when rate < 0.05
-echo -n "C.15 convergence detected when rate < 0.05... "
+# C.15: single iteration below threshold → UNCONVERGED (need 2 consecutive)
+echo -n "C.15 single iteration < 0.03 reports UNCONVERGED (need 2 consecutive)... "
 D5="$TMPDIR_TEST/c15"
 mkdir -p "$D5"
-# Create 100 total, then add 1 more → rate = 1/101 ≈ 0.0099
 echo "100" > "$D5/cumulative.txt"
 echo '[{"id":"PD-BIG","content":"x"}]' > "$TMPDIR_TEST/pd_one.json"
 bash "$CONV" add-detailed "$D5" 5 "u" "$TMPDIR_TEST/pd_one.json" >/dev/null 2>&1
 OUT=$(bash "$CONV" check "$D5" 2>&1 || true)
-if echo "$OUT" | grep -q "CONVERGED"; then echo "PASS"; PASS=$((PASS+1)); else echo "FAIL"; FAIL=$((FAIL+1)); fi
+if echo "$OUT" | grep -q "^UNCONVERGED.*need 2"; then echo "PASS"; PASS=$((PASS+1)); else echo "FAIL ($OUT)"; FAIL=$((FAIL+1)); fi
+
+# C.16: 2 consecutive < 0.03 → CONVERGED_PENDING_VALIDATION
+echo -n "C.16 2 consecutive < 0.03 reports CONVERGED_PENDING_VALIDATION... "
+D6="$TMPDIR_TEST/c16"
+mkdir -p "$D6"
+echo "100" > "$D6/cumulative.txt"
+echo '[{"id":"PD-A","content":"x"}]' > "$TMPDIR_TEST/pd_a.json"
+echo '[{"id":"PD-B","content":"y"}]' > "$TMPDIR_TEST/pd_b.json"
+bash "$CONV" add-detailed "$D6" 4 "u" "$TMPDIR_TEST/pd_a.json" >/dev/null 2>&1
+bash "$CONV" add-detailed "$D6" 5 "u" "$TMPDIR_TEST/pd_b.json" >/dev/null 2>&1
+OUT=$(bash "$CONV" check "$D6" 2>&1 || true)
+if echo "$OUT" | grep -q "CONVERGED_PENDING_VALIDATION"; then echo "PASS"; PASS=$((PASS+1)); else echo "FAIL ($OUT)"; FAIL=$((FAIL+1)); fi
+
+# C.17: validation iteration → CONVERGED
+echo -n "C.17 validation iteration < 0.03 reports CONVERGED... "
+D7="$TMPDIR_TEST/c17"
+mkdir -p "$D7"
+echo "100" > "$D7/cumulative.txt"
+echo '[{"id":"PD-C","content":"x"}]' > "$TMPDIR_TEST/pd_c.json"
+echo '[]' > "$TMPDIR_TEST/pd_empty.json"
+bash "$CONV" add-detailed "$D7" 4 "u" "$TMPDIR_TEST/pd_c.json" >/dev/null 2>&1
+bash "$CONV" add-detailed "$D7" 5 "u" "$TMPDIR_TEST/pd_c.json" >/dev/null 2>&1
+bash "$CONV" add-detailed "$D7" 6 "u" "$TMPDIR_TEST/pd_empty.json" --validation >/dev/null 2>&1
+OUT=$(bash "$CONV" check "$D7" 2>&1 || true)
+if echo "$OUT" | grep -q "^CONVERGED \[normal\]: validation PASS"; then echo "PASS"; PASS=$((PASS+1)); else echo "FAIL ($OUT)"; FAIL=$((FAIL+1)); fi
+
+# C.18: exit code 2 for CONVERGED_PENDING_VALIDATION
+echo -n "C.18 CONVERGED_PENDING_VALIDATION exits with code 2... "
+bash "$CONV" check "$D6" >/dev/null 2>&1; RC=$?
+if [ "$RC" = "2" ]; then echo "PASS"; PASS=$((PASS+1)); else echo "FAIL (exit=$RC)"; FAIL=$((FAIL+1)); fi
+
+# C.19: validation flag stored in iteration JSON
+echo -n "C.19 --validation flag stored in iteration JSON... "
+VAL=$(jq -r '.validation' "$D7/iteration-6.json" 2>/dev/null)
+if [ "$VAL" = "true" ]; then echo "PASS"; PASS=$((PASS+1)); else echo "FAIL (got: $VAL)"; FAIL=$((FAIL+1)); fi
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## Summary

- brownfield 収束基準を `single < 0.05` から `2 consecutive < 0.03 + validation iteration` に改善
- Claude Code CLI (1,907 files) に brownfield Phase 0-2 を適用し、70 propositions / 7 layers の条件付き公理系を構築
- 収束基準の探索プロンプトバイアス問題を発見・修正・テストケースで検証

## Changes

### convergence.sh (compatible change)
- 閾値: `single < 0.05` → `2 consecutive < 0.03`
- `--validation` フラグ追加（validation iteration を JSON にマーク）
- exit code: 0 (CONVERGED) / 1 (UNCONVERGED) / 2 (PENDING_VALIDATION)
- 根拠: capture-recapture 推定で 95%+ coverage (#525)

### SKILL.md (compatible change)
- Step 3.5 (Validation Iteration) 追加
- 収束条件の根拠記載（capture-recapture + 偽収束検出）

### ClaudeCodeCLI/ConditionalAxiomSystem.lean (conservative extension)
- 379 PDs → 70 propositions, 7 layers
- lake build PASS (6.2s)
- standalone mode, native_decide 証明

## Test plan

- [x] convergence.sh check で CONVERGED_PENDING_VALIDATION → validation → CONVERGED フロー確認
- [x] 偽収束検出: iter 8-9 の HARD CAP バイアスを validation で検出 (rate 0.093)
- [x] 真の収束確認: iter 14 validation で 0 new PDs
- [x] lake build PASS
- [x] check-monotonicity PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)