### PR TITLE
fix: worktree-guard.sh の誤ブロックを修正 (#561)

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -5,8 +5,8 @@
 # worktree で作業すべき状態なのに main repo を直接編集する誤操作を防止。
 #
 # 例外:
+# - worktree 内のファイル編集（worktree 自身の編集は許可）
 # - .claude/ 配下（hooks, skills, settings 等の構成ファイル）
-# - MEMORY.md, memory/ 配下
 # - scripts/ 配下（sync-counts.sh 等のインフラ）
 # - tests/ 配下
 #
@@ -28,9 +28,28 @@ if [[ "$WORKTREE_COUNT" -le 1 ]]; then
   exit 0
 fi
 
-# ファイルが main repo 内かチェック
-if [[ ! "$FILE_PATH" = "$PROJECT_ROOT"* ]]; then
-  # main repo 外のファイル（worktree 内等）→ OK
+# main worktree のパスを取得 (#561)
+MAIN_WORKTREE=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
+
+# worktree 内にいる場合: main repo へのクロス編集でなければ許可
+if [[ "$PROJECT_ROOT" != "$MAIN_WORKTREE" ]]; then
+  # worktree 内にいるが、FILE_PATH が main repo を指していたらブロック
+  if [[ "$FILE_PATH" = "$MAIN_WORKTREE/"* ]]; then
+    echo "BLOCKED: worktree 内から main repo のファイルを直接編集できません。" >&2
+    echo "" >&2
+    echo "  編集対象: $FILE_PATH" >&2
+    echo "  main repo: $MAIN_WORKTREE" >&2
+    exit 2
+  fi
+  # worktree 自身 or 外部ファイル → 許可
+  exit 0
+fi
+
+# ここ以降は main repo にいる場合のみ
+
+# ファイルが main repo 内かチェック (#561: trailing slash で prefix 誤マッチ防止)
+if [[ ! "$FILE_PATH" = "$PROJECT_ROOT/"* ]] && [[ "$FILE_PATH" != "$PROJECT_ROOT" ]]; then
+  # main repo 外のファイル（外部 worktree 内等）→ OK
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- worktree 内での Edit/Write が誤ブロックされる問題を修正
- worktree→main repo へのクロス編集ブロックを追加（セキュリティ修正）
- パスのプレフィックスマッチ誤検出を trailing slash で修正

## 変更内容

| Bug | Before | After |
|-----|--------|-------|
| worktree 内での Edit | BLOCKED (誤) | 許可 |
| worktree→main repo 編集 | 許可 (誤) | BLOCKED |
| `agent-manifesto-X` パス | main repo とマッチ (誤) | マッチしない |

## Root Cause
- `CLAUDE_PROJECT_DIR` が worktree 内でも main repo を返す ([anthropics/claude-code#27343](https://github.com/anthropics/claude-code/issues/27343))
- `git rev-parse --show-toplevel` で worktree root を取得し、`git worktree list` の先頭エントリ (main repo) と比較することで worktree 内かを判定

## Test plan
- [x] `test-all.sh`: 770/770 PASS
- [x] Verifier: PASS (addressable 2件を修正済み: クロス編集ブロック + コメント修正)

Closes #561
Ref #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)