### PR TITLE
feat: sandbox に localhost 通信を許可 (#600)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,12 @@
         "~/work",
         "./.claude/handoffs"
       ]
+    },
+    "network": {
+      "allowedDomains": [
+        "localhost"
+      ],
+      "allowLocalBinding": true
     }
   },
   "hooks": {


### PR DESCRIPTION
## Summary

- sandbox 設定に localhost 通信を許可する設定を追加
- #601 で導入した Verifier モード（logprob pairwise）が sandbox 内で llama-server にアクセスできるようにする
- `dangerouslyDisableSandbox` なしで /evolve, /research, /verify の Verifier モードが動作する

## Test plan

- [x] `python3 scripts/verifier_local.py health` — sandbox 内でも localhost:8090 にアクセス可能
- [x] test-all.sh 769/769 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)