### PR TITLE
fix: judge.md criteriaIndependent → framingIndependent + Bash 削除 (#573, #574)

### DIFF
--- a/.claude/agents/judge.md
+++ b/.claude/agents/judge.md
@@ -9,7 +9,6 @@ tools:
   - Read
   - Glob
   - Grep
-  - Bash
 ---
 
 <!-- @traces P3, V5, D3 -->
@@ -25,7 +24,7 @@ GQM（Goal-Question-Metric）ベースの基準で評価します。
 |------|---------------|------------|
 | 問い | コードは正しいか？ | 改善は価値を生むか？ |
 | 基準 | 正確性、セキュリティ、互換性 | 目標整合性、非自明性、計測裏付け |
-| 独立性 | contextSeparated | criteriaIndependent（基準は事前定義） |
+| 独立性 | contextSeparated | framingIndependent（基準は事前定義） |
 | 出力 | PASS/FAIL + findings | スコア (0.25-5.00) × 基準 + 総合判定 |
 | 反復 | K=3 for high risk (pass-rate) | K 回反復で平均/SD/CV (#555) |
 

--- a/.claude/metrics/p2-verified.jsonl
+++ b/.claude/metrics/p2-verified.jsonl
@@ -40,3 +40,4 @@
 {"timestamp":"2026-04-12T08:11:28Z","epoch":1775981488,"verdict":"PASS","files":[".claude/skills/brownfield/SKILL.md","tests/phase3/test-convergence-behavioral.sh","lean-formalization/Manifest/Models/Instances/AnthropicsClaudeCode/partial-order-mapping.json"],"verifier":"subagent","session":"manual"}
 {"epoch":1776308289,"files":[".claude/agents/judge.md",".claude/agents/verifier.md",".claude/skills/evolve/SKILL.md",".claude/skills/research/SKILL.md",".claude/skills/verify/SKILL.md"],"verdict":"PASS","evaluator":"subagent/claude","evaluator_independent":false}
 {"epoch":1776309420,"files":[".claude/agents/judge.md"],"verdict":"PASS","evaluator":"subagent/claude","evaluator_independent":false}
+{"epoch":1776310703,"files":[".claude/agents/judge.md","dist/agent-manifesto-plugin/agents/judge.md"],"verdict":"PASS","evaluator":"subagent/claude","evaluator_independent":false}

--- a/dist/agent-manifesto-plugin/agents/judge.md
+++ b/dist/agent-manifesto-plugin/agents/judge.md
@@ -9,7 +9,6 @@ tools:
   - Read
   - Glob
   - Grep
-  - Bash
 ---
 
 # Judge Agent (LLM-as-a-judge)
@@ -23,7 +22,7 @@ GQM（Goal-Question-Metric）ベースの基準で評価します。
 |------|---------------|------------|
 | 問い | コードは正しいか？ | 改善は価値を生むか？ |
 | 基準 | 正確性、セキュリティ、互換性 | 目標整合性、非自明性、計測裏付け |
-| 独立性 | contextSeparated | criteriaIndependent（基準は事前定義） |
+| 独立性 | contextSeparated | framingIndependent（基準は事前定義） |
 | 出力 | PASS/FAIL + findings | スコア (1-5) × 基準 + 総合判定 |
 
 ## 評価基準テンプレート（GQM ベース）


### PR DESCRIPTION
## Summary
- `criteriaIndependent` → `framingIndependent` (DesignFoundation.lean に定義済みの形式用語に統一)
- `Bash` を tools から削除 (Judge は Read/Glob/Grep のみ使用、Verifier と統一)
- dist copy も同期

Closes #573, #574

## Test plan
- [x] `bash tests/test-all.sh` → 769 passed, 0 failed (main repo)
- [x] Verifier PASS: framingIndependent の意味的正確性、Bash 削除の安全性を確認
- [x] dist copy の同期を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)