### PR TITLE
fix: branch-protection + branch-guard の CWD 抽出を再設計 (#548)

### DIFF
--- a/.claude/hooks/branch-protection.sh
+++ b/.claude/hooks/branch-protection.sh
@@ -18,11 +18,25 @@ if ! echo "$COMMAND" | grep -qE 'git\s+commit'; then
   exit 0
 fi
 
-# Resolve git working directory for worktree support
+# Resolve git working directory for worktree support (#548)
+# Strategy: check multiple patterns in priority order
+#   1. git -C <dir> — explicit git directory flag
+#   2. cd <dir> anywhere in command chain — last cd before git commit
+#   3. fallback to hook process CWD (no -C flag)
 GIT_DIR=""
-if echo "$COMMAND" | grep -qE '^[[:space:]]*cd[[:space:]]+'; then
-  GIT_DIR=$(echo "$COMMAND" | sed -n 's/^[[:space:]]*cd[[:space:]][[:space:]]*\("\([^"]*\)"\|\([^ &;]*\)\).*/\2\3/p')
+
+# 1. Extract git -C <dir> (highest priority — explicit)
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+-C[[:space:]]+'; then
+  GIT_DIR=$(echo "$COMMAND" | grep -oE 'git[[:space:]]+-C[[:space:]]+("[^"]*"|[^[:space:]]+)' | head -1 | sed 's/git[[:space:]]*-C[[:space:]]*//' | tr -d '"')
 fi
+
+# 2. Extract last cd <dir> from the pipeline segment containing git commit
+#    Split by | first to exclude pipe-separated cd (cd in pipe doesn't affect git)
+if [ -z "$GIT_DIR" ]; then
+  SEGMENT=$(echo "$COMMAND" | tr '|' '\n' | grep 'git.*commit' | head -1)
+  GIT_DIR=$(echo "$SEGMENT" | grep -oE '(^|[;&]+[[:space:]]*)cd[[:space:]]+("[^"]*"|[^ "&;]+)' | tail -1 | sed 's/.*cd[[:space:]]*//' | tr -d '"')
+fi
+
 GIT_CMD=(git)
 if [ -n "$GIT_DIR" ] && [ -d "$GIT_DIR" ]; then
   GIT_CMD=(git -C "$GIT_DIR")

--- a/.claude/hooks/main-repo-branch-guard.sh
+++ b/.claude/hooks/main-repo-branch-guard.sh
@@ -27,16 +27,23 @@ if ! echo "$COMMAND" | grep -qE 'git\s+(checkout|switch)'; then
   exit 0
 fi
 
-# cd で別ディレクトリに移動している場合はスルー（worktree 内の操作）
-if echo "$COMMAND" | grep -qE '^\s*cd\s+'; then
-  GIT_DIR=$(echo "$COMMAND" | sed -n 's/^[[:space:]]*cd[[:space:]][[:space:]]*\("\([^"]*\)"\|\([^ &;]*\)\).*/\2\3/p')
-  if [ -n "$GIT_DIR" ] && [ -d "$GIT_DIR" ]; then
-    PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-    GIT_DIR_REAL=$(cd "$GIT_DIR" && pwd)
-    # main repo 外のディレクトリなら許可
-    if [ "$GIT_DIR_REAL" != "$PROJECT_ROOT" ]; then
-      exit 0
-    fi
+# Resolve target directory from command (#548)
+# 1. git -C <dir>, 2. last cd <dir> in pipeline segment with checkout/switch
+TARGET_DIR=""
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+-C[[:space:]]+'; then
+  TARGET_DIR=$(echo "$COMMAND" | grep -oE 'git[[:space:]]+-C[[:space:]]+("[^"]*"|[^[:space:]]+)' | head -1 | sed 's/git[[:space:]]*-C[[:space:]]*//' | tr -d '"')
+fi
+if [ -z "$TARGET_DIR" ]; then
+  SEGMENT=$(echo "$COMMAND" | tr '|' '\n' | grep -E 'git.*(checkout|switch)' | head -1)
+  TARGET_DIR=$(echo "$SEGMENT" | grep -oE '(^|[;&]+[[:space:]]*)cd[[:space:]]+("[^"]*"|[^ "&;]+)' | tail -1 | sed 's/.*cd[[:space:]]*//' | tr -d '"')
+fi
+
+# If target directory resolves to outside main repo, allow (worktree operation)
+if [ -n "$TARGET_DIR" ] && [ -d "$TARGET_DIR" ]; then
+  PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+  TARGET_DIR_REAL=$(cd "$TARGET_DIR" && pwd)
+  if [ "$TARGET_DIR_REAL" != "$PROJECT_ROOT" ]; then
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
## Summary
- branch-protection.sh と main-repo-branch-guard.sh の CWD 抽出ロジックを再設計
- `cd` の行頭限定マッチを、パイプライン分割 + 同一セグメント内の最後の `cd` 採用に変更
- `git -C <dir>` パターンを新規追加（最優先）

## 変更内容
| 項目 | Before | After |
|------|--------|-------|
| cd 検出範囲 | 行頭のみ (`^cd`) | `&&`/`;` チェーン内のどこでも（最後の cd） |
| git -C | 未対応 | 最優先で検出 |
| パイプ `\|` | 誤検出あり | パイプライン分割で除外 |
| 対象 hook | branch-protection.sh のみ | 両 hook に同一ロジック |

## Test plan
- [x] `test-all.sh`: 770/770 PASS
- [x] パターンテスト 9/9 PASS (cd at start, cd in chain, multiple cd, git -C, quoted paths, pipe exclusion, no cd/no -C, semicolon)
- [x] Verifier: PASS (addressable 0件, Round 2)

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)