### PR TITLE
feat: Phase 2 完了 — JudgeBench + SWE-Bench Verified (#618)

### DIFF
--- a/research/verifier-gt/judgebench_gemma_q6_n100_k3.json
+++ b/research/verifier-gt/judgebench_gemma_q6_n100_k3.json
@@ -1,0 +1,782 @@
+{
+  "summary": {
+    "dataset": "judgebench",
+    "model_name": "gemma-4-E4B-it-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 85,
+    "correct": 59,
+    "accuracy": 0.694118,
+    "by_category": {
+      "mmlu-pro-health": {
+        "correct": 5,
+        "total": 5,
+        "accuracy": 1.0
+      },
+      "mmlu-pro-psychology": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "mmlu-pro-chemistry": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "mmlu-pro-philosophy": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "mmlu-pro-physics": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "mmlu-pro-history": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "mmlu-pro-math": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "mmlu-pro-other": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "mmlu-pro-law": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "mmlu-pro-engineering": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "mmlu-pro-business": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "mmlu-pro-economics": {
+        "correct": 2,
+        "total": 5,
+        "accuracy": 0.4
+      },
+      "mmlu-pro-biology": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "mmlu-pro-computer science": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "livebench-math": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "livebench-reasoning": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "livecodebench": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      }
+    },
+    "elapsed_seconds": 478.67
+  },
+  "per_example": [
+    {
+      "example_id": "b5ce1305-50fe-5a5e-b785-325ab15c6d2b",
+      "category": "mmlu-pro-health",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.115862,
+      "correct": true
+    },
+    {
+      "example_id": "8e1df938-fb37-5c27-8a0d-aedee854251a",
+      "category": "mmlu-pro-health",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.060092,
+      "correct": true
+    },
+    {
+      "example_id": "cba66923-b65f-566a-a766-03039fe2345c",
+      "category": "mmlu-pro-health",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.021707,
+      "correct": true
+    },
+    {
+      "example_id": "40a0f1d8-fbfe-53e3-947f-3ead7276284e",
+      "category": "mmlu-pro-health",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.457412,
+      "correct": true
+    },
+    {
+      "example_id": "bdad5388-27d0-5001-a4ba-cb2208edf775",
+      "category": "mmlu-pro-health",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.037338,
+      "correct": true
+    },
+    {
+      "example_id": "40fec759-5b84-5ed6-b35f-c9852da124b8",
+      "category": "mmlu-pro-psychology",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.169611,
+      "correct": true
+    },
+    {
+      "example_id": "851b5544-7fc0-5faa-940e-53e0ff149516",
+      "category": "mmlu-pro-psychology",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.016333,
+      "correct": true
+    },
+    {
+      "example_id": "f474b24e-316a-572d-8772-189739800d5d",
+      "category": "mmlu-pro-psychology",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.096232,
+      "correct": false
+    },
+    {
+      "example_id": "c2028682-fb48-55b9-a80b-75bdc961513b",
+      "category": "mmlu-pro-psychology",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.025057,
+      "correct": true
+    },
+    {
+      "example_id": "3762c45e-f29f-5641-aaee-ac545e09f4bf",
+      "category": "mmlu-pro-psychology",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.088607,
+      "correct": false
+    },
+    {
+      "example_id": "40259d3e-bfe0-5288-9378-b67e4bd6d4ea",
+      "category": "mmlu-pro-chemistry",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.103857,
+      "correct": false
+    },
+    {
+      "example_id": "fa4a7de8-dc94-51c2-af35-9a2a2feb9439",
+      "category": "mmlu-pro-chemistry",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.405993,
+      "correct": true
+    },
+    {
+      "example_id": "dc1df9a6-ac72-5834-bf91-c324da3d88ed",
+      "category": "mmlu-pro-chemistry",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.131704,
+      "correct": true
+    },
+    {
+      "example_id": "c186e988-2859-548e-937a-1f125900d1e1",
+      "category": "mmlu-pro-chemistry",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.125057,
+      "correct": false
+    },
+    {
+      "example_id": "429ad667-0c08-5c77-9fc3-a264dfa770fe",
+      "category": "mmlu-pro-chemistry",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.025257,
+      "correct": true
+    },
+    {
+      "example_id": "82b2af9a-722e-55b3-a365-8c861f5b5cde",
+      "category": "mmlu-pro-philosophy",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.048407,
+      "correct": false
+    },
+    {
+      "example_id": "3ca791e5-75b4-5172-bc59-14c5b21c60a1",
+      "category": "mmlu-pro-philosophy",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.179439,
+      "correct": true
+    },
+    {
+      "example_id": "0a75523a-50d2-5e71-8a08-257afd51fab7",
+      "category": "mmlu-pro-philosophy",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.077431,
+      "correct": false
+    },
+    {
+      "example_id": "4f9f8288-4e9e-553d-b444-1b9441c537e1",
+      "category": "mmlu-pro-philosophy",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.171745,
+      "correct": true
+    },
+    {
+      "example_id": "7cada2fd-2c0b-5301-9582-27b1ad933ee0",
+      "category": "mmlu-pro-philosophy",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.198508,
+      "correct": true
+    },
+    {
+      "example_id": "3536e15f-d919-5117-8494-4520a42f5367",
+      "category": "mmlu-pro-physics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.289908,
+      "correct": true
+    },
+    {
+      "example_id": "9f662634-6bf3-5943-bc97-defa5e01e3bb",
+      "category": "mmlu-pro-physics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.419202,
+      "correct": true
+    },
+    {
+      "example_id": "bd98f97e-668b-5b14-9e12-25f8287ac40a",
+      "category": "mmlu-pro-physics",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.172504,
+      "correct": false
+    },
+    {
+      "example_id": "6ecdf3e8-0e9b-5efe-bc37-ac496f4e0c24",
+      "category": "mmlu-pro-physics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.260697,
+      "correct": true
+    },
+    {
+      "example_id": "5faba119-90d9-5be4-8d17-09a42c3228dc",
+      "category": "mmlu-pro-physics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.140856,
+      "correct": true
+    },
+    {
+      "example_id": "0cf2d318-18be-5bda-b976-52e5f3bffa01",
+      "category": "mmlu-pro-history",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.349665,
+      "correct": true
+    },
+    {
+      "example_id": "eb39387a-e83c-5cc7-92f7-189a5e71bf26",
+      "category": "mmlu-pro-history",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.244763,
+      "correct": true
+    },
+    {
+      "example_id": "b25fc0d7-ca58-58c8-9430-0a2943209f95",
+      "category": "mmlu-pro-history",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.091414,
+      "correct": true
+    },
+    {
+      "example_id": "6101a179-ce72-51da-a1b4-643c7ee99009",
+      "category": "mmlu-pro-history",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.085753,
+      "correct": false
+    },
+    {
+      "example_id": "c2d66af7-e981-5b4f-849d-00876452ae3e",
+      "category": "mmlu-pro-history",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.076911,
+      "correct": false
+    },
+    {
+      "example_id": "4ff4607f-c38a-5039-8193-7c50efc59f20",
+      "category": "mmlu-pro-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.079556,
+      "correct": true
+    },
+    {
+      "example_id": "2fb6b499-99f2-546e-a2ae-2676ac419fb4",
+      "category": "mmlu-pro-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.286926,
+      "correct": true
+    },
+    {
+      "example_id": "ada72612-ba5d-56c3-83fe-3fd89d07e7be",
+      "category": "mmlu-pro-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.041244,
+      "correct": true
+    },
+    {
+      "example_id": "761e275c-7556-5238-8fcc-7b52af5dc416",
+      "category": "mmlu-pro-math",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.645672,
+      "correct": false
+    },
+    {
+      "example_id": "a74d50f7-9e44-5428-969c-89c74c5bd0ea",
+      "category": "mmlu-pro-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.567595,
+      "correct": true
+    },
+    {
+      "example_id": "7238d03a-3adc-5ad0-ae2f-9ce5f97ce216",
+      "category": "mmlu-pro-other",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.011288,
+      "correct": true
+    },
+    {
+      "example_id": "26cceffc-1fb6-5c3c-b257-84759fa87fa1",
+      "category": "mmlu-pro-other",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.000908,
+      "correct": true
+    },
+    {
+      "example_id": "fb576312-7ab1-5035-bb6d-14013d4dd65d",
+      "category": "mmlu-pro-other",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.003161,
+      "correct": true
+    },
+    {
+      "example_id": "74581892-e3c1-5ef1-8eca-46a1d4ed710a",
+      "category": "mmlu-pro-other",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.064977,
+      "correct": false
+    },
+    {
+      "example_id": "96d3b510-63de-5bc7-bdb5-5d53fce4e864",
+      "category": "mmlu-pro-other",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.076736,
+      "correct": true
+    },
+    {
+      "example_id": "6eea64c3-0413-5fdf-b089-80dd2336a931",
+      "category": "mmlu-pro-law",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.072338,
+      "correct": true
+    },
+    {
+      "example_id": "bbdcd0e8-c9f8-5d3d-bf42-7bd74bd75273",
+      "category": "mmlu-pro-law",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.172393,
+      "correct": false
+    },
+    {
+      "example_id": "4f912a80-4b06-5c52-8c09-46ab9dac3f50",
+      "category": "mmlu-pro-law",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.014949,
+      "correct": false
+    },
+    {
+      "example_id": "6ad0708f-c8f5-5e1b-8853-9da12e8f0e67",
+      "category": "mmlu-pro-law",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.001736,
+      "correct": true
+    },
+    {
+      "example_id": "076468c5-22e4-5b91-a74b-d31ba1182eaa",
+      "category": "mmlu-pro-law",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.027623,
+      "correct": true
+    },
+    {
+      "example_id": "609bc48e-5a9d-57b2-84b4-5cf3179dfbc2",
+      "category": "mmlu-pro-engineering",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.060929,
+      "correct": true
+    },
+    {
+      "example_id": "89ad682e-4678-5c95-8cb5-27a70a3df69f",
+      "category": "mmlu-pro-engineering",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.028675,
+      "correct": true
+    },
+    {
+      "example_id": "6c214deb-96b4-5152-801c-7b296182273e",
+      "category": "mmlu-pro-engineering",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.100624,
+      "correct": true
+    },
+    {
+      "example_id": "862781f4-edd0-53c0-a4a2-eafa093b2cf0",
+      "category": "mmlu-pro-engineering",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.251641,
+      "correct": true
+    },
+    {
+      "example_id": "feb2b600-421d-5a19-b39e-b1832ba41721",
+      "category": "mmlu-pro-engineering",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.026213,
+      "correct": false
+    },
+    {
+      "example_id": "3fe93ac0-3593-5d41-a7aa-58cab2fefedd",
+      "category": "mmlu-pro-business",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.008262,
+      "correct": false
+    },
+    {
+      "example_id": "b37bde81-c51d-5677-895a-90e7ea82769c",
+      "category": "mmlu-pro-business",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.214832,
+      "correct": true
+    },
+    {
+      "example_id": "e711a144-4bff-5e97-8d30-505ef5283f62",
+      "category": "mmlu-pro-business",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.024891,
+      "correct": true
+    },
+    {
+      "example_id": "95b24833-bf9c-51bc-91bb-120dc11251f4",
+      "category": "mmlu-pro-business",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.217544,
+      "correct": true
+    },
+    {
+      "example_id": "fb010453-c9a1-513e-80d2-6e862a7ac1eb",
+      "category": "mmlu-pro-business",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.192323,
+      "correct": true
+    },
+    {
+      "example_id": "f1891276-ff88-5171-8720-61908bff5e77",
+      "category": "mmlu-pro-economics",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.451548,
+      "correct": false
+    },
+    {
+      "example_id": "4f49c59b-c323-55ce-b658-dcbbc1b8fe7d",
+      "category": "mmlu-pro-economics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.062623,
+      "correct": true
+    },
+    {
+      "example_id": "182a216b-71f5-5d79-8947-fcbebab7e2c2",
+      "category": "mmlu-pro-economics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.033806,
+      "correct": true
+    },
+    {
+      "example_id": "8a434591-3536-5802-9480-1ed7d9cd60ac",
+      "category": "mmlu-pro-economics",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.02417,
+      "correct": false
+    },
+    {
+      "example_id": "2417995a-5baa-5b49-a5d2-84ef4202600d",
+      "category": "mmlu-pro-economics",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.148378,
+      "correct": false
+    },
+    {
+      "example_id": "01c32337-3782-5fc0-8040-2850d4d212f3",
+      "category": "mmlu-pro-biology",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.131903,
+      "correct": true
+    },
+    {
+      "example_id": "0f080546-ca02-545b-a1f0-c626bb610a2a",
+      "category": "mmlu-pro-biology",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.002248,
+      "correct": false
+    },
+    {
+      "example_id": "e82d2ea3-2496-5b19-a2e2-a15fe6d57534",
+      "category": "mmlu-pro-biology",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.046707,
+      "correct": true
+    },
+    {
+      "example_id": "8fc8e1f1-e82e-5c20-822c-af0e60866580",
+      "category": "mmlu-pro-biology",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.170447,
+      "correct": false
+    },
+    {
+      "example_id": "9461f002-1439-51fd-9531-36f752f3f1e4",
+      "category": "mmlu-pro-biology",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.224791,
+      "correct": true
+    },
+    {
+      "example_id": "c566a7a2-90fa-51a3-ad32-2fdf11cc8042",
+      "category": "mmlu-pro-computer science",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.025485,
+      "correct": true
+    },
+    {
+      "example_id": "a44180ee-5faf-5a97-94bb-660edb6edcac",
+      "category": "mmlu-pro-computer science",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.289233,
+      "correct": true
+    },
+    {
+      "example_id": "fbc46398-9882-54d4-95eb-215ddf1857bb",
+      "category": "mmlu-pro-computer science",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.254308,
+      "correct": true
+    },
+    {
+      "example_id": "b3f4a62f-a237-5310-8c00-f291e00d3c3a",
+      "category": "mmlu-pro-computer science",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.118862,
+      "correct": false
+    },
+    {
+      "example_id": "09f91a0b-f769-56af-a191-3ed83f705504",
+      "category": "mmlu-pro-computer science",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.11164,
+      "correct": true
+    },
+    {
+      "example_id": "2c28d749-9b2f-572b-b7cd-5c27e0ad9d1f",
+      "category": "livebench-math",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.002884,
+      "correct": false
+    },
+    {
+      "example_id": "db5fe3cd-488b-5996-b494-768c2a8add72",
+      "category": "livebench-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.010751,
+      "correct": true
+    },
+    {
+      "example_id": "d1ac1dc9-a0cc-5378-8762-7807e505f7c7",
+      "category": "livebench-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.113601,
+      "correct": true
+    },
+    {
+      "example_id": "35abf0af-4d34-54d4-84e7-e9e4c313b886",
+      "category": "livebench-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.390633,
+      "correct": true
+    },
+    {
+      "example_id": "fb5bb37e-22b1-5b7c-b536-69410557f89a",
+      "category": "livebench-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.195771,
+      "correct": true
+    },
+    {
+      "example_id": "0f03ad86-bab9-5804-8b7d-e366a96e3ef6",
+      "category": "livebench-reasoning",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.29698,
+      "correct": false
+    },
+    {
+      "example_id": "8dddf27e-b2f5-532c-a23f-ac533ad229b2",
+      "category": "livebench-reasoning",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.761273,
+      "correct": true
+    },
+    {
+      "example_id": "0f60f2b6-3f29-5063-8477-5579e8b59654",
+      "category": "livebench-reasoning",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.436476,
+      "correct": true
+    },
+    {
+      "example_id": "236e4c79-ae79-5ce9-a24f-6111bb1d069a",
+      "category": "livebench-reasoning",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.022809,
+      "correct": false
+    },
+    {
+      "example_id": "03637a9a-7d80-5ecb-a1d0-d1f6cffc6879",
+      "category": "livebench-reasoning",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.01162,
+      "correct": true
+    },
+    {
+      "example_id": "b487ea88-7f61-585f-a2ff-4f335d30a12e",
+      "category": "livecodebench",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.007722,
+      "correct": true
+    },
+    {
+      "example_id": "86d3d9db-2af1-541c-8f8b-da2aef85c544",
+      "category": "livecodebench",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.534895,
+      "correct": false
+    },
+    {
+      "example_id": "5395119b-d8e5-52d3-a610-be760aee401a",
+      "category": "livecodebench",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.007048,
+      "correct": false
+    },
+    {
+      "example_id": "b29e3027-00b8-5e06-8b51-aeed1a2e4bdb",
+      "category": "livecodebench",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.051138,
+      "correct": true
+    },
+    {
+      "example_id": "904ccc1f-7d96-58a4-9c78-721feed676db",
+      "category": "livecodebench",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.042948,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/judgebench_qwen4b_n100_k3.json
+++ b/research/verifier-gt/judgebench_qwen4b_n100_k3.json
@@ -1,0 +1,782 @@
+{
+  "summary": {
+    "dataset": "judgebench",
+    "model_name": "Qwen3.5-4B-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 85,
+    "correct": 47,
+    "accuracy": 0.552941,
+    "by_category": {
+      "mmlu-pro-health": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "mmlu-pro-psychology": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "mmlu-pro-chemistry": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "mmlu-pro-philosophy": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "mmlu-pro-physics": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "mmlu-pro-history": {
+        "correct": 1,
+        "total": 5,
+        "accuracy": 0.2
+      },
+      "mmlu-pro-math": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "mmlu-pro-other": {
+        "correct": 1,
+        "total": 5,
+        "accuracy": 0.2
+      },
+      "mmlu-pro-law": {
+        "correct": 2,
+        "total": 5,
+        "accuracy": 0.4
+      },
+      "mmlu-pro-engineering": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "mmlu-pro-business": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "mmlu-pro-economics": {
+        "correct": 2,
+        "total": 5,
+        "accuracy": 0.4
+      },
+      "mmlu-pro-biology": {
+        "correct": 2,
+        "total": 5,
+        "accuracy": 0.4
+      },
+      "mmlu-pro-computer science": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "livebench-math": {
+        "correct": 3,
+        "total": 5,
+        "accuracy": 0.6
+      },
+      "livebench-reasoning": {
+        "correct": 4,
+        "total": 5,
+        "accuracy": 0.8
+      },
+      "livecodebench": {
+        "correct": 1,
+        "total": 5,
+        "accuracy": 0.2
+      }
+    },
+    "elapsed_seconds": 467.18
+  },
+  "per_example": [
+    {
+      "example_id": "b5ce1305-50fe-5a5e-b785-325ab15c6d2b",
+      "category": "mmlu-pro-health",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.062036,
+      "correct": false
+    },
+    {
+      "example_id": "8e1df938-fb37-5c27-8a0d-aedee854251a",
+      "category": "mmlu-pro-health",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.087603,
+      "correct": true
+    },
+    {
+      "example_id": "cba66923-b65f-566a-a766-03039fe2345c",
+      "category": "mmlu-pro-health",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.072506,
+      "correct": true
+    },
+    {
+      "example_id": "40a0f1d8-fbfe-53e3-947f-3ead7276284e",
+      "category": "mmlu-pro-health",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.207348,
+      "correct": true
+    },
+    {
+      "example_id": "bdad5388-27d0-5001-a4ba-cb2208edf775",
+      "category": "mmlu-pro-health",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.152682,
+      "correct": false
+    },
+    {
+      "example_id": "40fec759-5b84-5ed6-b35f-c9852da124b8",
+      "category": "mmlu-pro-psychology",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.220064,
+      "correct": true
+    },
+    {
+      "example_id": "851b5544-7fc0-5faa-940e-53e0ff149516",
+      "category": "mmlu-pro-psychology",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.175681,
+      "correct": true
+    },
+    {
+      "example_id": "f474b24e-316a-572d-8772-189739800d5d",
+      "category": "mmlu-pro-psychology",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.006341,
+      "correct": true
+    },
+    {
+      "example_id": "c2028682-fb48-55b9-a80b-75bdc961513b",
+      "category": "mmlu-pro-psychology",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.143138,
+      "correct": false
+    },
+    {
+      "example_id": "3762c45e-f29f-5641-aaee-ac545e09f4bf",
+      "category": "mmlu-pro-psychology",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.342036,
+      "correct": false
+    },
+    {
+      "example_id": "40259d3e-bfe0-5288-9378-b67e4bd6d4ea",
+      "category": "mmlu-pro-chemistry",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.255916,
+      "correct": false
+    },
+    {
+      "example_id": "fa4a7de8-dc94-51c2-af35-9a2a2feb9439",
+      "category": "mmlu-pro-chemistry",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.310099,
+      "correct": true
+    },
+    {
+      "example_id": "dc1df9a6-ac72-5834-bf91-c324da3d88ed",
+      "category": "mmlu-pro-chemistry",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.195627,
+      "correct": true
+    },
+    {
+      "example_id": "c186e988-2859-548e-937a-1f125900d1e1",
+      "category": "mmlu-pro-chemistry",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.060708,
+      "correct": true
+    },
+    {
+      "example_id": "429ad667-0c08-5c77-9fc3-a264dfa770fe",
+      "category": "mmlu-pro-chemistry",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.007435,
+      "correct": false
+    },
+    {
+      "example_id": "82b2af9a-722e-55b3-a365-8c861f5b5cde",
+      "category": "mmlu-pro-philosophy",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.000298,
+      "correct": true
+    },
+    {
+      "example_id": "3ca791e5-75b4-5172-bc59-14c5b21c60a1",
+      "category": "mmlu-pro-philosophy",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.122804,
+      "correct": true
+    },
+    {
+      "example_id": "0a75523a-50d2-5e71-8a08-257afd51fab7",
+      "category": "mmlu-pro-philosophy",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.305283,
+      "correct": true
+    },
+    {
+      "example_id": "4f9f8288-4e9e-553d-b444-1b9441c537e1",
+      "category": "mmlu-pro-philosophy",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.190517,
+      "correct": false
+    },
+    {
+      "example_id": "7cada2fd-2c0b-5301-9582-27b1ad933ee0",
+      "category": "mmlu-pro-philosophy",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.290624,
+      "correct": true
+    },
+    {
+      "example_id": "3536e15f-d919-5117-8494-4520a42f5367",
+      "category": "mmlu-pro-physics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.358991,
+      "correct": true
+    },
+    {
+      "example_id": "9f662634-6bf3-5943-bc97-defa5e01e3bb",
+      "category": "mmlu-pro-physics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.206146,
+      "correct": true
+    },
+    {
+      "example_id": "bd98f97e-668b-5b14-9e12-25f8287ac40a",
+      "category": "mmlu-pro-physics",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.177919,
+      "correct": false
+    },
+    {
+      "example_id": "6ecdf3e8-0e9b-5efe-bc37-ac496f4e0c24",
+      "category": "mmlu-pro-physics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.266892,
+      "correct": true
+    },
+    {
+      "example_id": "5faba119-90d9-5be4-8d17-09a42c3228dc",
+      "category": "mmlu-pro-physics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.007464,
+      "correct": true
+    },
+    {
+      "example_id": "0cf2d318-18be-5bda-b976-52e5f3bffa01",
+      "category": "mmlu-pro-history",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.167042,
+      "correct": true
+    },
+    {
+      "example_id": "eb39387a-e83c-5cc7-92f7-189a5e71bf26",
+      "category": "mmlu-pro-history",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.025057,
+      "correct": false
+    },
+    {
+      "example_id": "b25fc0d7-ca58-58c8-9430-0a2943209f95",
+      "category": "mmlu-pro-history",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.098658,
+      "correct": false
+    },
+    {
+      "example_id": "6101a179-ce72-51da-a1b4-643c7ee99009",
+      "category": "mmlu-pro-history",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.456681,
+      "correct": false
+    },
+    {
+      "example_id": "c2d66af7-e981-5b4f-849d-00876452ae3e",
+      "category": "mmlu-pro-history",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.180849,
+      "correct": false
+    },
+    {
+      "example_id": "4ff4607f-c38a-5039-8193-7c50efc59f20",
+      "category": "mmlu-pro-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.003928,
+      "correct": true
+    },
+    {
+      "example_id": "2fb6b499-99f2-546e-a2ae-2676ac419fb4",
+      "category": "mmlu-pro-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.364567,
+      "correct": true
+    },
+    {
+      "example_id": "ada72612-ba5d-56c3-83fe-3fd89d07e7be",
+      "category": "mmlu-pro-math",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.001164,
+      "correct": false
+    },
+    {
+      "example_id": "761e275c-7556-5238-8fcc-7b52af5dc416",
+      "category": "mmlu-pro-math",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.428195,
+      "correct": false
+    },
+    {
+      "example_id": "a74d50f7-9e44-5428-969c-89c74c5bd0ea",
+      "category": "mmlu-pro-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.366721,
+      "correct": true
+    },
+    {
+      "example_id": "7238d03a-3adc-5ad0-ae2f-9ce5f97ce216",
+      "category": "mmlu-pro-other",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.018282,
+      "correct": false
+    },
+    {
+      "example_id": "26cceffc-1fb6-5c3c-b257-84759fa87fa1",
+      "category": "mmlu-pro-other",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.208474,
+      "correct": false
+    },
+    {
+      "example_id": "fb576312-7ab1-5035-bb6d-14013d4dd65d",
+      "category": "mmlu-pro-other",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.230072,
+      "correct": false
+    },
+    {
+      "example_id": "74581892-e3c1-5ef1-8eca-46a1d4ed710a",
+      "category": "mmlu-pro-other",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.011694,
+      "correct": true
+    },
+    {
+      "example_id": "96d3b510-63de-5bc7-bdb5-5d53fce4e864",
+      "category": "mmlu-pro-other",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.057805,
+      "correct": false
+    },
+    {
+      "example_id": "6eea64c3-0413-5fdf-b089-80dd2336a931",
+      "category": "mmlu-pro-law",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.219753,
+      "correct": true
+    },
+    {
+      "example_id": "bbdcd0e8-c9f8-5d3d-bf42-7bd74bd75273",
+      "category": "mmlu-pro-law",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.253645,
+      "correct": false
+    },
+    {
+      "example_id": "4f912a80-4b06-5c52-8c09-46ab9dac3f50",
+      "category": "mmlu-pro-law",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.069703,
+      "correct": false
+    },
+    {
+      "example_id": "6ad0708f-c8f5-5e1b-8853-9da12e8f0e67",
+      "category": "mmlu-pro-law",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.031104,
+      "correct": false
+    },
+    {
+      "example_id": "076468c5-22e4-5b91-a74b-d31ba1182eaa",
+      "category": "mmlu-pro-law",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.183738,
+      "correct": true
+    },
+    {
+      "example_id": "609bc48e-5a9d-57b2-84b4-5cf3179dfbc2",
+      "category": "mmlu-pro-engineering",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.032109,
+      "correct": true
+    },
+    {
+      "example_id": "89ad682e-4678-5c95-8cb5-27a70a3df69f",
+      "category": "mmlu-pro-engineering",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.24222,
+      "correct": true
+    },
+    {
+      "example_id": "6c214deb-96b4-5152-801c-7b296182273e",
+      "category": "mmlu-pro-engineering",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.09001,
+      "correct": false
+    },
+    {
+      "example_id": "862781f4-edd0-53c0-a4a2-eafa093b2cf0",
+      "category": "mmlu-pro-engineering",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.240793,
+      "correct": true
+    },
+    {
+      "example_id": "feb2b600-421d-5a19-b39e-b1832ba41721",
+      "category": "mmlu-pro-engineering",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.295322,
+      "correct": true
+    },
+    {
+      "example_id": "3fe93ac0-3593-5d41-a7aa-58cab2fefedd",
+      "category": "mmlu-pro-business",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.045394,
+      "correct": false
+    },
+    {
+      "example_id": "b37bde81-c51d-5677-895a-90e7ea82769c",
+      "category": "mmlu-pro-business",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.291755,
+      "correct": true
+    },
+    {
+      "example_id": "e711a144-4bff-5e97-8d30-505ef5283f62",
+      "category": "mmlu-pro-business",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.086306,
+      "correct": true
+    },
+    {
+      "example_id": "95b24833-bf9c-51bc-91bb-120dc11251f4",
+      "category": "mmlu-pro-business",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.287098,
+      "correct": true
+    },
+    {
+      "example_id": "fb010453-c9a1-513e-80d2-6e862a7ac1eb",
+      "category": "mmlu-pro-business",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.273641,
+      "correct": true
+    },
+    {
+      "example_id": "f1891276-ff88-5171-8720-61908bff5e77",
+      "category": "mmlu-pro-economics",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.377777,
+      "correct": false
+    },
+    {
+      "example_id": "4f49c59b-c323-55ce-b658-dcbbc1b8fe7d",
+      "category": "mmlu-pro-economics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.23595,
+      "correct": true
+    },
+    {
+      "example_id": "182a216b-71f5-5d79-8947-fcbebab7e2c2",
+      "category": "mmlu-pro-economics",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.058453,
+      "correct": false
+    },
+    {
+      "example_id": "8a434591-3536-5802-9480-1ed7d9cd60ac",
+      "category": "mmlu-pro-economics",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.018698,
+      "correct": true
+    },
+    {
+      "example_id": "2417995a-5baa-5b49-a5d2-84ef4202600d",
+      "category": "mmlu-pro-economics",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.474639,
+      "correct": false
+    },
+    {
+      "example_id": "01c32337-3782-5fc0-8040-2850d4d212f3",
+      "category": "mmlu-pro-biology",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.298034,
+      "correct": true
+    },
+    {
+      "example_id": "0f080546-ca02-545b-a1f0-c626bb610a2a",
+      "category": "mmlu-pro-biology",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.173942,
+      "correct": false
+    },
+    {
+      "example_id": "e82d2ea3-2496-5b19-a2e2-a15fe6d57534",
+      "category": "mmlu-pro-biology",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.010503,
+      "correct": false
+    },
+    {
+      "example_id": "8fc8e1f1-e82e-5c20-822c-af0e60866580",
+      "category": "mmlu-pro-biology",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.214263,
+      "correct": false
+    },
+    {
+      "example_id": "9461f002-1439-51fd-9531-36f752f3f1e4",
+      "category": "mmlu-pro-biology",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.273989,
+      "correct": true
+    },
+    {
+      "example_id": "c566a7a2-90fa-51a3-ad32-2fdf11cc8042",
+      "category": "mmlu-pro-computer science",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.031165,
+      "correct": false
+    },
+    {
+      "example_id": "a44180ee-5faf-5a97-94bb-660edb6edcac",
+      "category": "mmlu-pro-computer science",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.210617,
+      "correct": true
+    },
+    {
+      "example_id": "fbc46398-9882-54d4-95eb-215ddf1857bb",
+      "category": "mmlu-pro-computer science",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.202029,
+      "correct": true
+    },
+    {
+      "example_id": "b3f4a62f-a237-5310-8c00-f291e00d3c3a",
+      "category": "mmlu-pro-computer science",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.327335,
+      "correct": false
+    },
+    {
+      "example_id": "09f91a0b-f769-56af-a191-3ed83f705504",
+      "category": "mmlu-pro-computer science",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.290253,
+      "correct": true
+    },
+    {
+      "example_id": "2c28d749-9b2f-572b-b7cd-5c27e0ad9d1f",
+      "category": "livebench-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.095075,
+      "correct": true
+    },
+    {
+      "example_id": "db5fe3cd-488b-5996-b494-768c2a8add72",
+      "category": "livebench-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.196724,
+      "correct": true
+    },
+    {
+      "example_id": "d1ac1dc9-a0cc-5378-8762-7807e505f7c7",
+      "category": "livebench-math",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.346172,
+      "correct": false
+    },
+    {
+      "example_id": "35abf0af-4d34-54d4-84e7-e9e4c313b886",
+      "category": "livebench-math",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.321837,
+      "correct": true
+    },
+    {
+      "example_id": "fb5bb37e-22b1-5b7c-b536-69410557f89a",
+      "category": "livebench-math",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.008016,
+      "correct": false
+    },
+    {
+      "example_id": "0f03ad86-bab9-5804-8b7d-e366a96e3ef6",
+      "category": "livebench-reasoning",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.121111,
+      "correct": false
+    },
+    {
+      "example_id": "8dddf27e-b2f5-532c-a23f-ac533ad229b2",
+      "category": "livebench-reasoning",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.290842,
+      "correct": true
+    },
+    {
+      "example_id": "0f60f2b6-3f29-5063-8477-5579e8b59654",
+      "category": "livebench-reasoning",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.238288,
+      "correct": true
+    },
+    {
+      "example_id": "236e4c79-ae79-5ce9-a24f-6111bb1d069a",
+      "category": "livebench-reasoning",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.005995,
+      "correct": true
+    },
+    {
+      "example_id": "03637a9a-7d80-5ecb-a1d0-d1f6cffc6879",
+      "category": "livebench-reasoning",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.141886,
+      "correct": true
+    },
+    {
+      "example_id": "b487ea88-7f61-585f-a2ff-4f335d30a12e",
+      "category": "livecodebench",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.09569,
+      "correct": false
+    },
+    {
+      "example_id": "86d3d9db-2af1-541c-8f8b-da2aef85c544",
+      "category": "livecodebench",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.032226,
+      "correct": false
+    },
+    {
+      "example_id": "5395119b-d8e5-52d3-a610-be760aee401a",
+      "category": "livecodebench",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.03698,
+      "correct": false
+    },
+    {
+      "example_id": "b29e3027-00b8-5e06-8b51-aeed1a2e4bdb",
+      "category": "livecodebench",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.095229,
+      "correct": false
+    },
+    {
+      "example_id": "904ccc1f-7d96-58a4-9c78-721feed676db",
+      "category": "livecodebench",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.106214,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/swebench_gemma_q6_n100_k3.json
+++ b/research/verifier-gt/swebench_gemma_q6_n100_k3.json
@@ -1,0 +1,832 @@
+{
+  "summary": {
+    "dataset": "swebench",
+    "model_name": "gemma-4-E4B-it-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 100,
+    "correct": 100,
+    "accuracy": 1.0,
+    "by_category": {
+      "15 min - 1 hour": {
+        "correct": 54,
+        "total": 54,
+        "accuracy": 1.0
+      },
+      "1-4 hours": {
+        "correct": 9,
+        "total": 9,
+        "accuracy": 1.0
+      },
+      "<15 min fix": {
+        "correct": 37,
+        "total": 37,
+        "accuracy": 1.0
+      }
+    },
+    "elapsed_seconds": 721.87
+  },
+  "per_example": [
+    {
+      "example_id": "astropy__astropy-12907",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.020615,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13033",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.952367,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13236",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.990817,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13398",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.032307,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13453",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.229299,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13579",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.917138,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13977",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.925003,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14096",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998171,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14182",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.535513,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14309",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998465,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14365",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999705,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14369",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.5936,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14508",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999776,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14539",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.993639,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14598",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.988136,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14995",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999416,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7166",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999258,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7336",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997368,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7606",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999727,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7671",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99879,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-8707",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.501989,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-8872",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.773896,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10097",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999889,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10554",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.510442,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10880",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999263,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10914",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999666,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10973",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999561,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10999",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.986128,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11066",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999926,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11087",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.46224,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11095",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.859785,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11099",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999943,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11119",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999817,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11133",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999865,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11138",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.514722,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11141",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.996504,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11149",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.562112,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11163",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999959,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11179",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99994,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11206",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999833,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11211",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.094865,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11239",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.587824,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11265",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.974084,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11276",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999399,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11292",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999511,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11299",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.430719,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11333",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998375,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11400",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.502087,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11433",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.966831,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11451",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999023,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11477",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.996086,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11490",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.53743,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11532",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.598077,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11551",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.53867,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11555",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998732,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11603",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999852,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11728",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999147,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11734",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.967558,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11740",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.82873,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11749",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997929,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11790",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999745,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11815",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.9982,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11820",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998866,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11848",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999121,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11880",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99995,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11885",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.675191,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11951",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999701,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11964",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.983303,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11999",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.987432,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12039",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998557,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12050",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.80838,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12125",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.774529,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12143",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999959,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12155",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.996436,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12193",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999812,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12209",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99965,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12262",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.992391,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12273",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.949673,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12276",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.994256,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12304",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.852933,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12308",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999522,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12325",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.987402,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12406",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.55679,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12419",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999866,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12663",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.268553,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12708",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997102,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12713",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997741,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12741",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.97297,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12754",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.546337,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12774",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999897,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12858",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.628947,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12965",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.450578,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13012",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.823783,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13023",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999567,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13028",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.980682,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13033",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.213452,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13089",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999834,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13109",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999707,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13112",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.983768,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13121",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.543508,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/swebench_qwen4b_n100_k3.json
+++ b/research/verifier-gt/swebench_qwen4b_n100_k3.json
@@ -1,0 +1,832 @@
+{
+  "summary": {
+    "dataset": "swebench",
+    "model_name": "Qwen3.5-4B-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 100,
+    "correct": 99,
+    "accuracy": 0.99,
+    "by_category": {
+      "15 min - 1 hour": {
+        "correct": 53,
+        "total": 54,
+        "accuracy": 0.9815
+      },
+      "1-4 hours": {
+        "correct": 9,
+        "total": 9,
+        "accuracy": 1.0
+      },
+      "<15 min fix": {
+        "correct": 37,
+        "total": 37,
+        "accuracy": 1.0
+      }
+    },
+    "elapsed_seconds": 623.85
+  },
+  "per_example": [
+    {
+      "example_id": "astropy__astropy-12907",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.06829,
+      "correct": false
+    },
+    {
+      "example_id": "astropy__astropy-13033",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.328173,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13236",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.353784,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13398",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.048274,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13453",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.079209,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13579",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.033913,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13977",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.16324,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14096",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.485554,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14182",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.284499,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14309",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.215034,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14365",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.259044,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14369",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.187421,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14508",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.2662,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14539",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.003814,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14598",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.315512,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14995",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.327333,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7166",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.317839,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7336",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.34155,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7606",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.217083,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7671",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.276682,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-8707",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.198632,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-8872",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.11056,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10097",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.417317,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10554",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.159195,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10880",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.386506,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10914",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.318248,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10973",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.195865,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-10999",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.132563,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11066",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.274373,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11087",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.160637,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11095",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.161736,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11099",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.410597,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11119",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.386251,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11133",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.383217,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11138",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.187662,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11141",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.276484,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11149",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.272027,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11163",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.297236,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11179",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.100352,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11206",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.207608,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11211",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.085953,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11239",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.348157,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11265",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.371595,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11276",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.1741,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11292",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.117791,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11299",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.281297,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11333",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.280071,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11400",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.202246,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11433",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.322856,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11451",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.437684,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11477",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.096084,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11490",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.020361,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11532",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.034447,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11551",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.138827,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11555",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.364008,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11603",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.478717,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11728",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.262124,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11734",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.325225,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11740",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.167294,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11749",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.357758,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11790",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.435944,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11815",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.623087,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11820",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.325327,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11848",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.502412,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11880",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.215806,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11885",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.183784,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11951",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.411101,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11964",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.424521,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-11999",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.483098,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12039",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.362073,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12050",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.116696,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12125",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.35454,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12143",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.31992,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12155",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.294281,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12193",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.382539,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12209",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.044144,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12262",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.352405,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12273",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.094952,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12276",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.166869,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12304",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.13752,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12308",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.283069,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12325",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.065061,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12406",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.258991,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12419",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.456548,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12663",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.173536,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12708",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.190141,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12713",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.379909,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12741",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.159559,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12754",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.236324,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12774",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.302067,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12858",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.233565,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-12965",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.017747,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13012",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.022356,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13023",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.44359,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13028",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.427595,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13033",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.054479,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13089",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.130869,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13109",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.256943,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13112",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.111702,
+      "correct": true
+    },
+    {
+      "example_id": "django__django-13121",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.347896,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/swebench_qwen4b_smoke.json
+++ b/research/verifier-gt/swebench_qwen4b_smoke.json
@@ -1,0 +1,192 @@
+{
+  "summary": {
+    "dataset": "swebench",
+    "model_name": "Qwen3.5-4B-UD-Q6_K_XL.gguf",
+    "limit": 20,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 20,
+    "correct": 18,
+    "accuracy": 0.9,
+    "by_category": {
+      "15 min - 1 hour": {
+        "correct": 11,
+        "total": 13,
+        "accuracy": 0.8462
+      },
+      "1-4 hours": {
+        "correct": 3,
+        "total": 3,
+        "accuracy": 1.0
+      },
+      "<15 min fix": {
+        "correct": 4,
+        "total": 4,
+        "accuracy": 1.0
+      }
+    },
+    "elapsed_seconds": 162.55
+  },
+  "per_example": [
+    {
+      "example_id": "astropy__astropy-12907",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.035942,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13033",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.189142,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13236",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.454006,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13398",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.056324,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13453",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.003021,
+      "correct": false
+    },
+    {
+      "example_id": "astropy__astropy-13579",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.018686,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-13977",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.25271,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14096",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.383555,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14182",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.300763,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14309",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.221175,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14365",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.304895,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14369",
+      "category": "1-4 hours",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.174436,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14508",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.342143,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14539",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.001926,
+      "correct": false
+    },
+    {
+      "example_id": "astropy__astropy-14598",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.294449,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-14995",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.336312,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7166",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.327874,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7336",
+      "category": "<15 min fix",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.381642,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7606",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.221211,
+      "correct": true
+    },
+    {
+      "example_id": "astropy__astropy-7671",
+      "category": "15 min - 1 hour",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.267398,
+      "correct": true
+    }
+  ]
+}

--- a/scripts/verifier-gt/benchmark_loaders.py
+++ b/scripts/verifier-gt/benchmark_loaders.py
@@ -101,40 +101,117 @@ def load_rewardbench(
 def load_judgebench(
     limit: Optional[int] = None,
     cache_dir: Optional[str] = None,
+    stratified: bool = False,
+    split: str = "all",
 ) -> Iterator[PairwiseExample]:
-    """Load JudgeBench (pending concrete HF dataset name verification)."""
+    """Load JudgeBench (ScalerLab/JudgeBench).
+
+    Schema: pair_id, question, response_A, response_B, label ("A>B" or "B>A"),
+            source (category), response_model.
+    Splits: 'claude' (350), 'gpt' (350), 'all' (700).
+    """
     if load_dataset is None:
         raise RuntimeError("datasets library not installed")
 
-    # JudgeBench canonical dataset: ScalerLab/JudgeBench (tentative)
-    ds = load_dataset("ScalerLab/JudgeBench", split="train", cache_dir=cache_dir)
+    splits = ["claude", "gpt"] if split == "all" else [split]
+    all_rows = []
+    for sp in splits:
+        ds = load_dataset("ScalerLab/JudgeBench", split=sp, cache_dir=cache_dir)
+        for row in ds:
+            all_rows.append({**row, "_split": sp})
 
-    count = 0
-    for row in ds:
-        # JudgeBench format may differ — normalize best-effort
-        prompt = row.get("question") or row.get("prompt") or ""
-        chosen = row.get("chosen") or row.get("response_A") or ""
-        rejected = row.get("rejected") or row.get("response_B") or ""
-
-        yield PairwiseExample(
-            example_id=str(row.get("id", count)),
-            prompt=prompt,
+    def convert(row, idx):
+        label = row.get("label", "A>B")
+        if label.startswith("A>"):
+            chosen, rejected = row["response_A"], row["response_B"]
+        else:
+            chosen, rejected = row["response_B"], row["response_A"]
+        return PairwiseExample(
+            example_id=str(row.get("pair_id", idx)),
+            prompt=row["question"],
             chosen=chosen,
             rejected=rejected,
-            category=row.get("category"),
-            metadata={"source": "judgebench"},
+            category=row.get("source"),
+            metadata={
+                "source": "judgebench",
+                "split": row["_split"],
+                "response_model": row.get("response_model"),
+                "original_label": label,
+            },
         )
-        count += 1
-        if limit is not None and count >= limit:
+
+    if stratified and limit:
+        from collections import defaultdict
+        by_subset = defaultdict(list)
+        for row in all_rows:
+            by_subset[row.get("source") or "unknown"].append(row)
+        n_subsets = len(by_subset)
+        per_subset = max(1, limit // n_subsets)
+        count = 0
+        for subset, rows in by_subset.items():
+            for idx, row in enumerate(rows[:per_subset]):
+                yield convert(row, f"{subset}-{idx}")
+                count += 1
+                if count >= limit:
+                    return
+        return
+
+    for idx, row in enumerate(all_rows):
+        yield convert(row, idx)
+        if limit is not None and idx + 1 >= limit:
             break
 
 
 # --- Registry ---
 
+def load_swebench(
+    limit: Optional[int] = None,
+    cache_dir: Optional[str] = None,
+    stratified: bool = False,
+) -> Iterator[PairwiseExample]:
+    """Load SWE-Bench Verified as distractor pairs.
+
+    Since SWE-Bench Verified has a single correct patch per issue, we
+    construct pairwise comparisons by using another issue's patch as the
+    distractor (rejected). The correct patch should be preferred because
+    it actually addresses the given problem.
+
+    Schema mapping:
+        prompt = problem_statement
+        chosen = own patch (correct)
+        rejected = another issue's patch (distractor)
+        category = difficulty bucket
+    """
+    if load_dataset is None:
+        raise RuntimeError("datasets library not installed")
+
+    ds = load_dataset("princeton-nlp/SWE-bench_Verified", split="test", cache_dir=cache_dir)
+    rows = list(ds)
+
+    n = len(rows)
+    for i, row in enumerate(rows):
+        # Distractor: use row ((i + n//2) % n) — deterministic, far from own
+        distractor = rows[(i + n // 2) % n]
+        yield PairwiseExample(
+            example_id=row["instance_id"],
+            prompt=row["problem_statement"],
+            chosen=row["patch"],
+            rejected=distractor["patch"],
+            category=row.get("difficulty") or "unknown",
+            metadata={
+                "source": "swebench-verified",
+                "repo": row.get("repo"),
+                "distractor_instance": distractor["instance_id"],
+            },
+        )
+        if limit is not None and i + 1 >= limit:
+            break
+
+
 LOADERS = {
     "rewardbench": load_rewardbench,
     "judgebench": load_judgebench,
-    # SS3 SWE-Bench, SA1 commit, SA2 lean — added in later phases
+    "swebench": load_swebench,
 }
 
 

--- a/scripts/verifier-gt/converter.py
+++ b/scripts/verifier-gt/converter.py
@@ -35,6 +35,17 @@ JUDGEBENCH_CRITERION = {
     ),
 }
 
+SWEBENCH_CRITERION = {
+    "id": "patch_relevance",
+    "name": "Patch Relevance",
+    "description": (
+        "Does this code patch address the given problem? A patch that modifies "
+        "the correct files and implements the described fix scores HIGH. "
+        "A patch that touches unrelated files, addresses a different issue, "
+        "or is missing the core fix scores LOW."
+    ),
+}
+
 # Multi-criteria decomposition (for RQ2 — decomposition effect)
 REWARDBENCH_CRITERIA_DECOMPOSED = [
     {
@@ -99,6 +110,8 @@ def convert_pairwise(
             criteria = [REWARDBENCH_CRITERION]
         elif source == "judgebench":
             criteria = [JUDGEBENCH_CRITERION]
+        elif source == "swebench-verified":
+            criteria = [SWEBENCH_CRITERION]
         else:
             criteria = [REWARDBENCH_CRITERION]  # default
 

--- a/scripts/verifier-gt/harness.py
+++ b/scripts/verifier-gt/harness.py
@@ -106,7 +106,7 @@ def evaluate(
     start = time.time()
 
     loader_kwargs = {"limit": limit}
-    if dataset == "rewardbench":
+    if dataset in ("rewardbench", "judgebench"):
         loader_kwargs["stratified"] = stratified
 
     for i, ex in enumerate(load(dataset, **loader_kwargs)):


### PR DESCRIPTION
## Summary

#618 Phase 2 Tier S 全項目完了 (SS1-SS3 全 benchmark 測定済み)。

## Results

| Benchmark | Qwen3.5-4B Q6 | Gemma-4-E4B Q6 |
|-----------|---------------|----------------|
| RewardBench (既 merged) | 82.6% | 83.7% |
| **JudgeBench** (n=85) | 55.3% | 69.4% |
| **SWE-Bench Verified** (n=100) | 99.0% | 100.0% |

## Infrastructure

- benchmark_loaders.py: JudgeBench + SWE-Bench Verified loader 追加
- converter.py: SWEBENCH_CRITERION 追加

## Test plan

- [x] test-all.sh 771/771 passed
- [x] P2 Verifier token written
- [x] 新規 benchmark は独立 loader として追加 (既存機能に影響なし)

## 参照

- Parent: #618
- SS2 JudgeBench: #621
- SS3 SWE-Bench: #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)