### PR TITLE
feat: evaluatorIndependent structural enforcement (#558)

### DIFF
--- a/.claude/hooks/p2-verify-on-commit.sh
+++ b/.claude/hooks/p2-verify-on-commit.sh
@@ -5,9 +5,12 @@
 # 1回目の高リスクコミット → 警告
 # 2回目以降 → ブロック
 #
+# Critical files (CRITICAL_PATTERNS) additionally require evaluator_independent=true.
+# This ensures VerificationIndependence.evaluatorIndependent for safety-critical changes.
+#
 # 検証トークン: .claude/metrics/p2-verified.jsonl
 # TTL: 10 分
-# @traces P2, E1, D2
+# @traces P2, E1, D2, VerificationIndependence
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 if ! echo "$COMMAND" | grep -qE 'git\s+commit'; then
@@ -44,6 +47,55 @@ VERIFIED_LOG=".claude/metrics/p2-verified.jsonl"
 if [ -n "$GIT_DIR" ] && [ -f "$GIT_DIR/$VERIFIED_LOG" ]; then
 VERIFIED_LOG="$GIT_DIR/$VERIFIED_LOG"
 fi
+
+# --- evaluatorIndependent enforcement for critical files ---
+# CRITICAL_PATTERNS: subset of HIGH_RISK_PATTERNS requiring evaluator_independent=true.
+# Hook only checks the field value; choice of independent means (Ollama, another API, human)
+# is /verify SKILL.md's responsibility (normative layer).
+CRITICAL_PATTERNS='\.claude/hooks/|\.claude/settings\.json|\.claude/settings\.local\.json'
+CRITICAL_FILES=$(echo "$STAGED" | grep -E "$CRITICAL_PATTERNS" || true)
+if [ -n "$CRITICAL_FILES" ] && [ -f "$VERIFIED_LOG" ]; then
+  NOW=$(date +%s)
+  TTL=600
+  UNVERIFIED_CRITICAL=""
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    FOUND_INDEPENDENT=false
+    while IFS= read -r line; do
+      VERDICT=$(echo "$line" | jq -r '.verdict // empty' 2>/dev/null)
+      EVAL_INDEP=$(echo "$line" | jq -r '.evaluator_independent // false' 2>/dev/null)
+      if [ "$VERDICT" = "PASS" ] && [ "$EVAL_INDEP" = "true" ]; then
+        EPOCH=$(echo "$line" | jq -r '.epoch // empty' 2>/dev/null)
+        if [ -z "$EPOCH" ] || [ "$EPOCH" = "null" ]; then
+          continue
+        fi
+        AGE=$(( NOW - EPOCH ))
+        if [ "$AGE" -ge 0 ] && [ "$AGE" -le "$TTL" ]; then
+          if echo "$line" | jq -e --arg file "$f" '.files | index($file)' >/dev/null 2>&1; then
+            FOUND_INDEPENDENT=true
+            break
+          fi
+        fi
+      fi
+    done < <(tac "$VERIFIED_LOG" 2>/dev/null || tail -r "$VERIFIED_LOG" 2>/dev/null)
+    if [ "$FOUND_INDEPENDENT" = false ]; then
+      UNVERIFIED_CRITICAL="${UNVERIFIED_CRITICAL}${f}
+"
+    fi
+  done <<< "$CRITICAL_FILES"
+  UNVERIFIED_CRITICAL=$(echo "$UNVERIFIED_CRITICAL" | sed '/^$/d')
+  if [ -n "$UNVERIFIED_CRITICAL" ]; then
+    echo "P2: Critical files require evaluatorIndependent verification." >&2
+    echo "  Use Ollama, another API, or human review — subagent alone is insufficient." >&2
+    echo "  Critical files without independent verification:" >&2
+    echo "$UNVERIFIED_CRITICAL" | while IFS= read -r f; do
+      [ -n "$f" ] && echo "    - $f" >&2
+    done
+    exit 2
+  fi
+fi
+# --- end evaluatorIndependent enforcement ---
+
 if [ -f "$VERIFIED_LOG" ]; then
 NOW=$(date +%s)
 TTL=600
@@ -96,4 +148,6 @@ exit 0
 fi
 
 # Traceability:
-# E1: 検証独立性 — P2 検証トークンの有無で、独立検証を経たコミットかを判定 # D2: 認知的関心の分離 — 生成（Worker）と検証（Verifier）が分離されていることをコミット時に強制
+# E1: 検証独立性 — P2 検証トークンの有無で、独立検証を経たコミットかを判定
+# D2: 認知的関心の分離 — 生成（Worker）と検証（Verifier）が分離されていることをコミット時に強制
+# VerificationIndependence: CRITICAL_PATTERNS で evaluatorIndependent を構造的に強制

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -184,17 +184,34 @@ FAIL の場合は問題箇所をユーザーに提示し、判断を委ねる。
 Verifier が **PASS** を返した場合、検証対象ファイルのリストを P2 トークンとして記録する。
 これにより `p2-verify-on-commit.sh` が検証済みファイルのコミットを許可する。
 
+**evaluator_type の判定:**
+
+| 検証手段 | evaluator 値 | evaluator_independent |
+|---------|-------------|----------------------|
+| Subagent (Claude) | `"subagent/claude"` | `false` |
+| Local LLM (Ollama 等) | `"ollama/<model>"` | `true` |
+| 別 API | `"api/<provider>"` | `true` |
+| 人間 | `"human"` | `true` |
+
 ```bash
 # PASS の場合のみ実行
-echo '{"epoch":'$(date +%s)',"files":["file1","file2",...],"verdict":"PASS"}' \
+# evaluator と evaluator_independent は検証手段に応じて設定する
+echo '{"epoch":'$(date +%s)',"files":["file1","file2",...],"verdict":"PASS","evaluator":"subagent/claude","evaluator_independent":false}' \
   >> .claude/metrics/p2-verified.jsonl
 ```
+
+**Critical files** (`.claude/hooks/`, `.claude/settings.json`, `.claude/settings.local.json`) の
+コミットには `evaluator_independent: true` のトークンが必要。
+`p2-verify-on-commit.sh` が CRITICAL_PATTERNS で構造的に強制する。
 
 **トークンの仕様:**
 - 形式: JSONL（1 行 1 エントリ）
 - TTL: 10 分（`p2-verify-on-commit.sh` が epoch ベースで検査）
 - 場所: `.claude/metrics/p2-verified.jsonl`
 - files: 検証対象の全ファイルパス（git diff --cached --name-only の出力に一致させる）
+- evaluator: 検証手段の識別子（上記テーブル参照）
+- evaluator_independent: 評価者が Worker と異なるモデルファミリか（VerificationIndependence）
+- 後方互換: `evaluator_independent` フィールドがないトークンは `false` として扱われる
 
 **FAIL の場合:** トークンを書き込まない。修正後に再度 /verify を実行する。
 


### PR DESCRIPTION
## Summary

- p2-verify-on-commit.sh に CRITICAL_PATTERNS チェックを追加し、critical ファイルのコミット時に `evaluator_independent=true` の P2 トークンを要求
- /verify SKILL.md Step 5 に evaluator_type 判定テーブルとトークン形式拡張を追記
- 後方互換: `evaluator_independent` フィールドがない既存トークンは `false` として扱う

Closes #558, Closes #565, Closes #564

## 研究レポート

### 1. どんなもの？
#549 で設計した evaluatorIndependent を structural layer (hook) で強制する実装。CRITICAL_PATTERNS（`.claude/hooks/`, `.claude/settings*.json`）にマッチするファイルのコミット時に、同一モデルファミリ以外の検証（Ollama, 別 API, 人間）を構造的に要求する。

### 2. 先行研究と比べてどこがすごい？
既存の P2 hook は「検証トークンの有無」のみをチェックしていた。Subagent（同一モデル）の検証でもトークンが書き込まれ、critical ファイルでも通過していた。本実装は検証の独立性（evaluatorIndependent）をトークンのフィールドレベルで区別し、hook で構造的に強制する。

### 3. 技術や手法の肝はどこ？
- CRITICAL_PATTERNS を HIGH_RISK_PATTERNS のサブセットとして定義し、critical ファイルは「evaluatorIndependent チェック + 通常 P2 チェック」の両方を通過する必要がある
- Hook は `evaluator_independent` フィールドの値のみを検査し、手段（Ollama/API/人間）を問わない。手段の選択は /verify SKILL.md（normative layer）が担当
- 後方互換: `jq -r '.evaluator_independent // false'` で古いトークンをエラーなく処理

### 4. どうやって有効だと検証した？
- jq ロジック検証: 3 パターン（subagent→false, ollama→true, 旧トークン→false）全 PASS
- テスト: 770 passed, 0 failed
- 自己強制の実証: hook が自身のコミットをブロック → human review トークンで通過

### 5. 議論はある？
- Ollama の評価品質は未検証（CC-H1: gpt-oss-120b → Claude 転移性は仮定）
- 人間レビューのトークン書き込みは手動（自動トリガーは未実装）

### 6. 次に読むべき論文は？
- #555: K 次元反復検証の実装
- #556: G=20 粒度の実装
- #557: Enhanced Dedup トーナメント

## ドキュメント更新
- [x] /verify SKILL.md Step 5: evaluator_type テーブル + トークン形式拡張
- [x] ドキュメント更新なしの他ファイル: 純粋な hook + SKILL.md 変更のため

## 後続 Issue
- #555: K 次元反復検証の実装
- #556: G=20 粒度の実装
- #557: Enhanced Dedup トーナメント
（全て #549 研究から既に起票済み）

## Test plan
- [x] `bash tests/test-all.sh`: 770 passed, 0 failed
- [x] jq ロジック検証: subagent→false, ollama→true, 旧トークン→false
- [x] 自己強制テスト: hook が `.claude/hooks/` のコミットをブロック → human review で通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)