### PR TITLE
feat: SessionStart hook で pwd/branch/worktree を構造的表示 (#571)

### DIFF
--- a/.claude/hooks/session-context-check.sh
+++ b/.claude/hooks/session-context-check.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# @traces D1, T2
+# Session start: emit pwd / git branch / worktree count as additional context.
+# Structurally enforces CLAUDE.md session startup check (D1).
+
+set -uo pipefail
+
+PWD_VAL=$(pwd)
+BRANCH=$(git branch --show-current 2>/dev/null || echo "not-a-repo")
+WORKTREE_COUNT=$(git worktree list 2>/dev/null | wc -l | tr -d ' ')
+
+echo "[session] pwd=$PWD_VAL"
+echo "[session] branch=$BRANCH"
+if [ "$WORKTREE_COUNT" -gt 0 ] 2>/dev/null; then
+  echo "[session] worktrees=$WORKTREE_COUNT"
+fi
+
+# Traceability:
+# D1: 構造的強制 — セッション開始時の位置確認を hook で保証
+# T2: 構造永続性 — 確認事項を LLM 判断ではなく構造が提供

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -175,6 +175,10 @@
           {
             "type": "command",
             "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/handoff-resume-loader.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/session-context-check.sh"
           }
         ]
       }

--- a/scripts/setup-session-context-hook.sh
+++ b/scripts/setup-session-context-hook.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Setup script: add SessionStart hook for pwd/branch/worktree context check.
+# Addresses #571 (CLAUDE.MD-ONLY item #1).
+#
+# Creates:
+#   - .claude/hooks/session-context-check.sh (hook body)
+#   - appends entry to .claude/settings.json SessionStart hooks array
+#
+# Execute manually (L1: governance config requires human approval):
+#   bash scripts/setup-session-context-hook.sh
+
+set -euo pipefail
+
+REPO="$(git rev-parse --show-toplevel)"
+HOOK_DIR="$REPO/.claude/hooks"
+HOOK_FILE="$HOOK_DIR/session-context-check.sh"
+SETTINGS="$REPO/.claude/settings.json"
+
+if [ -f "$HOOK_FILE" ]; then
+  echo "ERROR: $HOOK_FILE already exists. Aborting."
+  exit 1
+fi
+
+# --- 1. write hook body ---
+cat > "$HOOK_FILE" <<'HOOK_EOF'
+#!/usr/bin/env bash
+# @traces D1, T2
+# Session start: emit pwd / git branch / worktree count as additional context.
+# Structurally enforces CLAUDE.md session startup check (D1).
+
+set -uo pipefail
+
+PWD_VAL=$(pwd)
+BRANCH=$(git branch --show-current 2>/dev/null || echo "not-a-repo")
+WORKTREE_COUNT=$(git worktree list 2>/dev/null | wc -l | tr -d ' ')
+
+echo "[session] pwd=$PWD_VAL"
+echo "[session] branch=$BRANCH"
+if [ "$WORKTREE_COUNT" -gt 0 ] 2>/dev/null; then
+  echo "[session] worktrees=$WORKTREE_COUNT"
+fi
+
+# Traceability:
+# D1: 構造的強制 — セッション開始時の位置確認を hook で保証
+# T2: 構造永続性 — 確認事項を LLM 判断ではなく構造が提供
+HOOK_EOF
+
+chmod +x "$HOOK_FILE"
+echo "Created: $HOOK_FILE"
+
+# --- 2. register in settings.json ---
+# Append {"type":"command","command":"bash $CLAUDE_PROJECT_DIR/.claude/hooks/session-context-check.sh"}
+# to the first SessionStart entry's hooks array.
+python3 - <<PY_EOF
+import json, sys
+from pathlib import Path
+p = Path("$SETTINGS")
+d = json.loads(p.read_text())
+hooks = d.setdefault("hooks", {})
+session_start = hooks.setdefault("SessionStart", [])
+if not session_start:
+    session_start.append({"matcher": "", "hooks": []})
+entry = session_start[0].setdefault("hooks", [])
+cmd = "bash \$CLAUDE_PROJECT_DIR/.claude/hooks/session-context-check.sh"
+if any(h.get("command") == cmd for h in entry):
+    print(f"Already registered in {p}")
+    sys.exit(0)
+entry.append({"type": "command", "command": cmd})
+p.write_text(json.dumps(d, indent=2, ensure_ascii=False) + "\n")
+print(f"Registered hook in {p}")
+PY_EOF
+
+# --- 3. verify ---
+echo ""
+echo "Verification:"
+ls -l "$HOOK_FILE"
+echo "---"
+python3 -c "
+import json
+with open('$SETTINGS') as f:
+    d = json.load(f)
+for e in d.get('hooks', {}).get('SessionStart', []):
+    for h in e.get('hooks', []):
+        print('  ', h.get('command'))
+"
+echo ""
+echo "Done. Start a new Claude Code session to see [session] pwd/branch/worktrees in additional context."


### PR DESCRIPTION
## Summary

- CLAUDE.md の「セッション開始直後に pwd/branch/worktree を確認」指示を構造的に強制（D1）
- SessionStart hook を追加し additional context に `[session] pwd=... branch=... worktrees=N` を出力
- 独立検証（logprob/qwen, k=3, bidirectional）で PASS

## 動作確認

```
[session] pwd=/Users/nirarin/work/agent-manifesto
[session] branch=main
[session] worktrees=7
```

## evaluatorIndependent 検証結果

Qwen3.5-4B-UD-Q6_K_XL による pairwise 評価:

| Criterion | A (変更) | B (現状維持) | Winner |
|-----------|---------|-------------|--------|
| Safety | 0.80 | 0.49 | A |
| Correctness | 0.78 | 0.55 | A |
| Compliance | 0.77 | 0.48 | A |
| **Total** | **2.35** | **1.53** | **A (margin 0.82)** |

## 互換性

conservative extension — 既存 SessionStart hook 4 本はそのまま動作。新 hook を追加のみ。

## Test plan

- [x] hook 単体実行で pwd/branch/worktrees を出力
- [x] settings.json 更新を確認（5 エントリに増加）
- [x] evaluatorIndependent verification PASS
- [ ] 新セッション起動で additional context 反映（マージ後に確認）

Closes #571 partially（CLAUDE.MD-ONLY #1 対応、他 3 項目は継続評価）

🤖 Generated with [Claude Code](https://claude.com/claude-code)