### PR TITLE
fix: pairwise_compare/tournament に bidirectional averaging を追加 (#605)

### DIFF
--- a/scripts/verifier_local.py
+++ b/scripts/verifier_local.py
@@ -204,7 +204,8 @@ def score_pair(problem: str, trace_a: str, trace_b: str, criterion: dict) -> dic
 
 
 def pairwise_compare(problem: str, trace_a: str, trace_b: str,
-                     criteria: list, k_rounds: int = 1) -> dict:
+                     criteria: list, k_rounds: int = 1,
+                     bidirectional: bool = True) -> dict:
     """Full pairwise comparison across all criteria with optional K-rounds.
 
     Args:
@@ -213,17 +214,78 @@ def pairwise_compare(problem: str, trace_a: str, trace_b: str,
         trace_b: Description of proposal B
         criteria: List of {"id", "name", "description"}
         k_rounds: Number of independent rounds (K>1 only meaningful for pairwise)
+        bidirectional: When True (default), run forward (A-B) and reverse (B-A)
+            and average symmetrically to cancel first-position bias (#606).
+            Doubles API cost but corrects position bias artifact from
+            conditional score_B on score_A's token.
 
     Returns: {
         "winner": "A"|"B",
         "total_a": float, "total_b": float,
         "criteria_results": [...],
-        "k_stats": {...} (if K>1)
+        "k_stats": {...} (if K>1),
+        "bidirectional": bool,
     }
     """
     if k_rounds < 1:
         k_rounds = 1
 
+    if bidirectional:
+        # Forward: trace_a in slot A, trace_b in slot B
+        fwd = _pairwise_single_direction(problem, trace_a, trace_b, criteria, k_rounds)
+        # Reverse: trace_b in slot A, trace_a in slot B (swapped)
+        rev = _pairwise_single_direction(problem, trace_b, trace_a, criteria, k_rounds)
+
+        # Symmetric averaging:
+        # trace_a's score = (fwd.total_a + rev.total_b) / 2
+        # trace_b's score = (fwd.total_b + rev.total_a) / 2
+        total_a = (fwd["total_a"] + rev["total_b"]) / 2
+        total_b = (fwd["total_b"] + rev["total_a"]) / 2
+
+        criteria_results = []
+        for ci, crit in enumerate(criteria):
+            f = fwd["criteria_results"][ci]
+            r = rev["criteria_results"][ci]
+            mean_a = (f["mean_a"] + r["mean_b"]) / 2
+            mean_b = (f["mean_b"] + r["mean_a"]) / 2
+
+            entry = {
+                "criterion": crit["id"],
+                "mean_a": round(mean_a, 6),
+                "mean_b": round(mean_b, 6),
+                "winner": "A" if mean_a > mean_b else "B",
+                "forward": {"mean_a": f["mean_a"], "mean_b": f["mean_b"]},
+                "reverse": {"mean_a": r["mean_a"], "mean_b": r["mean_b"]},
+            }
+
+            # Merge K-stats from both directions if present
+            if k_rounds > 1 and "k_stats" in f and "k_stats" in r:
+                entry["k_stats"] = {
+                    "fwd_margin_sd": f["k_stats"]["margin_sd"],
+                    "rev_margin_sd": r["k_stats"]["margin_sd"],
+                }
+
+            criteria_results.append(entry)
+
+        return {
+            "winner": "A" if total_a > total_b else "B",
+            "total_a": round(total_a, 6),
+            "total_b": round(total_b, 6),
+            "margin": round(total_a - total_b, 6),
+            "criteria_results": criteria_results,
+            "k_rounds": k_rounds,
+            "bidirectional": True,
+        }
+
+    # Unidirectional (legacy / for explicit position bias measurement)
+    result = _pairwise_single_direction(problem, trace_a, trace_b, criteria, k_rounds)
+    result["bidirectional"] = False
+    return result
+
+
+def _pairwise_single_direction(problem: str, trace_a: str, trace_b: str,
+                                criteria: list, k_rounds: int) -> dict:
+    """Single-direction pairwise (legacy behavior). Used as building block."""
     all_results = []
 
     for _k in range(k_rounds):
@@ -233,7 +295,6 @@ def pairwise_compare(problem: str, trace_a: str, trace_b: str,
             round_results.append(result)
         all_results.append(round_results)
 
-    # Aggregate across criteria and K-rounds
     total_a = 0.0
     total_b = 0.0
     criteria_results = []
@@ -278,7 +339,7 @@ def pairwise_compare(problem: str, trace_a: str, trace_b: str,
 
 
 def tournament(problem: str, proposals: list, criteria: list,
-               k_rounds: int = 1) -> dict:
+               k_rounds: int = 1, bidirectional: bool = True) -> dict:
     """Round-robin tournament: C(N,2) pairwise comparisons.
 
     Args:
@@ -286,10 +347,13 @@ def tournament(problem: str, proposals: list, criteria: list,
         proposals: List of {"id": str, "description": str}
         criteria: List of {"id", "name", "description"}
         k_rounds: K-rounds per comparison
+        bidirectional: When True (default), each pair is run forward+reverse
+            and averaged symmetrically to cancel first-position bias (#606).
 
     Returns: {
         "ranking": [{"id": str, "wins": int, "total_margin": float}],
         "matches": [...],
+        "bidirectional": bool,
     }
     """
     n = len(proposals)
@@ -297,6 +361,7 @@ def tournament(problem: str, proposals: list, criteria: list,
         return {
             "ranking": [{"id": proposals[0]["id"], "wins": 0, "total_margin": 0.0}] if proposals else [],
             "matches": [],
+            "bidirectional": bidirectional,
         }
 
     wins = {p["id"]: 0 for p in proposals}
@@ -311,6 +376,7 @@ def tournament(problem: str, proposals: list, criteria: list,
                 proposals[j]["description"],
                 criteria,
                 k_rounds,
+                bidirectional=bidirectional,
             )
 
             winner_id = proposals[i]["id"] if result["winner"] == "A" else proposals[j]["id"]
@@ -333,7 +399,7 @@ def tournament(problem: str, proposals: list, criteria: list,
         key=lambda x: (-x["wins"], -x["total_margin"]),
     )
 
-    return {"ranking": ranking, "matches": matches}
+    return {"ranking": ranking, "matches": matches, "bidirectional": bidirectional}
 
 
 def _std(arr: list) -> float:
@@ -401,6 +467,7 @@ def cmd_pairwise():
         trace_b=data["proposal_b"],
         criteria=data["criteria"],
         k_rounds=data.get("k_rounds", 1),
+        bidirectional=data.get("bidirectional", True),
     )
     json.dump(result, sys.stdout, indent=2)
     print()
@@ -416,6 +483,7 @@ def cmd_tournament():
         proposals=data["proposals"],
         criteria=data["criteria"],
         k_rounds=data.get("k_rounds", 1),
+        bidirectional=data.get("bidirectional", True),
     )
     json.dump(result, sys.stdout, indent=2)
     print()


### PR DESCRIPTION
## Summary

- **#605 研究で発見した critical bug の修正**: `score_pair` 実装が first-position bias を誘発していた (#601 の残存バグ)
- `pairwise_compare` / `tournament` に `bidirectional=True` オプション追加 (デフォルト有効)
- Forward (A-B) + Reverse (B-A) を実行し symmetric 平均で bias を構造的に相殺

## Problem Statement

`#600`/`#601` で導入した Verifier モードの `score_pair`:
```python
# score_A: 独立 (problem + 両 description)
prompt_a = base_prompt + "<score_A>"
score_a = extract_score_direct(prompt_a)

# score_B: score_A の選択トークンに条件付き (anchoring)
prompt_b = base_prompt + f"<score_A>{debug_a['selected_token']}</score_A>\n<score_B>"
score_b = extract_score_direct(prompt_b)
```

score_B が score_A の選択トークンに条件付きで評価されるため、**常に low 寄り**に anchoring され、**first-position bias 0.234** (10 pairs × 2 directions で 9/10 ペアで winner 逆転) が発生していた。

## Fix

```python
def pairwise_compare(..., bidirectional: bool = True) -> dict:
    if bidirectional:
        fwd = _pairwise_single_direction(problem, trace_a, trace_b, ...)
        rev = _pairwise_single_direction(problem, trace_b, trace_a, ...)
        # Symmetric averaging cancels position bias
        total_a = (fwd["total_a"] + rev["total_b"]) / 2
        total_b = (fwd["total_b"] + rev["total_a"]) / 2
```

## Verification (from #605 research)

| 検証 | Unidirectional | Bidirectional |
|------|---------------|---------------|
| Position bias | 0.234 (FAIL) | 0 (by construction) |
| Consistency rate | 10% (1/10) | 100% |
| Tournament ranking vs expected | 依 order | Kendall τ=0 (perfect) |
| Transitivity cycles | 2 (reverse mode) | 0 |

## Impact

- /evolve Phase 3.5 / Step 1.5
- /research Step 6a / Step 1b
- /verify Step 3

後方互換: default `bidirectional=True` により呼び出し側変更不要。コスト 2x API calls/pair だが bias 除去が優先。

## Test plan

- [x] `test-all.sh` 769/769 passed
- [x] #605 Sub-Issues 全 8 軸で検証完了
- [x] Worktree `agent-manifesto-research-605` で実環境動作確認 (2300+ 比較)

Closes #606 (#605 Sub-Issue)
Related #605 (Parent research), #614 #615 #616 (follow-ups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)