### PR TITLE
feat: Phase 4 完了 — Tier B benchmarks (#625 #627 #628 #629 #630) (#618)

### DIFF
--- a/research/verifier-gt/fever_gemma_q6_n100_k3.json
+++ b/research/verifier-gt/fever_gemma_q6_n100_k3.json
@@ -1,0 +1,824 @@
+{
+  "summary": {
+    "dataset": "fever",
+    "model_name": "gemma-4-E4B-it-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 99,
+    "correct": 98,
+    "accuracy": 0.989899,
+    "by_category": {
+      "REFUTES": {
+        "correct": 33,
+        "total": 33,
+        "accuracy": 1.0
+      },
+      "SUPPORTS": {
+        "correct": 33,
+        "total": 33,
+        "accuracy": 1.0
+      },
+      "NOT ENOUGH INFO": {
+        "correct": 32,
+        "total": 33,
+        "accuracy": 0.9697
+      }
+    },
+    "elapsed_seconds": 533.18
+  },
+  "per_example": [
+    {
+      "example_id": "e9a7305690bde211b7434ccd53b3a763",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.974496,
+      "correct": true
+    },
+    {
+      "example_id": "82caf51ce8a246f1b5244cc1fd8ca9d4",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997965,
+      "correct": true
+    },
+    {
+      "example_id": "377b91534e085b53efc2164d37fd1bc5",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.111221,
+      "correct": true
+    },
+    {
+      "example_id": "4e24bbf365def556b9b696dc3581df8a",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999328,
+      "correct": true
+    },
+    {
+      "example_id": "5c7e653c80d45b15031a1b43f5ec87d3",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999444,
+      "correct": true
+    },
+    {
+      "example_id": "fe75b78bccf0b5d5218818ff8599e5df",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.373906,
+      "correct": true
+    },
+    {
+      "example_id": "423dda4692393b44119f1ad6ce2369e3",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999174,
+      "correct": true
+    },
+    {
+      "example_id": "b8d7b254e312932dc34b0c1ff9ba2512",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.889573,
+      "correct": true
+    },
+    {
+      "example_id": "c961dc293849798e100ae369a788701a",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.113279,
+      "correct": true
+    },
+    {
+      "example_id": "133e8f865fdd9b870352e3088e4ca86c",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998339,
+      "correct": true
+    },
+    {
+      "example_id": "d94ec799f5e6457cab77e3cb8048c380",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.890885,
+      "correct": true
+    },
+    {
+      "example_id": "5097bb43f9f32c426fff2bd028570c59",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.992138,
+      "correct": true
+    },
+    {
+      "example_id": "2c7cc35290c8d5ba84f04e80f862ce01",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.038761,
+      "correct": true
+    },
+    {
+      "example_id": "e37c518766da14e37e2e6863defa8ce4",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.809168,
+      "correct": true
+    },
+    {
+      "example_id": "9afde7b6486570e461d93685e63751c7",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99958,
+      "correct": true
+    },
+    {
+      "example_id": "304d17d115090cc5c1c5eff4bf38306d",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.995215,
+      "correct": true
+    },
+    {
+      "example_id": "55511a7c60d8b264de2bf77af24c5c52",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.077417,
+      "correct": true
+    },
+    {
+      "example_id": "deabb21c85eeea8bce40668cf9201b25",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.639193,
+      "correct": true
+    },
+    {
+      "example_id": "68bff772ac3e6a9b24b36e3b2644e00a",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.187421,
+      "correct": true
+    },
+    {
+      "example_id": "d32ed589166c33fbdc656f34d3163863",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.043536,
+      "correct": true
+    },
+    {
+      "example_id": "e2db6232ec0bdeaaad71798e6a1cbe3a",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.628118,
+      "correct": true
+    },
+    {
+      "example_id": "1065feb7231a5e466fdf9d6969f003dc",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99499,
+      "correct": true
+    },
+    {
+      "example_id": "db69bf491ec7bb3f0b59a7961da2ad73",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.000343,
+      "correct": true
+    },
+    {
+      "example_id": "ac1ce39ba64ef545b91794680a307c83",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.990932,
+      "correct": true
+    },
+    {
+      "example_id": "0aa2ceb688c76fcc54b605efa6c37257",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.094058,
+      "correct": true
+    },
+    {
+      "example_id": "d0e99be704f02ac84c0d85a9937a32a2",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.198671,
+      "correct": true
+    },
+    {
+      "example_id": "58e8437d406e328b56ab3841823c3a2f",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999776,
+      "correct": true
+    },
+    {
+      "example_id": "f795541099098c3ea2fc43775a0bfb6a",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.996966,
+      "correct": true
+    },
+    {
+      "example_id": "a57dfb56ef805c6cd25d8a80b36ad02b",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.063325,
+      "correct": true
+    },
+    {
+      "example_id": "b2824dc61510b884d9b7f1c49a1e3133",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.222336,
+      "correct": true
+    },
+    {
+      "example_id": "b191bde87d745e012394f71befcfe806",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 8.2e-05,
+      "correct": true
+    },
+    {
+      "example_id": "97a0924efff3f510cb30789e15682a99",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99931,
+      "correct": true
+    },
+    {
+      "example_id": "b9b8492f716ec1616d219d786e364527",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.085767,
+      "correct": true
+    },
+    {
+      "example_id": "b8182754eb4410163c45b97ddb3b6de1",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999873,
+      "correct": true
+    },
+    {
+      "example_id": "75b69c74cd08062aeebb23326d6d9879",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999831,
+      "correct": true
+    },
+    {
+      "example_id": "56701244cd5e29e1fccaf69e54516549",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999473,
+      "correct": true
+    },
+    {
+      "example_id": "74bda06f7b2cd5eb5f59ec8cb6c713b2",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.913181,
+      "correct": true
+    },
+    {
+      "example_id": "25285a970841fe555d193995046eb7a2",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.985147,
+      "correct": true
+    },
+    {
+      "example_id": "e9c24bdf30640b809182e8a4a29f0458",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999769,
+      "correct": true
+    },
+    {
+      "example_id": "fbd3fbebeaed9c1ab5716c68b92a3e45",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.977143,
+      "correct": true
+    },
+    {
+      "example_id": "3aeeda3f29cb927e19d7b885efb90cc0",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999756,
+      "correct": true
+    },
+    {
+      "example_id": "c54ca9623d1faf64622629d5f3310ad0",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999408,
+      "correct": true
+    },
+    {
+      "example_id": "04a2b117a34c775d23a3a6986a7f4e76",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999861,
+      "correct": true
+    },
+    {
+      "example_id": "d2234c61916c84632803b1f1ecbe6a4e",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99986,
+      "correct": true
+    },
+    {
+      "example_id": "9b8a18711bdc52a491373376dfe79cc4",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999673,
+      "correct": true
+    },
+    {
+      "example_id": "bab914e1073698bdeb7d4f076cca9b49",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999736,
+      "correct": true
+    },
+    {
+      "example_id": "07bce330d02a3a552e8beeeb37335b5b",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999854,
+      "correct": true
+    },
+    {
+      "example_id": "1465858f408472d3fff75a8f6f0bc1b7",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999883,
+      "correct": true
+    },
+    {
+      "example_id": "55659ad094f28917ff9ddd66ff92b80a",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999829,
+      "correct": true
+    },
+    {
+      "example_id": "776c60e14509da84a9c1a4527d53e208",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999765,
+      "correct": true
+    },
+    {
+      "example_id": "7d58042699fd7fd37858c6f5d7f851e0",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.996955,
+      "correct": true
+    },
+    {
+      "example_id": "738035ea44ce6e2d2d539d5447c0daf4",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999877,
+      "correct": true
+    },
+    {
+      "example_id": "772606db420ef152b4c16aa9f1b659a9",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.996194,
+      "correct": true
+    },
+    {
+      "example_id": "f5ef0b89b1a7b6cb075ec38477826bd9",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999313,
+      "correct": true
+    },
+    {
+      "example_id": "d5db263920c7ab7fd213976fc03021a2",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999835,
+      "correct": true
+    },
+    {
+      "example_id": "012904176c127da03438ac3e91d736f2",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999128,
+      "correct": true
+    },
+    {
+      "example_id": "820fe520487c2e653069ed3c4009f625",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999407,
+      "correct": true
+    },
+    {
+      "example_id": "f78b0b65157635c4a8ffc3be4fac7279",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999286,
+      "correct": true
+    },
+    {
+      "example_id": "4fbc80c5784202df6072e373818c581f",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99959,
+      "correct": true
+    },
+    {
+      "example_id": "5e33a618bbdc93ef4b36463768d2023b",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999652,
+      "correct": true
+    },
+    {
+      "example_id": "1da9e8db12cf45cee20806629a501d60",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.995567,
+      "correct": true
+    },
+    {
+      "example_id": "4c2284e8a071787f9346bd4f23c38d99",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.888287,
+      "correct": true
+    },
+    {
+      "example_id": "eebf922f4a5086d0b853f3f725ba7fc0",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999598,
+      "correct": true
+    },
+    {
+      "example_id": "54c03f57096eec2c9f93ce897c1116e1",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.993303,
+      "correct": true
+    },
+    {
+      "example_id": "92378d9aa2d157ec43c44c1a94019b34",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999734,
+      "correct": true
+    },
+    {
+      "example_id": "026f7b6c2d891106b8248dae30dc9b16",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997539,
+      "correct": true
+    },
+    {
+      "example_id": "2ab70646fffa23b2c2546796d6d85fd3",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.990375,
+      "correct": true
+    },
+    {
+      "example_id": "95bcef60842dc24a2d9b18ae25020303",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.978927,
+      "correct": true
+    },
+    {
+      "example_id": "3391577ed5fef37c18007a09fb1272b0",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.987704,
+      "correct": true
+    },
+    {
+      "example_id": "f7db27d7659401d86e084398c41e6101",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.233019,
+      "correct": true
+    },
+    {
+      "example_id": "1a53b12e48b4d391f08abab5e7966083",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.593863,
+      "correct": true
+    },
+    {
+      "example_id": "6bf7275c5b0c60a05e425c179cb52ae6",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99662,
+      "correct": true
+    },
+    {
+      "example_id": "6a6edb21eba66433daa2b57e0e75c842",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.074842,
+      "correct": false
+    },
+    {
+      "example_id": "eaa070a35654fb179b4cbd5e4fbcfc74",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998808,
+      "correct": true
+    },
+    {
+      "example_id": "7e4821ee5a3c6edda6d4b4636f540dd1",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997977,
+      "correct": true
+    },
+    {
+      "example_id": "bc2935fd818894013f52caaf3f5923ad",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999799,
+      "correct": true
+    },
+    {
+      "example_id": "c2f0060cda87d2005a1f5f9e0557e27e",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998755,
+      "correct": true
+    },
+    {
+      "example_id": "c07e0d3807241c8f77304361b5431734",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.519932,
+      "correct": true
+    },
+    {
+      "example_id": "7992cdbfb84b09dc787c6543b9f66ab2",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.563354,
+      "correct": true
+    },
+    {
+      "example_id": "c1207a5fec25b9df9754199d83de028b",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.968077,
+      "correct": true
+    },
+    {
+      "example_id": "4d8194bb3537d46de0c187994c4e9fcf",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.965799,
+      "correct": true
+    },
+    {
+      "example_id": "e0f7dfb464f24cd7f61b9ef5efa3ef3c",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.842739,
+      "correct": true
+    },
+    {
+      "example_id": "a4412e4c43365390e3e6ee3663e373af",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.684652,
+      "correct": true
+    },
+    {
+      "example_id": "6bc50f081c33fe050cf45f9f8f744896",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 5.3e-05,
+      "correct": true
+    },
+    {
+      "example_id": "c1bc8f375841647c5521769ab8f8bf52",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.644349,
+      "correct": true
+    },
+    {
+      "example_id": "794bc1132aec65499f3e0b8153d7b7af",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.948411,
+      "correct": true
+    },
+    {
+      "example_id": "bdb41724209b6b5c94b29eeba1d6c3d1",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.863204,
+      "correct": true
+    },
+    {
+      "example_id": "312010ea0e5476981b438bd2ec507d22",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.996557,
+      "correct": true
+    },
+    {
+      "example_id": "49c4e86e1e0b1ee0e44cef00c7cab1a4",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.215276,
+      "correct": true
+    },
+    {
+      "example_id": "4eb28b2a0af18acab7c6f1b5bd112f91",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.068361,
+      "correct": true
+    },
+    {
+      "example_id": "061226b9ef121b39b371ab43193e6a6b",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.145873,
+      "correct": true
+    },
+    {
+      "example_id": "ed6deb12622cde1ce5e1e6bd0cddb4dc",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.75591,
+      "correct": true
+    },
+    {
+      "example_id": "9522d0c5e9e12ce99e06cb4cd2a9fde3",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 1.2e-05,
+      "correct": true
+    },
+    {
+      "example_id": "f10eb246976423f7adf5526acfa64038",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.00046,
+      "correct": true
+    },
+    {
+      "example_id": "4d1da40e229485b5d3aeb402333578ae",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.912262,
+      "correct": true
+    },
+    {
+      "example_id": "dad0c63c8dd2b69f81adab3b31967d9d",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.93716,
+      "correct": true
+    },
+    {
+      "example_id": "be45303261945279f17b1d81d95d40af",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999339,
+      "correct": true
+    },
+    {
+      "example_id": "8fc5fd2e4d6a7d8832962a7c730f7e89",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999521,
+      "correct": true
+    },
+    {
+      "example_id": "d8907857655086435a4098f550dea132",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.595163,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/fever_qwen4b_n100_k3.json
+++ b/research/verifier-gt/fever_qwen4b_n100_k3.json
@@ -1,0 +1,824 @@
+{
+  "summary": {
+    "dataset": "fever",
+    "model_name": "Qwen3.5-4B-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 99,
+    "correct": 95,
+    "accuracy": 0.959596,
+    "by_category": {
+      "REFUTES": {
+        "correct": 33,
+        "total": 33,
+        "accuracy": 1.0
+      },
+      "SUPPORTS": {
+        "correct": 33,
+        "total": 33,
+        "accuracy": 1.0
+      },
+      "NOT ENOUGH INFO": {
+        "correct": 29,
+        "total": 33,
+        "accuracy": 0.8788
+      }
+    },
+    "elapsed_seconds": 306.17
+  },
+  "per_example": [
+    {
+      "example_id": "e9a7305690bde211b7434ccd53b3a763",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.401428,
+      "correct": true
+    },
+    {
+      "example_id": "82caf51ce8a246f1b5244cc1fd8ca9d4",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.292786,
+      "correct": true
+    },
+    {
+      "example_id": "377b91534e085b53efc2164d37fd1bc5",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.423205,
+      "correct": true
+    },
+    {
+      "example_id": "4e24bbf365def556b9b696dc3581df8a",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.410865,
+      "correct": true
+    },
+    {
+      "example_id": "5c7e653c80d45b15031a1b43f5ec87d3",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.302387,
+      "correct": true
+    },
+    {
+      "example_id": "fe75b78bccf0b5d5218818ff8599e5df",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.101884,
+      "correct": true
+    },
+    {
+      "example_id": "423dda4692393b44119f1ad6ce2369e3",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.405903,
+      "correct": true
+    },
+    {
+      "example_id": "b8d7b254e312932dc34b0c1ff9ba2512",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.134781,
+      "correct": true
+    },
+    {
+      "example_id": "c961dc293849798e100ae369a788701a",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.020936,
+      "correct": true
+    },
+    {
+      "example_id": "133e8f865fdd9b870352e3088e4ca86c",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.158958,
+      "correct": true
+    },
+    {
+      "example_id": "d94ec799f5e6457cab77e3cb8048c380",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.355738,
+      "correct": true
+    },
+    {
+      "example_id": "5097bb43f9f32c426fff2bd028570c59",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.302276,
+      "correct": true
+    },
+    {
+      "example_id": "2c7cc35290c8d5ba84f04e80f862ce01",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.118495,
+      "correct": true
+    },
+    {
+      "example_id": "e37c518766da14e37e2e6863defa8ce4",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.233487,
+      "correct": true
+    },
+    {
+      "example_id": "9afde7b6486570e461d93685e63751c7",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.371789,
+      "correct": true
+    },
+    {
+      "example_id": "304d17d115090cc5c1c5eff4bf38306d",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.411007,
+      "correct": true
+    },
+    {
+      "example_id": "55511a7c60d8b264de2bf77af24c5c52",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.143092,
+      "correct": true
+    },
+    {
+      "example_id": "deabb21c85eeea8bce40668cf9201b25",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.19796,
+      "correct": true
+    },
+    {
+      "example_id": "68bff772ac3e6a9b24b36e3b2644e00a",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.031246,
+      "correct": true
+    },
+    {
+      "example_id": "d32ed589166c33fbdc656f34d3163863",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.02203,
+      "correct": true
+    },
+    {
+      "example_id": "e2db6232ec0bdeaaad71798e6a1cbe3a",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.159863,
+      "correct": true
+    },
+    {
+      "example_id": "1065feb7231a5e466fdf9d6969f003dc",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.379367,
+      "correct": true
+    },
+    {
+      "example_id": "db69bf491ec7bb3f0b59a7961da2ad73",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.008192,
+      "correct": true
+    },
+    {
+      "example_id": "ac1ce39ba64ef545b91794680a307c83",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.341471,
+      "correct": true
+    },
+    {
+      "example_id": "0aa2ceb688c76fcc54b605efa6c37257",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.031594,
+      "correct": true
+    },
+    {
+      "example_id": "d0e99be704f02ac84c0d85a9937a32a2",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.082003,
+      "correct": true
+    },
+    {
+      "example_id": "58e8437d406e328b56ab3841823c3a2f",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.332417,
+      "correct": true
+    },
+    {
+      "example_id": "f795541099098c3ea2fc43775a0bfb6a",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.249061,
+      "correct": true
+    },
+    {
+      "example_id": "a57dfb56ef805c6cd25d8a80b36ad02b",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.053754,
+      "correct": true
+    },
+    {
+      "example_id": "b2824dc61510b884d9b7f1c49a1e3133",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.143159,
+      "correct": true
+    },
+    {
+      "example_id": "b191bde87d745e012394f71befcfe806",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.011232,
+      "correct": true
+    },
+    {
+      "example_id": "97a0924efff3f510cb30789e15682a99",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.371886,
+      "correct": true
+    },
+    {
+      "example_id": "b9b8492f716ec1616d219d786e364527",
+      "category": "REFUTES",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.113451,
+      "correct": true
+    },
+    {
+      "example_id": "b8182754eb4410163c45b97ddb3b6de1",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.470316,
+      "correct": true
+    },
+    {
+      "example_id": "75b69c74cd08062aeebb23326d6d9879",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.348407,
+      "correct": true
+    },
+    {
+      "example_id": "56701244cd5e29e1fccaf69e54516549",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.370727,
+      "correct": true
+    },
+    {
+      "example_id": "74bda06f7b2cd5eb5f59ec8cb6c713b2",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.386772,
+      "correct": true
+    },
+    {
+      "example_id": "25285a970841fe555d193995046eb7a2",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.311624,
+      "correct": true
+    },
+    {
+      "example_id": "e9c24bdf30640b809182e8a4a29f0458",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.441165,
+      "correct": true
+    },
+    {
+      "example_id": "fbd3fbebeaed9c1ab5716c68b92a3e45",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.340043,
+      "correct": true
+    },
+    {
+      "example_id": "3aeeda3f29cb927e19d7b885efb90cc0",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.345174,
+      "correct": true
+    },
+    {
+      "example_id": "c54ca9623d1faf64622629d5f3310ad0",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.299317,
+      "correct": true
+    },
+    {
+      "example_id": "04a2b117a34c775d23a3a6986a7f4e76",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.450383,
+      "correct": true
+    },
+    {
+      "example_id": "d2234c61916c84632803b1f1ecbe6a4e",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.408482,
+      "correct": true
+    },
+    {
+      "example_id": "9b8a18711bdc52a491373376dfe79cc4",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.195199,
+      "correct": true
+    },
+    {
+      "example_id": "bab914e1073698bdeb7d4f076cca9b49",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.415382,
+      "correct": true
+    },
+    {
+      "example_id": "07bce330d02a3a552e8beeeb37335b5b",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.433532,
+      "correct": true
+    },
+    {
+      "example_id": "1465858f408472d3fff75a8f6f0bc1b7",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.427355,
+      "correct": true
+    },
+    {
+      "example_id": "55659ad094f28917ff9ddd66ff92b80a",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.480187,
+      "correct": true
+    },
+    {
+      "example_id": "776c60e14509da84a9c1a4527d53e208",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.367405,
+      "correct": true
+    },
+    {
+      "example_id": "7d58042699fd7fd37858c6f5d7f851e0",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.28868,
+      "correct": true
+    },
+    {
+      "example_id": "738035ea44ce6e2d2d539d5447c0daf4",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.289146,
+      "correct": true
+    },
+    {
+      "example_id": "772606db420ef152b4c16aa9f1b659a9",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.367311,
+      "correct": true
+    },
+    {
+      "example_id": "f5ef0b89b1a7b6cb075ec38477826bd9",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.305578,
+      "correct": true
+    },
+    {
+      "example_id": "d5db263920c7ab7fd213976fc03021a2",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.443039,
+      "correct": true
+    },
+    {
+      "example_id": "012904176c127da03438ac3e91d736f2",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.29652,
+      "correct": true
+    },
+    {
+      "example_id": "820fe520487c2e653069ed3c4009f625",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.325446,
+      "correct": true
+    },
+    {
+      "example_id": "f78b0b65157635c4a8ffc3be4fac7279",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.393733,
+      "correct": true
+    },
+    {
+      "example_id": "4fbc80c5784202df6072e373818c581f",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.440617,
+      "correct": true
+    },
+    {
+      "example_id": "5e33a618bbdc93ef4b36463768d2023b",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.416823,
+      "correct": true
+    },
+    {
+      "example_id": "1da9e8db12cf45cee20806629a501d60",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.415137,
+      "correct": true
+    },
+    {
+      "example_id": "4c2284e8a071787f9346bd4f23c38d99",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.271906,
+      "correct": true
+    },
+    {
+      "example_id": "eebf922f4a5086d0b853f3f725ba7fc0",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.355971,
+      "correct": true
+    },
+    {
+      "example_id": "54c03f57096eec2c9f93ce897c1116e1",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.290563,
+      "correct": true
+    },
+    {
+      "example_id": "92378d9aa2d157ec43c44c1a94019b34",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.398898,
+      "correct": true
+    },
+    {
+      "example_id": "026f7b6c2d891106b8248dae30dc9b16",
+      "category": "SUPPORTS",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.234369,
+      "correct": true
+    },
+    {
+      "example_id": "2ab70646fffa23b2c2546796d6d85fd3",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.150724,
+      "correct": true
+    },
+    {
+      "example_id": "95bcef60842dc24a2d9b18ae25020303",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.370692,
+      "correct": true
+    },
+    {
+      "example_id": "3391577ed5fef37c18007a09fb1272b0",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.066057,
+      "correct": true
+    },
+    {
+      "example_id": "f7db27d7659401d86e084398c41e6101",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.056099,
+      "correct": true
+    },
+    {
+      "example_id": "1a53b12e48b4d391f08abab5e7966083",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.062661,
+      "correct": true
+    },
+    {
+      "example_id": "6bf7275c5b0c60a05e425c179cb52ae6",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.322099,
+      "correct": true
+    },
+    {
+      "example_id": "6a6edb21eba66433daa2b57e0e75c842",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.005562,
+      "correct": false
+    },
+    {
+      "example_id": "eaa070a35654fb179b4cbd5e4fbcfc74",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.315072,
+      "correct": true
+    },
+    {
+      "example_id": "7e4821ee5a3c6edda6d4b4636f540dd1",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.283344,
+      "correct": true
+    },
+    {
+      "example_id": "bc2935fd818894013f52caaf3f5923ad",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.386269,
+      "correct": true
+    },
+    {
+      "example_id": "c2f0060cda87d2005a1f5f9e0557e27e",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.211411,
+      "correct": true
+    },
+    {
+      "example_id": "c07e0d3807241c8f77304361b5431734",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.190844,
+      "correct": true
+    },
+    {
+      "example_id": "7992cdbfb84b09dc787c6543b9f66ab2",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.01341,
+      "correct": true
+    },
+    {
+      "example_id": "c1207a5fec25b9df9754199d83de028b",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.11964,
+      "correct": true
+    },
+    {
+      "example_id": "4d8194bb3537d46de0c187994c4e9fcf",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.285606,
+      "correct": true
+    },
+    {
+      "example_id": "e0f7dfb464f24cd7f61b9ef5efa3ef3c",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.169233,
+      "correct": true
+    },
+    {
+      "example_id": "a4412e4c43365390e3e6ee3663e373af",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.145501,
+      "correct": true
+    },
+    {
+      "example_id": "6bc50f081c33fe050cf45f9f8f744896",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.05373,
+      "correct": false
+    },
+    {
+      "example_id": "c1bc8f375841647c5521769ab8f8bf52",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.033314,
+      "correct": false
+    },
+    {
+      "example_id": "794bc1132aec65499f3e0b8153d7b7af",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.011376,
+      "correct": false
+    },
+    {
+      "example_id": "bdb41724209b6b5c94b29eeba1d6c3d1",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.16091,
+      "correct": true
+    },
+    {
+      "example_id": "312010ea0e5476981b438bd2ec507d22",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.142684,
+      "correct": true
+    },
+    {
+      "example_id": "49c4e86e1e0b1ee0e44cef00c7cab1a4",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.032942,
+      "correct": true
+    },
+    {
+      "example_id": "4eb28b2a0af18acab7c6f1b5bd112f91",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.0763,
+      "correct": true
+    },
+    {
+      "example_id": "061226b9ef121b39b371ab43193e6a6b",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.023015,
+      "correct": true
+    },
+    {
+      "example_id": "ed6deb12622cde1ce5e1e6bd0cddb4dc",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.288838,
+      "correct": true
+    },
+    {
+      "example_id": "9522d0c5e9e12ce99e06cb4cd2a9fde3",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.012201,
+      "correct": true
+    },
+    {
+      "example_id": "f10eb246976423f7adf5526acfa64038",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.028609,
+      "correct": true
+    },
+    {
+      "example_id": "4d1da40e229485b5d3aeb402333578ae",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.374064,
+      "correct": true
+    },
+    {
+      "example_id": "dad0c63c8dd2b69f81adab3b31967d9d",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.236067,
+      "correct": true
+    },
+    {
+      "example_id": "be45303261945279f17b1d81d95d40af",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.314165,
+      "correct": true
+    },
+    {
+      "example_id": "8fc5fd2e4d6a7d8832962a7c730f7e89",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.36845,
+      "correct": true
+    },
+    {
+      "example_id": "d8907857655086435a4098f550dea132",
+      "category": "NOT ENOUGH INFO",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.133099,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/gsm8k_gemma_q6_n100_k3.json
+++ b/research/verifier-gt/gsm8k_gemma_q6_n100_k3.json
@@ -1,0 +1,822 @@
+{
+  "summary": {
+    "dataset": "gsm8k",
+    "model_name": "gemma-4-E4B-it-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 100,
+    "correct": 100,
+    "accuracy": 1.0,
+    "by_category": {
+      "gsm8k": {
+        "correct": 100,
+        "total": 100,
+        "accuracy": 1.0
+      }
+    },
+    "elapsed_seconds": 476.01
+  },
+  "per_example": [
+    {
+      "example_id": "0",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999843,
+      "correct": true
+    },
+    {
+      "example_id": "1",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.953941,
+      "correct": true
+    },
+    {
+      "example_id": "2",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999849,
+      "correct": true
+    },
+    {
+      "example_id": "3",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999135,
+      "correct": true
+    },
+    {
+      "example_id": "4",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999612,
+      "correct": true
+    },
+    {
+      "example_id": "5",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999658,
+      "correct": true
+    },
+    {
+      "example_id": "6",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999863,
+      "correct": true
+    },
+    {
+      "example_id": "7",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999815,
+      "correct": true
+    },
+    {
+      "example_id": "8",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999707,
+      "correct": true
+    },
+    {
+      "example_id": "9",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999895,
+      "correct": true
+    },
+    {
+      "example_id": "10",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999904,
+      "correct": true
+    },
+    {
+      "example_id": "11",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99958,
+      "correct": true
+    },
+    {
+      "example_id": "12",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999421,
+      "correct": true
+    },
+    {
+      "example_id": "13",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997954,
+      "correct": true
+    },
+    {
+      "example_id": "14",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999781,
+      "correct": true
+    },
+    {
+      "example_id": "15",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99988,
+      "correct": true
+    },
+    {
+      "example_id": "16",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.814044,
+      "correct": true
+    },
+    {
+      "example_id": "17",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999759,
+      "correct": true
+    },
+    {
+      "example_id": "18",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999785,
+      "correct": true
+    },
+    {
+      "example_id": "19",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999928,
+      "correct": true
+    },
+    {
+      "example_id": "20",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999466,
+      "correct": true
+    },
+    {
+      "example_id": "21",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999575,
+      "correct": true
+    },
+    {
+      "example_id": "22",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999211,
+      "correct": true
+    },
+    {
+      "example_id": "23",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999522,
+      "correct": true
+    },
+    {
+      "example_id": "24",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999575,
+      "correct": true
+    },
+    {
+      "example_id": "25",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999629,
+      "correct": true
+    },
+    {
+      "example_id": "26",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998881,
+      "correct": true
+    },
+    {
+      "example_id": "27",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999304,
+      "correct": true
+    },
+    {
+      "example_id": "28",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998942,
+      "correct": true
+    },
+    {
+      "example_id": "29",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999645,
+      "correct": true
+    },
+    {
+      "example_id": "30",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999759,
+      "correct": true
+    },
+    {
+      "example_id": "31",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999899,
+      "correct": true
+    },
+    {
+      "example_id": "32",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99941,
+      "correct": true
+    },
+    {
+      "example_id": "33",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99987,
+      "correct": true
+    },
+    {
+      "example_id": "34",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999841,
+      "correct": true
+    },
+    {
+      "example_id": "35",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997616,
+      "correct": true
+    },
+    {
+      "example_id": "36",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.865327,
+      "correct": true
+    },
+    {
+      "example_id": "37",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.828123,
+      "correct": true
+    },
+    {
+      "example_id": "38",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998469,
+      "correct": true
+    },
+    {
+      "example_id": "39",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999925,
+      "correct": true
+    },
+    {
+      "example_id": "40",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.979081,
+      "correct": true
+    },
+    {
+      "example_id": "41",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999834,
+      "correct": true
+    },
+    {
+      "example_id": "42",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999915,
+      "correct": true
+    },
+    {
+      "example_id": "43",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999835,
+      "correct": true
+    },
+    {
+      "example_id": "44",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999758,
+      "correct": true
+    },
+    {
+      "example_id": "45",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999915,
+      "correct": true
+    },
+    {
+      "example_id": "46",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999831,
+      "correct": true
+    },
+    {
+      "example_id": "47",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999705,
+      "correct": true
+    },
+    {
+      "example_id": "48",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999757,
+      "correct": true
+    },
+    {
+      "example_id": "49",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.9998,
+      "correct": true
+    },
+    {
+      "example_id": "50",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999864,
+      "correct": true
+    },
+    {
+      "example_id": "51",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999607,
+      "correct": true
+    },
+    {
+      "example_id": "52",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.995919,
+      "correct": true
+    },
+    {
+      "example_id": "53",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999938,
+      "correct": true
+    },
+    {
+      "example_id": "54",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999748,
+      "correct": true
+    },
+    {
+      "example_id": "55",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999816,
+      "correct": true
+    },
+    {
+      "example_id": "56",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999743,
+      "correct": true
+    },
+    {
+      "example_id": "57",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999802,
+      "correct": true
+    },
+    {
+      "example_id": "58",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998006,
+      "correct": true
+    },
+    {
+      "example_id": "59",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999612,
+      "correct": true
+    },
+    {
+      "example_id": "60",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.9992,
+      "correct": true
+    },
+    {
+      "example_id": "61",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998788,
+      "correct": true
+    },
+    {
+      "example_id": "62",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.974931,
+      "correct": true
+    },
+    {
+      "example_id": "63",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.996103,
+      "correct": true
+    },
+    {
+      "example_id": "64",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999627,
+      "correct": true
+    },
+    {
+      "example_id": "65",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999234,
+      "correct": true
+    },
+    {
+      "example_id": "66",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999871,
+      "correct": true
+    },
+    {
+      "example_id": "67",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999849,
+      "correct": true
+    },
+    {
+      "example_id": "68",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999891,
+      "correct": true
+    },
+    {
+      "example_id": "69",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999742,
+      "correct": true
+    },
+    {
+      "example_id": "70",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999731,
+      "correct": true
+    },
+    {
+      "example_id": "71",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999734,
+      "correct": true
+    },
+    {
+      "example_id": "72",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999592,
+      "correct": true
+    },
+    {
+      "example_id": "73",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999465,
+      "correct": true
+    },
+    {
+      "example_id": "74",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999767,
+      "correct": true
+    },
+    {
+      "example_id": "75",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999809,
+      "correct": true
+    },
+    {
+      "example_id": "76",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.995969,
+      "correct": true
+    },
+    {
+      "example_id": "77",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999366,
+      "correct": true
+    },
+    {
+      "example_id": "78",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999904,
+      "correct": true
+    },
+    {
+      "example_id": "79",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997939,
+      "correct": true
+    },
+    {
+      "example_id": "80",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999834,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999773,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999744,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999794,
+      "correct": true
+    },
+    {
+      "example_id": "84",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99761,
+      "correct": true
+    },
+    {
+      "example_id": "85",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999695,
+      "correct": true
+    },
+    {
+      "example_id": "86",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999854,
+      "correct": true
+    },
+    {
+      "example_id": "87",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998985,
+      "correct": true
+    },
+    {
+      "example_id": "88",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.994071,
+      "correct": true
+    },
+    {
+      "example_id": "89",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999473,
+      "correct": true
+    },
+    {
+      "example_id": "90",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999841,
+      "correct": true
+    },
+    {
+      "example_id": "91",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99984,
+      "correct": true
+    },
+    {
+      "example_id": "92",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999879,
+      "correct": true
+    },
+    {
+      "example_id": "93",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999525,
+      "correct": true
+    },
+    {
+      "example_id": "94",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999845,
+      "correct": true
+    },
+    {
+      "example_id": "95",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999918,
+      "correct": true
+    },
+    {
+      "example_id": "96",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999302,
+      "correct": true
+    },
+    {
+      "example_id": "97",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99986,
+      "correct": true
+    },
+    {
+      "example_id": "98",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.962743,
+      "correct": true
+    },
+    {
+      "example_id": "99",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999816,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/gsm8k_qwen4b_n100_k3.json
+++ b/research/verifier-gt/gsm8k_qwen4b_n100_k3.json
@@ -1,0 +1,822 @@
+{
+  "summary": {
+    "dataset": "gsm8k",
+    "model_name": "Qwen3.5-4B-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 100,
+    "correct": 100,
+    "accuracy": 1.0,
+    "by_category": {
+      "gsm8k": {
+        "correct": 100,
+        "total": 100,
+        "accuracy": 1.0
+      }
+    },
+    "elapsed_seconds": 398.73
+  },
+  "per_example": [
+    {
+      "example_id": "0",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.410996,
+      "correct": true
+    },
+    {
+      "example_id": "1",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.197754,
+      "correct": true
+    },
+    {
+      "example_id": "2",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.433422,
+      "correct": true
+    },
+    {
+      "example_id": "3",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.396161,
+      "correct": true
+    },
+    {
+      "example_id": "4",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.263448,
+      "correct": true
+    },
+    {
+      "example_id": "5",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.37666,
+      "correct": true
+    },
+    {
+      "example_id": "6",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.314241,
+      "correct": true
+    },
+    {
+      "example_id": "7",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.261988,
+      "correct": true
+    },
+    {
+      "example_id": "8",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.293654,
+      "correct": true
+    },
+    {
+      "example_id": "9",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.524093,
+      "correct": true
+    },
+    {
+      "example_id": "10",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.364604,
+      "correct": true
+    },
+    {
+      "example_id": "11",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.264969,
+      "correct": true
+    },
+    {
+      "example_id": "12",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.229078,
+      "correct": true
+    },
+    {
+      "example_id": "13",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.287345,
+      "correct": true
+    },
+    {
+      "example_id": "14",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.351804,
+      "correct": true
+    },
+    {
+      "example_id": "15",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.183726,
+      "correct": true
+    },
+    {
+      "example_id": "16",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.062327,
+      "correct": true
+    },
+    {
+      "example_id": "17",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.394796,
+      "correct": true
+    },
+    {
+      "example_id": "18",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.243098,
+      "correct": true
+    },
+    {
+      "example_id": "19",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.450373,
+      "correct": true
+    },
+    {
+      "example_id": "20",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.385241,
+      "correct": true
+    },
+    {
+      "example_id": "21",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.400683,
+      "correct": true
+    },
+    {
+      "example_id": "22",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.377481,
+      "correct": true
+    },
+    {
+      "example_id": "23",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.388316,
+      "correct": true
+    },
+    {
+      "example_id": "24",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.398025,
+      "correct": true
+    },
+    {
+      "example_id": "25",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.42862,
+      "correct": true
+    },
+    {
+      "example_id": "26",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.386237,
+      "correct": true
+    },
+    {
+      "example_id": "27",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.269227,
+      "correct": true
+    },
+    {
+      "example_id": "28",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.160342,
+      "correct": true
+    },
+    {
+      "example_id": "29",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.35938,
+      "correct": true
+    },
+    {
+      "example_id": "30",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.43226,
+      "correct": true
+    },
+    {
+      "example_id": "31",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.39521,
+      "correct": true
+    },
+    {
+      "example_id": "32",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.445431,
+      "correct": true
+    },
+    {
+      "example_id": "33",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.432461,
+      "correct": true
+    },
+    {
+      "example_id": "34",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.072756,
+      "correct": true
+    },
+    {
+      "example_id": "35",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.133448,
+      "correct": true
+    },
+    {
+      "example_id": "36",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.400198,
+      "correct": true
+    },
+    {
+      "example_id": "37",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.072342,
+      "correct": true
+    },
+    {
+      "example_id": "38",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.307832,
+      "correct": true
+    },
+    {
+      "example_id": "39",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.471023,
+      "correct": true
+    },
+    {
+      "example_id": "40",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.294313,
+      "correct": true
+    },
+    {
+      "example_id": "41",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.23086,
+      "correct": true
+    },
+    {
+      "example_id": "42",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.435565,
+      "correct": true
+    },
+    {
+      "example_id": "43",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.340199,
+      "correct": true
+    },
+    {
+      "example_id": "44",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.285041,
+      "correct": true
+    },
+    {
+      "example_id": "45",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.313031,
+      "correct": true
+    },
+    {
+      "example_id": "46",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.22598,
+      "correct": true
+    },
+    {
+      "example_id": "47",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.35039,
+      "correct": true
+    },
+    {
+      "example_id": "48",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.423548,
+      "correct": true
+    },
+    {
+      "example_id": "49",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.418269,
+      "correct": true
+    },
+    {
+      "example_id": "50",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.394655,
+      "correct": true
+    },
+    {
+      "example_id": "51",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.39424,
+      "correct": true
+    },
+    {
+      "example_id": "52",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.197989,
+      "correct": true
+    },
+    {
+      "example_id": "53",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.359795,
+      "correct": true
+    },
+    {
+      "example_id": "54",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.224931,
+      "correct": true
+    },
+    {
+      "example_id": "55",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.728955,
+      "correct": true
+    },
+    {
+      "example_id": "56",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.409194,
+      "correct": true
+    },
+    {
+      "example_id": "57",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.506623,
+      "correct": true
+    },
+    {
+      "example_id": "58",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.317666,
+      "correct": true
+    },
+    {
+      "example_id": "59",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.368569,
+      "correct": true
+    },
+    {
+      "example_id": "60",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.415898,
+      "correct": true
+    },
+    {
+      "example_id": "61",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.257942,
+      "correct": true
+    },
+    {
+      "example_id": "62",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.226579,
+      "correct": true
+    },
+    {
+      "example_id": "63",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.398395,
+      "correct": true
+    },
+    {
+      "example_id": "64",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.219754,
+      "correct": true
+    },
+    {
+      "example_id": "65",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.122181,
+      "correct": true
+    },
+    {
+      "example_id": "66",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.082657,
+      "correct": true
+    },
+    {
+      "example_id": "67",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.305373,
+      "correct": true
+    },
+    {
+      "example_id": "68",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.068628,
+      "correct": true
+    },
+    {
+      "example_id": "69",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.382969,
+      "correct": true
+    },
+    {
+      "example_id": "70",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.276604,
+      "correct": true
+    },
+    {
+      "example_id": "71",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.423565,
+      "correct": true
+    },
+    {
+      "example_id": "72",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.420878,
+      "correct": true
+    },
+    {
+      "example_id": "73",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.412623,
+      "correct": true
+    },
+    {
+      "example_id": "74",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.387858,
+      "correct": true
+    },
+    {
+      "example_id": "75",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.331785,
+      "correct": true
+    },
+    {
+      "example_id": "76",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.244362,
+      "correct": true
+    },
+    {
+      "example_id": "77",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.158971,
+      "correct": true
+    },
+    {
+      "example_id": "78",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.432862,
+      "correct": true
+    },
+    {
+      "example_id": "79",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.192827,
+      "correct": true
+    },
+    {
+      "example_id": "80",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.33191,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.363023,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.201336,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.457957,
+      "correct": true
+    },
+    {
+      "example_id": "84",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.570314,
+      "correct": true
+    },
+    {
+      "example_id": "85",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.298924,
+      "correct": true
+    },
+    {
+      "example_id": "86",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.420375,
+      "correct": true
+    },
+    {
+      "example_id": "87",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.27067,
+      "correct": true
+    },
+    {
+      "example_id": "88",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.553352,
+      "correct": true
+    },
+    {
+      "example_id": "89",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.331523,
+      "correct": true
+    },
+    {
+      "example_id": "90",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.384225,
+      "correct": true
+    },
+    {
+      "example_id": "91",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.5547,
+      "correct": true
+    },
+    {
+      "example_id": "92",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.365214,
+      "correct": true
+    },
+    {
+      "example_id": "93",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.455688,
+      "correct": true
+    },
+    {
+      "example_id": "94",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.280207,
+      "correct": true
+    },
+    {
+      "example_id": "95",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.3644,
+      "correct": true
+    },
+    {
+      "example_id": "96",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.392151,
+      "correct": true
+    },
+    {
+      "example_id": "97",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.393668,
+      "correct": true
+    },
+    {
+      "example_id": "98",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.086867,
+      "correct": true
+    },
+    {
+      "example_id": "99",
+      "category": "gsm8k",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.430302,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/humaneval_gemma_q6_n100_k3.json
+++ b/research/verifier-gt/humaneval_gemma_q6_n100_k3.json
@@ -1,0 +1,822 @@
+{
+  "summary": {
+    "dataset": "humaneval",
+    "model_name": "gemma-4-E4B-it-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 100,
+    "correct": 100,
+    "accuracy": 1.0,
+    "by_category": {
+      "HumanEval": {
+        "correct": 100,
+        "total": 100,
+        "accuracy": 1.0
+      }
+    },
+    "elapsed_seconds": 542.28
+  },
+  "per_example": [
+    {
+      "example_id": "HumanEval/0",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997999,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/1",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99843,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/2",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999603,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/3",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999903,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/4",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999582,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/5",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998883,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/6",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999409,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/7",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999856,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/8",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999802,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/9",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999452,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/10",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.956352,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/11",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999407,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/12",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999165,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/13",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999872,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/14",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999577,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/15",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999831,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/16",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999857,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/17",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999946,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/18",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.995959,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/19",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999315,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/20",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.935425,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/21",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999891,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/22",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999857,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/23",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999861,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/24",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999618,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/25",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999482,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/26",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998054,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/27",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999815,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/28",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999845,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/29",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999862,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/30",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999861,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/31",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.983829,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/32",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.621283,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/33",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999742,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/34",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.995412,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/35",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999222,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/36",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.984498,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/37",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.990174,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/38",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.070726,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/39",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.934067,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/40",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999777,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/41",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.494889,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/42",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999867,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/43",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999775,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/44",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999741,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/45",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999765,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/46",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998872,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/47",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999868,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/48",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999642,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/49",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998727,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/50",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99904,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/51",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998439,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/52",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999704,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/53",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999869,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/54",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999008,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/55",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999802,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/56",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999812,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/57",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998896,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/58",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999506,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/59",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.724293,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/60",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999462,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/61",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999781,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/62",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.704385,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/63",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999637,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/64",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.994117,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/65",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999676,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/66",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999926,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/67",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.994605,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/68",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.983487,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/69",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99839,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/70",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.971548,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/71",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999959,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/72",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999709,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/73",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999873,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/74",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999479,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/75",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.723384,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/76",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.984756,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/77",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.989668,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/78",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999927,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/79",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.9998,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/80",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999561,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/81",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999902,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/82",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999051,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/83",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.995312,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/84",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.709012,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/85",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.998747,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/86",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.985458,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/87",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997518,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/88",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999694,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/89",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997541,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/90",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999345,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/91",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.990185,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/92",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999595,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/93",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997048,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/94",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.99841,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/95",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.90893,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/96",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.997724,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/97",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999521,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/98",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999225,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/99",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.46091,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/humaneval_qwen4b_n100_k3.json
+++ b/research/verifier-gt/humaneval_qwen4b_n100_k3.json
@@ -1,0 +1,822 @@
+{
+  "summary": {
+    "dataset": "humaneval",
+    "model_name": "Qwen3.5-4B-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 100,
+    "correct": 95,
+    "accuracy": 0.95,
+    "by_category": {
+      "HumanEval": {
+        "correct": 95,
+        "total": 100,
+        "accuracy": 0.95
+      }
+    },
+    "elapsed_seconds": 349.2
+  },
+  "per_example": [
+    {
+      "example_id": "HumanEval/0",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.040714,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/1",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.081558,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/2",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.340373,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/3",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.437213,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/4",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.405315,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/5",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.230837,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/6",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.579821,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/7",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.418939,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/8",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.41186,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/9",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.446964,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/10",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.029118,
+      "correct": false
+    },
+    {
+      "example_id": "HumanEval/11",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.400081,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/12",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.451442,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/13",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.286006,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/14",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.353243,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/15",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.336533,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/16",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.379619,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/17",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.003823,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/18",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.332087,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/19",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.148757,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/20",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.046296,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/21",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.42624,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/22",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.462039,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/23",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.447912,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/24",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.024014,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/25",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.170659,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/26",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.443728,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/27",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.432899,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/28",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.424576,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/29",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.49833,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/30",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.436271,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/31",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.136937,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/32",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.018507,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/33",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.311058,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/34",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.338576,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/35",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.077582,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/36",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.01843,
+      "correct": false
+    },
+    {
+      "example_id": "HumanEval/37",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.028014,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/38",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.009144,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/39",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.027731,
+      "correct": false
+    },
+    {
+      "example_id": "HumanEval/40",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.192258,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/41",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.057486,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/42",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.26807,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/43",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.295438,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/44",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.144567,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/45",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.35449,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/46",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.135913,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/47",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.033075,
+      "correct": false
+    },
+    {
+      "example_id": "HumanEval/48",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.216391,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/49",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.21417,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/50",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.086648,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/51",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.318565,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/52",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.403011,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/53",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.298496,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/54",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.121433,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/55",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.221201,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/56",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.392473,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/57",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.270637,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/58",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.104627,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/59",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.069657,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/60",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.127308,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/61",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.340201,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/62",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.043,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/63",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.192319,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/64",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.017713,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/65",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.341434,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/66",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.493119,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/67",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.047503,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/68",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.027047,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/69",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.355465,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/70",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.084624,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/71",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.13071,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/72",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.340373,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/73",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.127268,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/74",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.086979,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/75",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.105307,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/76",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.069845,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/77",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.268667,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/78",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.070743,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/79",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.400219,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/80",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.438304,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/81",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.335284,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/82",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.174685,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/83",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.015224,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/84",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.236365,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/85",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.419624,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/86",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.125956,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/87",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.051881,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/88",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.004293,
+      "correct": false
+    },
+    {
+      "example_id": "HumanEval/89",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.178542,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/90",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.168612,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/91",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.08816,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/92",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.161826,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/93",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.063875,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/94",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.304529,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/95",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.082618,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/96",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.094867,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/97",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.261327,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/98",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.358086,
+      "correct": true
+    },
+    {
+      "example_id": "HumanEval/99",
+      "category": "HumanEval",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.034101,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/mt_bench_gemma_q6_n100_k3.json
+++ b/research/verifier-gt/mt_bench_gemma_q6_n100_k3.json
@@ -1,0 +1,827 @@
+{
+  "summary": {
+    "dataset": "mt-bench",
+    "model_name": "gemma-4-E4B-it-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 100,
+    "correct": 71,
+    "accuracy": 0.71,
+    "by_category": {
+      "1": {
+        "correct": 32,
+        "total": 50,
+        "accuracy": 0.64
+      },
+      "2": {
+        "correct": 39,
+        "total": 50,
+        "accuracy": 0.78
+      }
+    },
+    "elapsed_seconds": 340.13
+  },
+  "per_example": [
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.499925,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.489025,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.459455,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.59312,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.522817,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.48896,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.489018,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.689558,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.689583,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.246427,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.594677,
+      "correct": false
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.592457,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.091649,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.181191,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.178692,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.215377,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.186472,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.18637,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.0842,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.091635,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.372986,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.275079,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.258359,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.241082,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.075258,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.075276,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.056383,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.175191,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.186572,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.186572,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.294137,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.655677,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.655697,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.655731,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.200041,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.079682,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.294139,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.220626,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.279662,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.148664,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999561,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.148428,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.207853,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.218399,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.185167,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.185067,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.011053,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999183,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999436,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.499925,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.49998,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.59312,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.488943,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.510879,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.177154,
+      "correct": false
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.137525,
+      "correct": false
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.689544,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.689518,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.246858,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.582357,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.090716,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.18561,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.181191,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.165404,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.215363,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.175301,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.18637,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.0842,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.215325,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.372983,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.259546,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.232206,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.269172,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.086679,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.05198,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.066173,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.186472,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.1753,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.175099,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.294142,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.655676,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.655717,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.655725,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.200041,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.065869,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.294142,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.213404,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.279636,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.134014,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.999561,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.149114,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.208139,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.218646,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.218635,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.165647,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999436,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.0142,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.01164,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/mt_bench_qwen4b_n100_k3.json
+++ b/research/verifier-gt/mt_bench_qwen4b_n100_k3.json
@@ -1,0 +1,827 @@
+{
+  "summary": {
+    "dataset": "mt-bench",
+    "model_name": "Qwen3.5-4B-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 100,
+    "correct": 70,
+    "accuracy": 0.7,
+    "by_category": {
+      "1": {
+        "correct": 31,
+        "total": 50,
+        "accuracy": 0.62
+      },
+      "2": {
+        "correct": 39,
+        "total": 50,
+        "accuracy": 0.78
+      }
+    },
+    "elapsed_seconds": 282.83
+  },
+  "per_example": [
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.050028,
+      "correct": false
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.023221,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.121664,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.061053,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.226984,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.043483,
+      "correct": false
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.034732,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.189815,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.19292,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.127681,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.107992,
+      "correct": false
+    },
+    {
+      "example_id": "81",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.227019,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.178416,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.032756,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.253287,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.24947,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.190409,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.012394,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.13896,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.174841,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.249093,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.224745,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.199098,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.181008,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.096613,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.220337,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.087411,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.053057,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.077169,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.020188,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.134239,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.101536,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.186845,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.20951,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.277163,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.136227,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.108853,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.216156,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.100248,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.142466,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.419815,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.003284,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.240976,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.222789,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.230184,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.223549,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.005049,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.391051,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.342942,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 1,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.438566,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.231681,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.130691,
+      "correct": false
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.140209,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.196758,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.027223,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.17637,
+      "correct": false
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.061287,
+      "correct": false
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.206217,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.312688,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.137854,
+      "correct": true
+    },
+    {
+      "example_id": "81",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.106128,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.146736,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.163318,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.093415,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.351224,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.120804,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.090746,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.001467,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.133705,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.252783,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.028582,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.173333,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.239657,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.155517,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.020457,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.120271,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.138974,
+      "correct": false
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.014643,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.026098,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.03455,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.069025,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.215068,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.101408,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.261535,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.263648,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.015838,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.077192,
+      "correct": true
+    },
+    {
+      "example_id": "82",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.174513,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.065284,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.01645,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.406579,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.107769,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.151547,
+      "correct": false
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.248345,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.24729,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.278964,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.405108,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.378114,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.066867,
+      "correct": true
+    },
+    {
+      "example_id": "83",
+      "category": 2,
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.158216,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/ultrafeedback_gemma_q6_n100_k3.json
+++ b/research/verifier-gt/ultrafeedback_gemma_q6_n100_k3.json
@@ -1,0 +1,854 @@
+{
+  "summary": {
+    "dataset": "ultrafeedback",
+    "model_name": "gemma-4-E4B-it-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 99,
+    "correct": 82,
+    "accuracy": 0.828283,
+    "by_category": {
+      "evol_instruct": {
+        "correct": 11,
+        "total": 11,
+        "accuracy": 1.0
+      },
+      "false_qa": {
+        "correct": 7,
+        "total": 11,
+        "accuracy": 0.6364
+      },
+      "flan_v2_cot": {
+        "correct": 10,
+        "total": 11,
+        "accuracy": 0.9091
+      },
+      "flan_v2_flan2021": {
+        "correct": 8,
+        "total": 11,
+        "accuracy": 0.7273
+      },
+      "flan_v2_niv2": {
+        "correct": 9,
+        "total": 11,
+        "accuracy": 0.8182
+      },
+      "flan_v2_p3": {
+        "correct": 10,
+        "total": 11,
+        "accuracy": 0.9091
+      },
+      "sharegpt": {
+        "correct": 9,
+        "total": 11,
+        "accuracy": 0.8182
+      },
+      "truthful_qa": {
+        "correct": 9,
+        "total": 11,
+        "accuracy": 0.8182
+      },
+      "ultrachat": {
+        "correct": 9,
+        "total": 11,
+        "accuracy": 0.8182
+      }
+    },
+    "elapsed_seconds": 507.96
+  },
+  "per_example": [
+    {
+      "example_id": "0",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.999069,
+      "correct": true
+    },
+    {
+      "example_id": "1",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.28029,
+      "correct": true
+    },
+    {
+      "example_id": "2",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.101459,
+      "correct": true
+    },
+    {
+      "example_id": "3",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.18754,
+      "correct": true
+    },
+    {
+      "example_id": "4",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.50247,
+      "correct": true
+    },
+    {
+      "example_id": "5",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.500833,
+      "correct": true
+    },
+    {
+      "example_id": "6",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.122424,
+      "correct": true
+    },
+    {
+      "example_id": "7",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.373727,
+      "correct": true
+    },
+    {
+      "example_id": "8",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.618022,
+      "correct": true
+    },
+    {
+      "example_id": "9",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.08845,
+      "correct": true
+    },
+    {
+      "example_id": "10",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.092962,
+      "correct": true
+    },
+    {
+      "example_id": "9934",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.794644,
+      "correct": true
+    },
+    {
+      "example_id": "9935",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.776788,
+      "correct": true
+    },
+    {
+      "example_id": "9936",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.055494,
+      "correct": true
+    },
+    {
+      "example_id": "9937",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.284664,
+      "correct": true
+    },
+    {
+      "example_id": "9938",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.038875,
+      "correct": false
+    },
+    {
+      "example_id": "9939",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.844083,
+      "correct": true
+    },
+    {
+      "example_id": "9940",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.324856,
+      "correct": true
+    },
+    {
+      "example_id": "9941",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.163733,
+      "correct": false
+    },
+    {
+      "example_id": "9942",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.108736,
+      "correct": false
+    },
+    {
+      "example_id": "9943",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.028895,
+      "correct": true
+    },
+    {
+      "example_id": "9944",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.342922,
+      "correct": false
+    },
+    {
+      "example_id": "12260",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.022556,
+      "correct": false
+    },
+    {
+      "example_id": "12261",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.707695,
+      "correct": true
+    },
+    {
+      "example_id": "12262",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.025226,
+      "correct": true
+    },
+    {
+      "example_id": "12263",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.9206,
+      "correct": true
+    },
+    {
+      "example_id": "12264",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.284384,
+      "correct": true
+    },
+    {
+      "example_id": "12265",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.800936,
+      "correct": true
+    },
+    {
+      "example_id": "12266",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.301961,
+      "correct": true
+    },
+    {
+      "example_id": "12267",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.103734,
+      "correct": true
+    },
+    {
+      "example_id": "12268",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.390769,
+      "correct": true
+    },
+    {
+      "example_id": "12269",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.25155,
+      "correct": true
+    },
+    {
+      "example_id": "12270",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.548312,
+      "correct": true
+    },
+    {
+      "example_id": "15250",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.154305,
+      "correct": false
+    },
+    {
+      "example_id": "15251",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.112955,
+      "correct": false
+    },
+    {
+      "example_id": "15252",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.002016,
+      "correct": false
+    },
+    {
+      "example_id": "15253",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.79548,
+      "correct": true
+    },
+    {
+      "example_id": "15254",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.967334,
+      "correct": true
+    },
+    {
+      "example_id": "15255",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.0421,
+      "correct": true
+    },
+    {
+      "example_id": "15256",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.463609,
+      "correct": true
+    },
+    {
+      "example_id": "15257",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.54239,
+      "correct": true
+    },
+    {
+      "example_id": "15258",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.671824,
+      "correct": true
+    },
+    {
+      "example_id": "15259",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.672847,
+      "correct": true
+    },
+    {
+      "example_id": "15260",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.623912,
+      "correct": true
+    },
+    {
+      "example_id": "15749",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.480836,
+      "correct": true
+    },
+    {
+      "example_id": "15750",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.306893,
+      "correct": true
+    },
+    {
+      "example_id": "15751",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.006763,
+      "correct": true
+    },
+    {
+      "example_id": "15752",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.372267,
+      "correct": true
+    },
+    {
+      "example_id": "15753",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.516934,
+      "correct": false
+    },
+    {
+      "example_id": "15754",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.09911,
+      "correct": true
+    },
+    {
+      "example_id": "15755",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.1325,
+      "correct": false
+    },
+    {
+      "example_id": "15756",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.957161,
+      "correct": true
+    },
+    {
+      "example_id": "15757",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.265036,
+      "correct": true
+    },
+    {
+      "example_id": "15758",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.813735,
+      "correct": true
+    },
+    {
+      "example_id": "15759",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.925997,
+      "correct": true
+    },
+    {
+      "example_id": "31211",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.595029,
+      "correct": true
+    },
+    {
+      "example_id": "31212",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.742063,
+      "correct": true
+    },
+    {
+      "example_id": "31213",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.000511,
+      "correct": true
+    },
+    {
+      "example_id": "31214",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.15601,
+      "correct": true
+    },
+    {
+      "example_id": "31215",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.349268,
+      "correct": true
+    },
+    {
+      "example_id": "31216",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.184841,
+      "correct": true
+    },
+    {
+      "example_id": "31217",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.605034,
+      "correct": true
+    },
+    {
+      "example_id": "31218",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.961057,
+      "correct": true
+    },
+    {
+      "example_id": "31219",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.184392,
+      "correct": true
+    },
+    {
+      "example_id": "31220",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.699964,
+      "correct": false
+    },
+    {
+      "example_id": "31221",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.627325,
+      "correct": true
+    },
+    {
+      "example_id": "33121",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.805722,
+      "correct": true
+    },
+    {
+      "example_id": "33122",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.891769,
+      "correct": true
+    },
+    {
+      "example_id": "33123",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.89537,
+      "correct": true
+    },
+    {
+      "example_id": "33124",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.196492,
+      "correct": true
+    },
+    {
+      "example_id": "33125",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.176346,
+      "correct": false
+    },
+    {
+      "example_id": "33126",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.067959,
+      "correct": true
+    },
+    {
+      "example_id": "33127",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.050887,
+      "correct": true
+    },
+    {
+      "example_id": "33128",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.835422,
+      "correct": true
+    },
+    {
+      "example_id": "33129",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.26032,
+      "correct": true
+    },
+    {
+      "example_id": "33130",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.122668,
+      "correct": false
+    },
+    {
+      "example_id": "33131",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.045453,
+      "correct": true
+    },
+    {
+      "example_id": "52941",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.199119,
+      "correct": true
+    },
+    {
+      "example_id": "52942",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.184308,
+      "correct": true
+    },
+    {
+      "example_id": "52943",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.183293,
+      "correct": true
+    },
+    {
+      "example_id": "52944",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.247266,
+      "correct": false
+    },
+    {
+      "example_id": "52945",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.052037,
+      "correct": true
+    },
+    {
+      "example_id": "52946",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.668064,
+      "correct": true
+    },
+    {
+      "example_id": "52947",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.164769,
+      "correct": false
+    },
+    {
+      "example_id": "52948",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.13628,
+      "correct": true
+    },
+    {
+      "example_id": "52949",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.737138,
+      "correct": true
+    },
+    {
+      "example_id": "52950",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.228373,
+      "correct": true
+    },
+    {
+      "example_id": "52951",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.152438,
+      "correct": true
+    },
+    {
+      "example_id": "53749",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.27716,
+      "correct": true
+    },
+    {
+      "example_id": "53750",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.974172,
+      "correct": true
+    },
+    {
+      "example_id": "53751",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.033738,
+      "correct": false
+    },
+    {
+      "example_id": "53752",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.164361,
+      "correct": false
+    },
+    {
+      "example_id": "53753",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.243889,
+      "correct": true
+    },
+    {
+      "example_id": "53754",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.777222,
+      "correct": true
+    },
+    {
+      "example_id": "53755",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.260082,
+      "correct": true
+    },
+    {
+      "example_id": "53756",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.026778,
+      "correct": true
+    },
+    {
+      "example_id": "53757",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.171574,
+      "correct": true
+    },
+    {
+      "example_id": "53758",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.469595,
+      "correct": true
+    },
+    {
+      "example_id": "53759",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.425921,
+      "correct": true
+    }
+  ]
+}

--- a/research/verifier-gt/ultrafeedback_qwen4b_n100_k3.json
+++ b/research/verifier-gt/ultrafeedback_qwen4b_n100_k3.json
@@ -1,0 +1,854 @@
+{
+  "summary": {
+    "dataset": "ultrafeedback",
+    "model_name": "Qwen3.5-4B-UD-Q6_K_XL.gguf",
+    "limit": 100,
+    "k_rounds": 3,
+    "bidirectional": true,
+    "total": 99,
+    "correct": 75,
+    "accuracy": 0.757576,
+    "by_category": {
+      "evol_instruct": {
+        "correct": 8,
+        "total": 11,
+        "accuracy": 0.7273
+      },
+      "false_qa": {
+        "correct": 8,
+        "total": 11,
+        "accuracy": 0.7273
+      },
+      "flan_v2_cot": {
+        "correct": 7,
+        "total": 11,
+        "accuracy": 0.6364
+      },
+      "flan_v2_flan2021": {
+        "correct": 7,
+        "total": 11,
+        "accuracy": 0.6364
+      },
+      "flan_v2_niv2": {
+        "correct": 9,
+        "total": 11,
+        "accuracy": 0.8182
+      },
+      "flan_v2_p3": {
+        "correct": 11,
+        "total": 11,
+        "accuracy": 1.0
+      },
+      "sharegpt": {
+        "correct": 9,
+        "total": 11,
+        "accuracy": 0.8182
+      },
+      "truthful_qa": {
+        "correct": 8,
+        "total": 11,
+        "accuracy": 0.7273
+      },
+      "ultrachat": {
+        "correct": 8,
+        "total": 11,
+        "accuracy": 0.7273
+      }
+    },
+    "elapsed_seconds": 419.35
+  },
+  "per_example": [
+    {
+      "example_id": "0",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.224569,
+      "correct": true
+    },
+    {
+      "example_id": "1",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.243337,
+      "correct": true
+    },
+    {
+      "example_id": "2",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.03827,
+      "correct": false
+    },
+    {
+      "example_id": "3",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.369403,
+      "correct": true
+    },
+    {
+      "example_id": "4",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.142175,
+      "correct": true
+    },
+    {
+      "example_id": "5",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.307859,
+      "correct": false
+    },
+    {
+      "example_id": "6",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.159715,
+      "correct": true
+    },
+    {
+      "example_id": "7",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.031011,
+      "correct": false
+    },
+    {
+      "example_id": "8",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.166124,
+      "correct": true
+    },
+    {
+      "example_id": "9",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.160608,
+      "correct": true
+    },
+    {
+      "example_id": "10",
+      "category": "evol_instruct",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.04151,
+      "correct": true
+    },
+    {
+      "example_id": "9934",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.400432,
+      "correct": true
+    },
+    {
+      "example_id": "9935",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.333389,
+      "correct": true
+    },
+    {
+      "example_id": "9936",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.143115,
+      "correct": true
+    },
+    {
+      "example_id": "9937",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.329489,
+      "correct": true
+    },
+    {
+      "example_id": "9938",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.305193,
+      "correct": true
+    },
+    {
+      "example_id": "9939",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.323448,
+      "correct": true
+    },
+    {
+      "example_id": "9940",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.205161,
+      "correct": true
+    },
+    {
+      "example_id": "9941",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.198251,
+      "correct": false
+    },
+    {
+      "example_id": "9942",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.306605,
+      "correct": false
+    },
+    {
+      "example_id": "9943",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.071795,
+      "correct": true
+    },
+    {
+      "example_id": "9944",
+      "category": "false_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.002203,
+      "correct": false
+    },
+    {
+      "example_id": "12260",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.16894,
+      "correct": true
+    },
+    {
+      "example_id": "12261",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.39685,
+      "correct": true
+    },
+    {
+      "example_id": "12262",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.125358,
+      "correct": false
+    },
+    {
+      "example_id": "12263",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.394744,
+      "correct": true
+    },
+    {
+      "example_id": "12264",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.007632,
+      "correct": false
+    },
+    {
+      "example_id": "12265",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.131725,
+      "correct": true
+    },
+    {
+      "example_id": "12266",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.309551,
+      "correct": true
+    },
+    {
+      "example_id": "12267",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.156604,
+      "correct": true
+    },
+    {
+      "example_id": "12268",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.136933,
+      "correct": false
+    },
+    {
+      "example_id": "12269",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.447533,
+      "correct": true
+    },
+    {
+      "example_id": "12270",
+      "category": "flan_v2_cot",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.327484,
+      "correct": false
+    },
+    {
+      "example_id": "15250",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.107994,
+      "correct": true
+    },
+    {
+      "example_id": "15251",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.29784,
+      "correct": false
+    },
+    {
+      "example_id": "15252",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.062609,
+      "correct": false
+    },
+    {
+      "example_id": "15253",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.07568,
+      "correct": true
+    },
+    {
+      "example_id": "15254",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.391921,
+      "correct": true
+    },
+    {
+      "example_id": "15255",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.280633,
+      "correct": false
+    },
+    {
+      "example_id": "15256",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.239925,
+      "correct": false
+    },
+    {
+      "example_id": "15257",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.13563,
+      "correct": true
+    },
+    {
+      "example_id": "15258",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.229405,
+      "correct": true
+    },
+    {
+      "example_id": "15259",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.089903,
+      "correct": true
+    },
+    {
+      "example_id": "15260",
+      "category": "flan_v2_flan2021",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.219186,
+      "correct": true
+    },
+    {
+      "example_id": "15749",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.011441,
+      "correct": true
+    },
+    {
+      "example_id": "15750",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.101516,
+      "correct": true
+    },
+    {
+      "example_id": "15751",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.220964,
+      "correct": true
+    },
+    {
+      "example_id": "15752",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.214925,
+      "correct": true
+    },
+    {
+      "example_id": "15753",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.15763,
+      "correct": false
+    },
+    {
+      "example_id": "15754",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.126781,
+      "correct": true
+    },
+    {
+      "example_id": "15755",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.244545,
+      "correct": false
+    },
+    {
+      "example_id": "15756",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.275717,
+      "correct": true
+    },
+    {
+      "example_id": "15757",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.162066,
+      "correct": true
+    },
+    {
+      "example_id": "15758",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.336179,
+      "correct": true
+    },
+    {
+      "example_id": "15759",
+      "category": "flan_v2_niv2",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.060576,
+      "correct": true
+    },
+    {
+      "example_id": "31211",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.363957,
+      "correct": true
+    },
+    {
+      "example_id": "31212",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.298738,
+      "correct": true
+    },
+    {
+      "example_id": "31213",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.361453,
+      "correct": true
+    },
+    {
+      "example_id": "31214",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.213133,
+      "correct": true
+    },
+    {
+      "example_id": "31215",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.208548,
+      "correct": true
+    },
+    {
+      "example_id": "31216",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.015266,
+      "correct": true
+    },
+    {
+      "example_id": "31217",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.310187,
+      "correct": true
+    },
+    {
+      "example_id": "31218",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.406384,
+      "correct": true
+    },
+    {
+      "example_id": "31219",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.433374,
+      "correct": true
+    },
+    {
+      "example_id": "31220",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.099417,
+      "correct": true
+    },
+    {
+      "example_id": "31221",
+      "category": "flan_v2_p3",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.156206,
+      "correct": true
+    },
+    {
+      "example_id": "33121",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.238867,
+      "correct": true
+    },
+    {
+      "example_id": "33122",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.399009,
+      "correct": true
+    },
+    {
+      "example_id": "33123",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.344888,
+      "correct": true
+    },
+    {
+      "example_id": "33124",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.13815,
+      "correct": true
+    },
+    {
+      "example_id": "33125",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.269845,
+      "correct": true
+    },
+    {
+      "example_id": "33126",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.094477,
+      "correct": true
+    },
+    {
+      "example_id": "33127",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.185258,
+      "correct": true
+    },
+    {
+      "example_id": "33128",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.110632,
+      "correct": false
+    },
+    {
+      "example_id": "33129",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.244708,
+      "correct": true
+    },
+    {
+      "example_id": "33130",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.175907,
+      "correct": true
+    },
+    {
+      "example_id": "33131",
+      "category": "sharegpt",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.074867,
+      "correct": false
+    },
+    {
+      "example_id": "52941",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.078404,
+      "correct": true
+    },
+    {
+      "example_id": "52942",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.153575,
+      "correct": true
+    },
+    {
+      "example_id": "52943",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.143228,
+      "correct": false
+    },
+    {
+      "example_id": "52944",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.019071,
+      "correct": false
+    },
+    {
+      "example_id": "52945",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.201995,
+      "correct": true
+    },
+    {
+      "example_id": "52946",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.307208,
+      "correct": true
+    },
+    {
+      "example_id": "52947",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.029326,
+      "correct": true
+    },
+    {
+      "example_id": "52948",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.261338,
+      "correct": true
+    },
+    {
+      "example_id": "52949",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.099888,
+      "correct": true
+    },
+    {
+      "example_id": "52950",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.162616,
+      "correct": true
+    },
+    {
+      "example_id": "52951",
+      "category": "truthful_qa",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.149236,
+      "correct": false
+    },
+    {
+      "example_id": "53749",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.095245,
+      "correct": false
+    },
+    {
+      "example_id": "53750",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.39111,
+      "correct": true
+    },
+    {
+      "example_id": "53751",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.02964,
+      "correct": false
+    },
+    {
+      "example_id": "53752",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "B",
+      "margin": -0.057889,
+      "correct": false
+    },
+    {
+      "example_id": "53753",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.138939,
+      "correct": true
+    },
+    {
+      "example_id": "53754",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.301861,
+      "correct": true
+    },
+    {
+      "example_id": "53755",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.210699,
+      "correct": true
+    },
+    {
+      "example_id": "53756",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.118955,
+      "correct": true
+    },
+    {
+      "example_id": "53757",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.264217,
+      "correct": true
+    },
+    {
+      "example_id": "53758",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.040861,
+      "correct": true
+    },
+    {
+      "example_id": "53759",
+      "category": "ultrachat",
+      "gt_winner": "A",
+      "predicted_winner": "A",
+      "margin": 0.2239,
+      "correct": true
+    }
+  ]
+}

--- a/scripts/verifier-gt/benchmark_loaders.py
+++ b/scripts/verifier-gt/benchmark_loaders.py
@@ -353,12 +353,395 @@ def load_lean_proof_matching(
             break
 
 
+def load_ultrafeedback(
+    limit: Optional[int] = None,
+    cache_dir: Optional[str] = None,
+    stratified: bool = False,
+) -> Iterator[PairwiseExample]:
+    """UltraFeedback (argilla/ultrafeedback-binarized-preferences, #625).
+
+    Uses chosen/rejected from GPT-4 preference (quasi-ground-truth).
+    """
+    if load_dataset is None:
+        raise RuntimeError("datasets library not installed")
+
+    ds = load_dataset("argilla/ultrafeedback-binarized-preferences", split="train", cache_dir=cache_dir)
+
+    def convert(row, idx):
+        # Schema: source, instruction, chosen_response, rejected_response, chosen_rating, rejected_rating
+        prompt = row.get("instruction") or ""
+        chosen = row.get("chosen_response") or row.get("chosen", "")
+        rejected = row.get("rejected_response") or row.get("rejected", "")
+        return PairwiseExample(
+            example_id=str(idx),
+            prompt=prompt,
+            chosen=chosen,
+            rejected=rejected,
+            category=row.get("source"),
+            metadata={
+                "source": "ultrafeedback",
+                "chosen_rating": row.get("chosen_rating"),
+                "rejected_rating": row.get("rejected_rating"),
+            },
+        )
+
+    if stratified and limit:
+        from collections import defaultdict
+        by_src = defaultdict(list)
+        for idx, row in enumerate(ds):
+            by_src[row.get("source") or "unknown"].append((idx, row))
+        n_src = len(by_src)
+        per_src = max(1, limit // n_src)
+        count = 0
+        for src, items in by_src.items():
+            for idx, row in items[:per_src]:
+                yield convert(row, idx)
+                count += 1
+                if count >= limit:
+                    return
+        return
+
+    for idx, row in enumerate(ds):
+        yield convert(row, idx)
+        if limit is not None and idx + 1 >= limit:
+            break
+
+
+def load_chatbot_arena(
+    limit: Optional[int] = None,
+    cache_dir: Optional[str] = None,
+    stratified: bool = False,
+) -> Iterator[PairwiseExample]:
+    """Chatbot Arena Conversations (lmsys/chatbot_arena_conversations, #626).
+
+    Filters rows with clear winner vote. Uses single-turn prompts.
+    """
+    if load_dataset is None:
+        raise RuntimeError("datasets library not installed")
+
+    ds = load_dataset("lmsys/chatbot_arena_conversations", split="train", cache_dir=cache_dir)
+
+    def _extract_first_turn(conv):
+        """conv is a list of dicts with role/content. Return first user prompt and assistant reply."""
+        if not conv:
+            return "", ""
+        user = ""
+        assistant = ""
+        for msg in conv:
+            role = msg.get("role", "")
+            if role == "user" and not user:
+                user = msg.get("content", "") or ""
+            elif role == "assistant" and user and not assistant:
+                assistant = msg.get("content", "") or ""
+                break
+        return user, assistant
+
+    def convert(row, idx):
+        winner = row.get("winner", "")
+        if winner not in ("model_a", "model_b"):
+            return None
+        conv_a = row.get("conversation_a") or []
+        conv_b = row.get("conversation_b") or []
+        prompt_a, resp_a = _extract_first_turn(conv_a)
+        prompt_b, resp_b = _extract_first_turn(conv_b)
+        prompt = prompt_a or prompt_b
+        if not prompt or not resp_a or not resp_b:
+            return None
+        if winner == "model_a":
+            chosen, rejected = resp_a, resp_b
+        else:
+            chosen, rejected = resp_b, resp_a
+        return PairwiseExample(
+            example_id=str(row.get("question_id", idx)),
+            prompt=prompt,
+            chosen=chosen,
+            rejected=rejected,
+            category=row.get("language") or row.get("turn"),
+            metadata={
+                "source": "chatbot-arena",
+                "model_a": row.get("model_a"),
+                "model_b": row.get("model_b"),
+                "winner": winner,
+            },
+        )
+
+    count = 0
+    all_rows = []
+    for idx, row in enumerate(ds):
+        ex = convert(row, idx)
+        if ex is None:
+            continue
+        all_rows.append(ex)
+
+    if stratified and limit:
+        from collections import defaultdict
+        by_cat = defaultdict(list)
+        for ex in all_rows:
+            by_cat[ex.category or "unknown"].append(ex)
+        n_cats = len(by_cat)
+        per_cat = max(1, limit // n_cats)
+        for cat, items in by_cat.items():
+            for ex in items[:per_cat]:
+                yield ex
+                count += 1
+                if count >= limit:
+                    return
+        return
+
+    for ex in all_rows:
+        yield ex
+        count += 1
+        if limit is not None and count >= limit:
+            break
+
+
+def load_mt_bench(
+    limit: Optional[int] = None,
+    cache_dir: Optional[str] = None,
+    stratified: bool = False,
+) -> Iterator[PairwiseExample]:
+    """MT-Bench human judgments (lmsys/mt_bench_human_judgments, #627).
+
+    Uses first-turn pairwise human-preference judgments.
+    """
+    if load_dataset is None:
+        raise RuntimeError("datasets library not installed")
+
+    ds = load_dataset("lmsys/mt_bench_human_judgments", split="human", cache_dir=cache_dir)
+
+    def convert(row, idx):
+        winner = row.get("winner", "")
+        if winner not in ("model_a", "model_b"):
+            return None
+        conv_a = row.get("conversation_a") or []
+        conv_b = row.get("conversation_b") or []
+
+        def turns_to_text(conv):
+            if not conv:
+                return "", ""
+            user = ""
+            assistant = ""
+            for msg in conv:
+                r = msg.get("role")
+                c = msg.get("content") or ""
+                if r == "user" and not user:
+                    user = c
+                elif r == "assistant" and user and not assistant:
+                    assistant = c
+                    break
+            return user, assistant
+
+        prompt_a, resp_a = turns_to_text(conv_a)
+        prompt_b, resp_b = turns_to_text(conv_b)
+        prompt = prompt_a or prompt_b
+        if not prompt or not resp_a or not resp_b:
+            return None
+        if winner == "model_a":
+            chosen, rejected = resp_a, resp_b
+        else:
+            chosen, rejected = resp_b, resp_a
+        return PairwiseExample(
+            example_id=str(row.get("question_id", idx)),
+            prompt=prompt,
+            chosen=chosen,
+            rejected=rejected,
+            category=row.get("category") or row.get("turn"),
+            metadata={
+                "source": "mt-bench",
+                "model_a": row.get("model_a"),
+                "model_b": row.get("model_b"),
+                "turn": row.get("turn"),
+            },
+        )
+
+    all_rows = []
+    for idx, row in enumerate(ds):
+        ex = convert(row, idx)
+        if ex is not None:
+            all_rows.append(ex)
+
+    if stratified and limit:
+        from collections import defaultdict
+        by_cat = defaultdict(list)
+        for ex in all_rows:
+            by_cat[ex.category or "unknown"].append(ex)
+        n_cats = len(by_cat)
+        per_cat = max(1, limit // n_cats)
+        count = 0
+        for cat, items in by_cat.items():
+            for ex in items[:per_cat]:
+                yield ex
+                count += 1
+                if count >= limit:
+                    return
+        return
+
+    count = 0
+    for ex in all_rows:
+        yield ex
+        count += 1
+        if limit is not None and count >= limit:
+            break
+
+
+def load_humaneval(
+    limit: Optional[int] = None,
+    cache_dir: Optional[str] = None,
+    stratified: bool = False,
+) -> Iterator[PairwiseExample]:
+    """HumanEval (openai_humaneval, #628).
+
+    Constructed pairwise: prompt = function signature + docstring;
+    chosen = canonical_solution (passes tests); rejected = another problem's solution (distractor).
+    """
+    if load_dataset is None:
+        raise RuntimeError("datasets library not installed")
+
+    ds = load_dataset("openai_humaneval", split="test", cache_dir=cache_dir)
+    rows = list(ds)
+    n = len(rows)
+
+    def convert(row, d):
+        return PairwiseExample(
+            example_id=row["task_id"],
+            prompt=row["prompt"],
+            chosen=row["canonical_solution"],
+            rejected=d["canonical_solution"],
+            category=row["task_id"].split("/")[0],
+            metadata={"source": "humaneval", "distractor": d["task_id"]},
+        )
+
+    for i, row in enumerate(rows):
+        distractor = rows[(i + n // 2) % n]
+        yield convert(row, distractor)
+        if limit is not None and i + 1 >= limit:
+            break
+
+
+def load_gsm8k(
+    limit: Optional[int] = None,
+    cache_dir: Optional[str] = None,
+    stratified: bool = False,
+) -> Iterator[PairwiseExample]:
+    """GSM8K (gsm8k, #629).
+
+    Constructed pairwise: prompt = math word problem;
+    chosen = correct reasoning + answer; rejected = another problem's reasoning (distractor).
+    """
+    if load_dataset is None:
+        raise RuntimeError("datasets library not installed")
+
+    ds = load_dataset("gsm8k", "main", split="test", cache_dir=cache_dir)
+    rows = list(ds)
+    n = len(rows)
+
+    def convert(row, d, idx):
+        return PairwiseExample(
+            example_id=str(idx),
+            prompt=row["question"],
+            chosen=row["answer"],
+            rejected=d["answer"],
+            category="gsm8k",
+            metadata={"source": "gsm8k"},
+        )
+
+    for i, row in enumerate(rows):
+        distractor = rows[(i + n // 2) % n]
+        yield convert(row, distractor, i)
+        if limit is not None and i + 1 >= limit:
+            break
+
+
+def load_fever(
+    limit: Optional[int] = None,
+    cache_dir: Optional[str] = None,
+    stratified: bool = False,
+) -> Iterator[PairwiseExample]:
+    """FEVER with gold evidence (copenlu/fever_gold_evidence, #630).
+
+    Substitutes for the original SciFact plan (HF-gated dataset scripts).
+    Constructed pairwise over claims + evidence:
+    chosen = this claim's own gold evidence (topically relevant);
+    rejected = another claim's evidence (topical distractor).
+    """
+    if load_dataset is None:
+        raise RuntimeError("datasets library not installed")
+
+    ds = load_dataset("copenlu/fever_gold_evidence", split="validation", cache_dir=cache_dir)
+    rows = []
+    for row in ds:
+        ev = row.get("evidence")
+        if not ev:
+            continue
+        # evidence is a stringified list-of-lists [[title, line_id, text], ...]
+        try:
+            import ast
+            parsed = ast.literal_eval(ev) if isinstance(ev, str) else ev
+            evidence_texts = []
+            for e in parsed:
+                if isinstance(e, list) and len(e) >= 3:
+                    evidence_texts.append(str(e[2]))
+            ev_joined = " ".join(evidence_texts)[:1500]
+        except Exception:
+            continue
+        if not ev_joined:
+            continue
+        rows.append({
+            "id": row.get("id"),
+            "claim": row.get("claim", ""),
+            "evidence": ev_joined,
+            "label": row.get("label", ""),
+        })
+
+    n = len(rows)
+    if n < 2:
+        return
+
+    def convert(r, d, i):
+        return PairwiseExample(
+            example_id=str(r["id"] or i),
+            prompt=f"Claim: {r['claim']}\n\nWhich text provides evidence directly relevant to this claim?",
+            chosen=r["evidence"],
+            rejected=d["evidence"],
+            category=r["label"],
+            metadata={"source": "fever", "distractor": d["id"]},
+        )
+
+    if stratified and limit:
+        from collections import defaultdict
+        by_label = defaultdict(list)
+        for r in rows:
+            by_label[r["label"]].append(r)
+        n_labels = len(by_label)
+        per_label = max(1, limit // n_labels)
+        count = 0
+        for label, items in by_label.items():
+            for idx, r in enumerate(items[:per_label]):
+                orig_idx = rows.index(r)
+                yield convert(r, rows[(orig_idx + n // 2) % n], orig_idx)
+                count += 1
+                if count >= limit:
+                    return
+        return
+
+    for i, r in enumerate(rows):
+        yield convert(r, rows[(i + n // 2) % n], i)
+        if limit is not None and i + 1 >= limit:
+            break
+
+
 LOADERS = {
     "rewardbench": load_rewardbench,
     "judgebench": load_judgebench,
     "swebench": load_swebench,
     "commit-faithfulness": load_git_commit_faithfulness,
     "lean-proof": load_lean_proof_matching,
+    "ultrafeedback": load_ultrafeedback,
+    "chatbot-arena": load_chatbot_arena,
+    "mt-bench": load_mt_bench,
+    "humaneval": load_humaneval,
+    "gsm8k": load_gsm8k,
+    "fever": load_fever,
 }
 
 

--- a/scripts/verifier-gt/converter.py
+++ b/scripts/verifier-gt/converter.py
@@ -68,6 +68,70 @@ COMMIT_FAITHFULNESS_CRITERION = {
     ),
 }
 
+ULTRAFEEDBACK_CRITERION = {
+    "id": "gpt4_preference",
+    "name": "GPT-4 Preference",
+    "description": (
+        "Which response is better per high-quality judgment? Consider "
+        "correctness, helpfulness, and clarity. A high-quality response "
+        "scores HIGH; a response with factual errors, poor instruction "
+        "following, or weak reasoning scores LOW."
+    ),
+}
+
+ARENA_CRITERION = {
+    "id": "human_preference",
+    "name": "Human Preference",
+    "description": (
+        "Which response would a human prefer? Consider helpfulness, "
+        "correctness, naturalness, and completeness. A response humans "
+        "would rate as better scores HIGH; one they would reject scores LOW."
+    ),
+}
+
+MT_BENCH_CRITERION = {
+    "id": "response_quality",
+    "name": "Response Quality",
+    "description": (
+        "Which response better addresses the question? Consider correctness, "
+        "depth, structure, and adherence to instructions. A strong answer "
+        "scores HIGH; a weaker or incorrect answer scores LOW."
+    ),
+}
+
+HUMANEVAL_CRITERION = {
+    "id": "code_relevance",
+    "name": "Code Relevance",
+    "description": (
+        "Does this Python code correctly implement the described function? "
+        "Code whose logic matches the signature and docstring scores HIGH. "
+        "Code that implements a different function or contains obvious bugs "
+        "scores LOW."
+    ),
+}
+
+GSM8K_CRITERION = {
+    "id": "math_answer_relevance",
+    "name": "Math Answer Relevance",
+    "description": (
+        "Does this reasoning and answer address the given math word problem? "
+        "A step-by-step solution that matches the problem's quantities and "
+        "produces a consistent numeric answer scores HIGH. A solution that "
+        "uses unrelated numbers or targets a different problem scores LOW."
+    ),
+}
+
+FEVER_CRITERION = {
+    "id": "evidence_relevance",
+    "name": "Evidence Relevance",
+    "description": (
+        "Does this text provide evidence directly relevant to the claim? "
+        "Text that addresses the claim's subject and supports or refutes it "
+        "with specific facts scores HIGH. Text about a different topic or "
+        "unrelated evidence scores LOW."
+    ),
+}
+
 # Multi-criteria decomposition (for RQ2 — decomposition effect)
 REWARDBENCH_CRITERIA_DECOMPOSED = [
     {
@@ -138,6 +202,18 @@ def convert_pairwise(
             criteria = [COMMIT_FAITHFULNESS_CRITERION]
         elif source == "lean-proof-matching":
             criteria = [LEAN_PROOF_CRITERION]
+        elif source == "ultrafeedback":
+            criteria = [ULTRAFEEDBACK_CRITERION]
+        elif source == "chatbot-arena":
+            criteria = [ARENA_CRITERION]
+        elif source == "mt-bench":
+            criteria = [MT_BENCH_CRITERION]
+        elif source == "humaneval":
+            criteria = [HUMANEVAL_CRITERION]
+        elif source == "gsm8k":
+            criteria = [GSM8K_CRITERION]
+        elif source == "fever":
+            criteria = [FEVER_CRITERION]
         else:
             criteria = [REWARDBENCH_CRITERION]  # default
 

--- a/scripts/verifier-gt/harness.py
+++ b/scripts/verifier-gt/harness.py
@@ -106,7 +106,9 @@ def evaluate(
     start = time.time()
 
     loader_kwargs = {"limit": limit}
-    if dataset in ("rewardbench", "judgebench", "commit-faithfulness", "lean-proof"):
+    if dataset in ("rewardbench", "judgebench", "commit-faithfulness", "lean-proof",
+                   "ultrafeedback", "chatbot-arena", "mt-bench",
+                   "humaneval", "gsm8k", "fever"):
         loader_kwargs["stratified"] = stratified
 
     for i, ex in enumerate(load(dataset, **loader_kwargs)):


### PR DESCRIPTION
## Summary

- #618 Phase 4 (Tier B 汎用ベンチマーク 5 データセット) の loader と実測結果を追加
- Qwen3.5-4B Q6 と Gemma-4-E4B Q6 を n=100 / k=3 / bidirectional / stratified で評価
- #626 Chatbot Arena は HF gated dataset のため deferred（他issueで再開可能）

## 結果

| Dataset | Qwen | Gemma | Δ |
|---------|------|-------|---|
| UltraFeedback | 75.8% | 82.8% | +7.1 |
| MT-Bench | 70.0% | 71.0% | +1.0 |
| HumanEval | 95.0% | 100.0% | +5.0 |
| GSM8K | 100.0% | 100.0% | +0.0 |
| FEVER | 96.0% | 99.0% | +3.0 |

## 所見

- **自然 pairwise タスク（UltraFeedback/MT-Bench）**: 論文水準（70-80%）
- **構築 pairwise タスク（HumanEval/GSM8K/FEVER）**: ≥95%、topical mismatch 強で容易
- MT-Bench 70% は他より低い — human judgment 自体のノイズと整合
- Gemma 一貫優位だが Tier B では Qwen も実用水準

## Test plan

- [x] 5 loader smoke test
- [x] Qwen3.5-4B / Gemma-4-E4B 両モデル完走
- [x] 各 issue に結果コメント投稿済み

Closes #625, closes #627, closes #628, closes #629, closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)