### PR TITLE
feat: /paperize skill — autonomous research paperization (#642, #643)

### DIFF
--- a/.claude/hooks/paperize-jsonl-warn.sh
+++ b/.claude/hooks/paperize-jsonl-warn.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# paperize-jsonl-warn.sh — SessionStart hook.
+# p2-verified.jsonl に未処理エントリがあれば警告する。
+# @traces P3, D1
+
+set -euo pipefail
+BASE="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+JSONL="$BASE/.claude/metrics/p2-verified.jsonl"
+[ -f "$JSONL" ] || exit 0
+N=$(grep -c '' "$JSONL" 2>/dev/null || echo 0)
+[ "$N" -gt 0 ] 2>/dev/null || exit 0
+
+PAPERIZE_MODE=$(yq -r '.enforcement.mode // "warn"' "$BASE/paperize.yaml" 2>/dev/null || echo "warn")
+case "$PAPERIZE_MODE" in
+  skip) exit 0 ;;
+esac
+
+echo "[paperize] p2-verified.jsonl に $N 件の未処理検証トークンがあります" >&2
+echo "[paperize] /paperize で論文化 → todos.md 保存 → jsonl flush を実行できます" >&2

--- a/.claude/hooks/paperize-stop-reminder.sh
+++ b/.claude/hooks/paperize-stop-reminder.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# paperize-stop-reminder.sh — Stop hook.
+# セッション終了時に jsonl エントリがあれば /paperize 起動を促す。
+# @traces P3, D1
+
+set -euo pipefail
+BASE="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+JSONL="$BASE/.claude/metrics/p2-verified.jsonl"
+[ -f "$JSONL" ] || exit 0
+N=$(grep -c '' "$JSONL" 2>/dev/null || echo 0)
+[ "$N" -gt 0 ] 2>/dev/null || exit 0
+
+PAPERIZE_MODE=$(yq -r '.enforcement.mode // "warn"' "$BASE/paperize.yaml" 2>/dev/null || echo "warn")
+case "$PAPERIZE_MODE" in
+  skip) exit 0 ;;
+esac
+
+echo "[paperize] セッション終了: p2-verified.jsonl に $N 件の検証トークンが蓄積中" >&2
+echo "[paperize] 次セッション開始前に /paperize 実行を推奨" >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -179,6 +179,10 @@
           {
             "type": "command",
             "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/session-context-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/paperize-jsonl-warn.sh"
           }
         ]
       }
@@ -205,6 +209,17 @@
           }
         ],
         "matcher": ""
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/paperize-stop-reminder.sh"
+          }
+        ]
       }
     ]
   }

--- a/.claude/skills/paperize/SKILL.md
+++ b/.claude/skills/paperize/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: paperize
+user-invocable: true
+description: >
+  .claude/metrics/p2-verified.jsonl の検証トークンから論文成果物 (paper.pdf +
+  todos.md + evidence/) を生成する。P3 学習ライフサイクルの「統合→退役」段階を
+  構造化する。PaperOrchestra 5-agent pipeline (outline → [plotting ∥ litreview] →
+  writing → refinement) を採用し、AutoResearchClaw の Knowledge Base 6-cat を
+  follow-up tracking に採用、AI-Scientist-v2 の paperize.yaml 外部設定を採用する。
+  「論文化」「paperize」「jsonl フラッシュ」「宿題化」で起動。
+dependencies:
+  invokes:
+    - skill: verify
+      type: hard
+      phase: "Phase 4 Refinement"
+      condition: "refinement halt rule 評価"
+  invoked_by:
+    - skill: evolve
+      phase: "退役 (Retirement)"
+      expected_output: "p2-verified.jsonl → paper.pdf + todos.md + flush"
+---
+<!-- @traces P3, D13, T2 -->
+
+# /paperize — Autonomous Research Paperization
+
+`.claude/metrics/p2-verified.jsonl` が蓄積した検証トークン群を、
+LaTeX 論文 + 後続宿題 todos.md + 証拠 evidence/ に変換し、jsonl を空化する。
+
+設計文書: `docs/research/autonomous-research-pipelines/04-integrated-design.md`
+
+## 起動条件
+
+- `.claude/metrics/p2-verified.jsonl` が存在し、エントリが 1 件以上
+- git repo 内部
+- `paperize.yaml` が存在する（無ければ `paperize.yaml.example` を cp して促す）
+
+## 5-Agent Pipeline
+
+| # | Agent | 役割 | Source |
+|---|-------|------|--------|
+| 1 | **Outline** | manifest.json → outline.json (章立て + 各章の論点) | [S2 §2.1] |
+| 2a | **Plotting** | evidence/ → 図表（matplotlib で numeric plot, pandoc で table） | [S2 §2.2] |
+| 2b | **LitReview** | internal citation graph 構築（PR/issue/commit hash を第一級化） | [S2 §2.3] adapted |
+| 3 | **Writing** | outline + evidence → paper.tex (single-pass + extended thinking) | [S2 §2.4] |
+| 4 | **Refinement** | verifier-refinement.py (logprob pairwise, halt on margin<0) | [S2 §2.5] + PR #637 |
+
+Agent 2a/2b は独立、並列化可。
+
+## 実行手順
+
+### Step 0: 前提チェック
+
+```bash
+[ -f .claude/metrics/p2-verified.jsonl ] || { echo "no jsonl"; exit 0; }
+[ -s .claude/metrics/p2-verified.jsonl ] || { echo "empty jsonl"; exit 0; }
+[ -f paperize.yaml ] || { cp .claude/skills/paperize/paperize.yaml.example paperize.yaml; echo "created paperize.yaml — review before re-running"; exit 1; }
+```
+
+### Step 1: Aggregate (Phase 1 + 4, deterministic)
+
+```bash
+SLUG=$(date +%Y-%m-%d)-$(yq -r '.paper.slug_format // "paperize"' paperize.yaml | sed 's/[^a-z0-9-]/-/g')
+OUT="docs/papers/$SLUG"
+scripts/aggregate-jsonl.sh "$OUT" \
+  "$(yq -r '.input.jsonl_path' paperize.yaml)" \
+  "$(yq -r '.input.git_range' paperize.yaml)"
+```
+
+成果物: `$OUT/manifest.json` + `$OUT/evidence/{p2-verified-snapshot.jsonl,commits.md,sources.md}`
+
+### Step 2: Extraction + Synthesis (Phase 2 + 3, LLM)
+
+`manifest.json` を読み、`references/agent-prompts/extraction-prompt.md` のルールで:
+
+1. 各 verification を 1〜3 文の narrative に要約（未検証事項は `[UNVERIFIED]` tag）
+2. 重複を merge、独立プロジェクトを分離
+3. 抽出物を `$OUT/idea.md` + `$OUT/experimental_log.md` に書き出す
+
+### Step 3: Outline Agent
+
+`references/schemas/outline.schema.json` に準拠した `$OUT/outline.json` を生成。
+ページ数上限は `paperize.yaml:paper.max_pages` から取得 (default 8)。
+
+### Step 4: Plotting ∥ LitReview（並列）
+
+- **Plotting**: `evidence/` 中の numeric data → `figures/*.pdf`
+- **LitReview**: `manifest.json:commits` + `evidence/sources.md` → `references.md`（internal citation graph）
+
+### Step 5: Writing Agent
+
+`outline.json` + `idea.md` + `experimental_log.md` + `figures/` + `references.md` → `paper.tex`。
+single-pass (extended_thinking=true)。Section ごとの Aider-style 反復は避ける。
+
+### Step 6: Refinement Agent
+
+`scripts/verifier-refinement.py` で logprob pairwise verifier を回す:
+- K=3 rounds, bidirectional, winner=A and margin>0 で accept
+- winner=B または margin<0 で halt（AgentReview halt rule）
+- max_iterations=7
+
+### Step 7: Compile
+
+```bash
+scripts/compile-paper.sh "$OUT/paper.tex" "$OUT/paper.pdf"
+```
+
+### Step 8: Follow-up tracking
+
+```bash
+scripts/update-todos.py "$OUT/todos.md" "$OUT/manifest.json"
+scripts/decay-expired-questions.py "$OUT/todos.md"
+```
+
+Knowledge Base 6 カテゴリ (`references/knowledge-base-schema.md`):
+- decisions / experiments / findings / literature / questions / reviews
+- 30-day time decay で stale を `$OUT/evidence/expired-questions.md` に退避
+
+### Step 9: Metadata + Flush
+
+```bash
+jq -n --arg model "$(yq -r '.agents.refinement.verifier' paperize.yaml)" \
+      --arg k "$(yq -r '.agents.refinement.k_rounds' paperize.yaml)" \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      '{model:$model, k_rounds:$k, timestamp:$ts}' > "$OUT/metadata.json"
+
+# Flush (enforcement.jsonl_flush_on_complete で条件付き)
+if [ "$(yq -r '.enforcement.jsonl_flush_on_complete' paperize.yaml)" = "true" ]; then
+  scripts/flush-jsonl.sh "$(yq -r '.input.jsonl_path' paperize.yaml)"
+fi
+
+# Commit (enforcement.git_commit_on_complete で条件付き)
+if [ "$(yq -r '.enforcement.git_commit_on_complete' paperize.yaml)" = "true" ]; then
+  git add "$OUT" && git commit -m "paperize: $SLUG (compatible change)"
+fi
+```
+
+## Enforcement モード (paperize.yaml:enforcement.mode)
+
+| mode | 挙動 |
+|------|------|
+| `warn` | SessionStart/Stop hook で「jsonl N 件未処理」を表示するだけ |
+| `block` | 次の commit を block（commit hook で検知。要 L1 承認） |
+| `skip` | 強制なし、明示起動のみ |
+
+Default: `warn`。
+
+## 成果物構造
+
+```
+docs/papers/YYYY-MM-DD-<slug>/
+├── paper.tex              # writing agent output
+├── paper.pdf              # compile-paper.sh output
+├── outline.json           # outline agent output
+├── idea.md                # extraction agent output
+├── experimental_log.md    # extraction agent output
+├── todos.md               # knowledge-base 6 cat
+├── manifest.json          # aggregate-jsonl.sh output
+├── metadata.json          # reproducibility (model/k/ts)
+├── figures/               # plotting agent output
+├── references.md          # litreview agent output
+└── evidence/
+    ├── p2-verified-snapshot.jsonl
+    ├── commits.md
+    ├── sources.md
+    ├── lessons.md         # MetaClaw 軽量版 (SS8 で追加)
+    └── expired-questions.md
+```
+
+## 不変条件
+
+- `paper.pdf` 生成前に jsonl flush しない（G3: atomic commit）
+- refinement で winner=B なら commit せず `$OUT/evidence/refinement-rejected.md` に記録
+- `evaluator_independent=false` の verification は manifest で `quarantined: true` タグ付け
+
+## 未実装箇所（SS7-SS11 で埋める）
+
+- [ ] Phase 2/3 LLM 実行 → SKILL.md 本体のプロンプト化（本ファイルで記述中）
+- [ ] `scripts/verifier-refinement.py` → SS7
+- [ ] `scripts/update-todos.py` + `scripts/decay-expired-questions.py` → SS8
+- [ ] `scripts/compile-paper.sh` + `references/template/paper.tex` → SS9
+- [ ] commit hook / Stop hook (enforcement.mode=warn/block) → SS10
+- [ ] end-to-end smoke test → SS11

--- a/.claude/skills/paperize/paperize.yaml.example
+++ b/.claude/skills/paperize/paperize.yaml.example
@@ -1,0 +1,50 @@
+# paperize.yaml — /paperize 外部設定
+# Source: [S1 §3] bfts_config.yaml / [S3 §4] config.arc.yaml
+# Doc: docs/research/autonomous-research-pipelines/04-integrated-design.md §5
+
+# ---- 入力指定 ----
+input:
+  jsonl_path: .claude/metrics/p2-verified.jsonl
+  git_range: HEAD~20..HEAD
+  issue_labels: [research, verifier]
+  pr_merged_since: 7d
+
+# ---- 論文設定 ----
+paper:
+  template: internal-report         # [P] or neurips / iclr
+  max_pages: 8                      # [S1 §2.3] page length constraint
+  slug_format: "{date}-{primary-topic}"
+
+# ---- Agent 設定 ----
+agents:
+  outline:
+    model: claude-opus-4-7
+    max_tokens: 8000
+  section_writing:
+    model: claude-opus-4-7
+    extended_thinking: true         # [S1 §2.3] reflection 相当
+  refinement:
+    verifier: logprob/qwen          # [P] PR #637
+    k_rounds: 3                     # [P] PR #636
+    bidirectional: true             # [P] PR #617
+    halt_on_margin_below: 0.0       # [S2 §2.5] winner=B で halt
+    max_iterations: 7               # [S2] "5-7 calls"
+
+# ---- Follow-up 管理 ----
+follow_up:
+  todos_file: todos.md              # [S3 §3]
+  categories:                       # [S3 §3] 6 cat
+    - decisions
+    - experiments
+    - findings
+    - literature
+    - questions
+    - reviews
+  decay_days: 30                    # [S3 §3]
+
+# ---- 強制 ----
+enforcement:
+  mode: warn                        # [P] T6: warn / block / skip
+  jsonl_flush_on_complete: true     # [P] G3
+  git_commit_on_complete: true      # [P] 成果物を追跡
+  require_evaluator_independent: true  # [P] P2

--- a/.claude/skills/paperize/references/agent-prompts/extraction-prompt.md
+++ b/.claude/skills/paperize/references/agent-prompts/extraction-prompt.md
@@ -1,0 +1,47 @@
+# Extraction Prompt — Phase 2 (LLM)
+
+Source: [S2 §3.4] PaperOrchestra Aggregator Phase 2
+
+## Input
+
+- `$OUT/manifest.json` (aggregate-jsonl.sh output)
+- `$OUT/evidence/commits.md`
+- `$OUT/evidence/sources.md`
+
+## Output
+
+- `$OUT/idea.md`
+- `$OUT/experimental_log.md`
+
+## Instructions
+
+Read `manifest.json` and group verifications by `source` field. Each group is
+a candidate "experimental thread".
+
+For each thread, write a paragraph in `experimental_log.md` covering:
+1. **What was verified** (derived from files + verdict)
+2. **When** (timestamp range)
+3. **Outcome** (verdict, margin if present)
+4. **Supporting commits** (match by date to `manifest.json:commits`)
+
+If `evaluator_independent` is null or false for a verification, tag the
+corresponding narrative with `[UNVERIFIED]`. See `anti-hallucination-rules.md:R1`.
+
+### idea.md
+
+Synthesize threads into 1-3 "research ideas" at a higher abstraction level.
+Each idea must:
+- Reference at least one thread from `experimental_log.md`
+- State the hypothesis being tested
+- Cite internal commits with 8-char SHA (see `anti-hallucination-rules.md:R2`)
+
+### Synthesis constraints (Phase 3)
+
+- Merge redundant verifications (same files, same day, same verdict) into one record
+- Split distinct projects (if file sets are disjoint across threads, treat as separate ideas)
+- Preserve `[UNVERIFIED]` tags through merges
+
+## Page budget hint
+
+Extraction output (idea.md + experimental_log.md combined) should fit within
+~3000 words. This bounds downstream writing agent.

--- a/.claude/skills/paperize/references/agent-prompts/outline-prompt.md
+++ b/.claude/skills/paperize/references/agent-prompts/outline-prompt.md
@@ -1,0 +1,29 @@
+# Outline Prompt — Phase 3 Outline Agent
+
+Source: [S2 §2.1] PaperOrchestra Outline Agent
+
+## Input
+
+- `$OUT/idea.md`
+- `$OUT/experimental_log.md`
+- `paperize.yaml:paper.max_pages`
+
+## Output
+
+- `$OUT/outline.json` conforming to `references/schemas/outline.schema.json`
+
+## Instructions
+
+Produce an outline with:
+- `title` (≤ 80 chars)
+- `sections[]`: each with `heading`, `purpose` (1 sentence), `key_claims[]`, `supporting_evidence[]` (references to `experimental_log.md` / `manifest.json:verifications`)
+- Budget ~= max_pages × 500 words/page
+
+Prefer 5 sections (internal-report template):
+1. Motivation
+2. Method
+3. Experiments
+4. Findings
+5. Limitations + follow-up
+
+Do NOT introduce claims not grounded in `experimental_log.md`.

--- a/.claude/skills/paperize/references/agent-prompts/refinement-prompt.md
+++ b/.claude/skills/paperize/references/agent-prompts/refinement-prompt.md
@@ -1,0 +1,40 @@
+# Refinement Prompt — Phase 4 (LLM + Verifier)
+
+Source: [S2 §2.5] PaperOrchestra AgentReview + PR #637 logprob pairwise
+
+## Loop
+
+```
+for iter in 1..max_iterations:
+  A = current paper.tex
+  B = llm_revise(A, critique_prompt)
+  verdict = verifier.compare(A, B, criteria)   # scripts/verifier-refinement.py
+  if verdict.winner == "A" and verdict.margin > 0:
+    accept B → continue
+  elif verdict.winner == "B":
+    halt → record refinement-rejected.md, keep A
+  else:  # margin <= 0
+    halt → keep A (no net improvement)
+```
+
+## critique_prompt
+
+Focus on (in decreasing priority):
+1. Unsupported numeric claims (see `anti-hallucination-rules.md:R5`)
+2. Missing `[UNVERIFIED]` tags where `evaluator_independent=null`
+3. Internal citation hash presence
+4. Page budget compliance (max_pages)
+5. Section coherence
+
+Do NOT:
+- Introduce new experiments
+- Speculate about future work in the body (use `todos.md:questions` instead)
+- Inflate section count
+
+## Verifier criteria (3 axes)
+
+- **factual_grounding**: claims supported by `manifest.json` / `evidence/`
+- **citation_integrity**: internal hashes present, external citations in config
+- **narrative_coherence**: section ordering, logical flow
+
+Verifier returns `{winner, margin, criterion_breakdown}`.

--- a/.claude/skills/paperize/references/anti-hallucination-rules.md
+++ b/.claude/skills/paperize/references/anti-hallucination-rules.md
@@ -1,0 +1,38 @@
+# Anti-Hallucination Rules
+
+Source: [S2 §4] PaperOrchestra Lit Review + Content Refinement twin defense
+
+内部研究版に適応。外部引用は optional、**internal citation** を第一級化する。
+
+## Rules
+
+### R1: `[UNVERIFIED]` tag 強制
+
+Phase 2 Extraction で `manifest.json:verifications[].evaluator_independent` が
+`null` / `false` のエントリから抽出した narrative は必ず `[UNVERIFIED]` tag を付与。
+
+例:
+> K-plateau は K=16 以降で improvement が頭打ち [UNVERIFIED: sample-based, not rigorous].
+
+### R2: Internal citation は hash 必須
+
+Phase 2 で PR / issue / commit を引用する場合、SHA prefix (8 文字) を必ず含める。
+例: `(PR #637, commit 76c18fa3)` ✓ / `(PR #637)` ✗
+
+### R3: 外部引用は空のまま許容
+
+arXiv / Semantic Scholar は呼ばない（cost）。もし外部を引用する必要があれば、
+**LLM に URL を生成させない**。`paperize.yaml:input.external_citations:` に人手で記入。
+
+### R4: "data が存在しなければ無視" ルール
+
+Refinement phase で verifier が「新規 experiment を追加せよ」と要求した場合、
+`evidence/` / `manifest.json` に該当データが無ければ:
+- 該当 section の主張を弱めるか削除
+- 新 experiment を追加しない
+- `questions` カテゴリに "need additional experiment for X" を記入
+
+### R5: Numeric claim は source 参照必須
+
+「+10.9pp improvement」「K=16 plateau」等の数値主張は、`evidence/` 中のファイル
+または `manifest.json:verifications[].margin` を指す内部 citation を付ける。

--- a/.claude/skills/paperize/references/knowledge-base-schema.md
+++ b/.claude/skills/paperize/references/knowledge-base-schema.md
@@ -1,0 +1,44 @@
+# Knowledge Base Schema — todos.md 6 カテゴリ
+
+Source: [S3 §3] AutoResearchClaw Knowledge Base
+
+## カテゴリ
+
+| Category | 目的 | 例 |
+|----------|------|-----|
+| **decisions** | 論文で下した判定（採用 / 却下 / 保留） | "K=3 を採用、K=16 以降は CONDITIONAL" |
+| **experiments** | 実行した検証とその結果 | "pairwise vs individual: +10.9pp" |
+| **findings** | 再利用可能な知見 | "bidirectional averaging が position bias を消す" |
+| **literature** | 引用した外部/内部資料 | "[S2] PaperOrchestra arXiv:2604.05018" |
+| **questions** | 未解決、後続で追う問い | "margin threshold の最適値は？" |
+| **reviews** | 評価・批判・反証 | "AgentReview halt rule は recall を落とすが precision が高い" |
+
+## Time Decay
+
+- 30 日経過した `questions` は `$OUT/evidence/expired-questions.md` に退避
+- 他カテゴリは decay しない（findings は永続）
+
+## Schema (todos.md YAML front-matter)
+
+```yaml
+---
+schema_version: "1"
+generated_at: 2026-04-20T10:00:00Z
+source_manifest: docs/papers/2026-04-20-verifier/manifest.json
+decay_days: 30
+---
+```
+
+カテゴリ本体は markdown リストで記述:
+
+```markdown
+## decisions
+- [2026-04-20] K=3 を採用（K=16 plateau 検証、N=128 rounds）
+  - source: commit 9159f62 / PR #636
+  - compatibility: compatible change
+
+## questions
+- [2026-04-20] margin threshold 0.0 は実務で最適？
+  - decay_at: 2026-05-20
+  - discovered_in: paper §5
+```

--- a/.claude/skills/paperize/references/schemas/outline.schema.json
+++ b/.claude/skills/paperize/references/schemas/outline.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Paperize Outline",
+  "description": "Outline produced by /paperize outline agent. [S2 §2.1]",
+  "type": "object",
+  "required": ["schema_version", "title", "sections"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "title": { "type": "string", "maxLength": 80 },
+    "target_max_pages": { "type": "integer", "minimum": 1, "maximum": 20 },
+    "sections": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "required": ["heading", "purpose", "key_claims"],
+        "properties": {
+          "heading": { "type": "string" },
+          "purpose": { "type": "string" },
+          "key_claims": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          },
+          "supporting_evidence": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["type", "ref"],
+              "properties": {
+                "type": { "enum": ["commit", "verification", "file", "pr", "issue"] },
+                "ref":  { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/paperize/references/schemas/todos.schema.json
+++ b/.claude/skills/paperize/references/schemas/todos.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Paperize Todos (Knowledge Base)",
+  "description": "Follow-up tracking in 6 categories. [S3 §3]",
+  "type": "object",
+  "required": ["schema_version", "generated_at", "entries"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "source_manifest": { "type": "string" },
+    "decay_days": { "type": "integer", "minimum": 1, "default": 30 },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["category", "recorded_at", "text"],
+        "properties": {
+          "category": {
+            "enum": ["decisions", "experiments", "findings", "literature", "questions", "reviews"]
+          },
+          "recorded_at": { "type": "string", "format": "date" },
+          "text": { "type": "string" },
+          "source": {
+            "type": "object",
+            "properties": {
+              "commit": { "type": "string", "pattern": "^[0-9a-f]{8,40}$" },
+              "pr": { "type": "integer" },
+              "issue": { "type": "integer" },
+              "file": { "type": "string" }
+            }
+          },
+          "compatibility": { "enum": ["conservative extension", "compatible change", "breaking change"] },
+          "decay_at": { "type": "string", "format": "date" }
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/paperize/references/template/guidelines.md
+++ b/.claude/skills/paperize/references/template/guidelines.md
@@ -1,0 +1,43 @@
+# Internal Research Report Guidelines
+
+Source: [P] internal convention.
+
+## Structure (5 sections)
+
+1. **Motivation** — why the research was needed, what question it answers
+2. **Method** — experimental setup, verifier model, K-rounds, criteria
+3. **Experiments** — what was tested, with counts + evidence pointers
+4. **Findings** — numeric results, claims (all supported by `manifest.json`)
+5. **Limitations and Follow-up** — open questions → link to `todos.md`
+
+## Length
+
+- Default: ≤ 8 pages (paperize.yaml:paper.max_pages)
+- Abstract: ≤ 200 words
+- Each main section: ≤ 2 pages
+
+## Citation style
+
+### Internal (primary)
+
+- Commit: `(commit \texttt{9159f62c})`
+- PR: `(PR \#637)`
+- Issue: `(issue \#642)`
+- Verification token: `(p2-verified.jsonl:epoch=1776663606)`
+
+### External (optional)
+
+Pre-declare in `paperize.yaml:input.external_citations:`. The LLM must NOT
+generate new URLs.
+
+## Figures
+
+- Numeric: matplotlib → `figures/*.pdf` (vector)
+- Tables: LaTeX `booktabs`, no vertical lines
+- Place figures near first reference, not at end
+
+## Tone
+
+- Internal report, not a conference submission
+- First-person plural ("we observed") allowed
+- Claim every numeric result with source reference (anti-hallucination R5)

--- a/.claude/skills/paperize/references/template/paper.tex
+++ b/.claude/skills/paperize/references/template/paper.tex
@@ -1,0 +1,59 @@
+% Internal Research Report template for /paperize
+% Source: [P] internal convention, inspired by [S1 §2.3] single-pass format
+% Variables to replace (section-writing agent):
+%   {{TITLE}}, {{AUTHORS}}, {{DATE}}, {{ABSTRACT}},
+%   {{MOTIVATION}}, {{METHOD}}, {{EXPERIMENTS}}, {{FINDINGS}}, {{LIMITATIONS}},
+%   {{APPENDIX_EVIDENCE}}
+
+\documentclass[11pt,a4paper]{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+\usepackage[margin=2.5cm]{geometry}
+\usepackage{hyperref}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{listings}
+\usepackage{xcolor}
+
+\hypersetup{colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue}
+
+\lstset{
+  basicstyle=\footnotesize\ttfamily,
+  breaklines=true,
+  frame=single,
+  rulecolor=\color{gray!40}
+}
+
+\title{ {{TITLE}} }
+\author{ {{AUTHORS}} }
+\date{ {{DATE}} }
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+{{ABSTRACT}}
+\end{abstract}
+
+\section{Motivation}
+{{MOTIVATION}}
+
+\section{Method}
+{{METHOD}}
+
+\section{Experiments}
+{{EXPERIMENTS}}
+
+\section{Findings}
+{{FINDINGS}}
+
+\section{Limitations and Follow-up}
+{{LIMITATIONS}}
+
+\appendix
+\section{Evidence Index}
+{{APPENDIX_EVIDENCE}}
+
+\end{document}

--- a/docs/research/autonomous-research-pipelines/01-ai-scientist-v2.md
+++ b/docs/research/autonomous-research-pipelines/01-ai-scientist-v2.md
@@ -1,0 +1,205 @@
+# Survey 1: AI-Scientist-v2 (SakanaAI, 2026-04)
+
+> **Parent Issue**: #642
+> **Survey Sub-Issue**: SS1
+> **Status**: 深堀サーベイ完了 (2026-04-20)
+> **Primary Source**: [arXiv:2504.08066v1](https://arxiv.org/abs/2504.08066) (Yamada et al., 2025-04-10), [GitHub: SakanaAI/AI-Scientist-v2](https://github.com/SakanaAI/AI-Scientist-v2)
+
+---
+
+## 1. What is it
+
+AI-Scientist-v2 は、AI 研究論文を**完全自律生成**するエンドツーエンド system。
+前身 v1 が要求したタスク特化 code template への依存を排除し、**domain-general**
+に展開可能となった後継実装。
+
+最大の実績: ICLR 2025 workshop (ICBINB) へ 3 本を blind 投稿し、
+うち **1 本が人間 reviewer の合格ラインを超えた**（reviewer scores 6, 7, 6, mean 6.33, top 45%）。
+AI 単独生成論文の peer review 通過の最初の事例。
+
+## 2. 3-stage Pipeline
+
+```
+┌──────────────┐   ┌──────────────────────┐   ┌──────────────┐
+│ Idea         │   │ Tree-Based           │   │ Paper        │
+│ Generation   │──▶│ Experimentation      │──▶│ Write-Up     │
+│              │   │  (4 sub-stages)      │   │              │
+└──────────────┘   └──────────────────────┘   └──────────────┘
+       │                      │                      │
+ Novelty check          Experiment Manager     Plotting + VLM
+ (Semantic Scholar)     + Parallel workers     Manuscript template
+ Idea scoring           Node types (B/R/H/A/Agg) Single-pass + reflection
+ Archiving              Best-first selection   LLM paper reviewing
+```
+
+### 2.1 Idea Generation (§3.1)
+
+- **入力**: workshop topic を書いた markdown (`my_research_topic.md`)
+- **LLM が open-ended な hypothesis を 20 件ほど生成**、grant-proposal 相当の抽象度
+- **Novelty check**: Semantic Scholar API で既存研究と照合
+- **Scoring + archiving**: scoring と prompt improvement をループ (`--num-reflections 5`)
+- **出力**: 構造化 JSON (`my_research_topic.json`)
+
+### 2.2 Tree-Based Experimentation (§3.2) ★中核
+
+**Experiment Progress Manager** が 4 段階を coordinate:
+
+| Stage | 目的 | 停止条件 |
+|-------|------|---------|
+| Stage 1 | Preliminary Investigation: 最小動作 prototype 確立 | 基本 prototype が走る |
+| Stage 2 | Hyperparameter Tuning: lr/epochs 等を最適化 | training 曲線が収束し ≥2 dataset で成功 |
+| Stage 3 | Research Agenda Execution: 核心的な研究 agenda 実行 | 計算予算枯渇 |
+| Stage 4 | Ablation Studies: 各 component の重要度評価 | 計算予算枯渇 |
+
+- 各 stage の終わりで **LLM evaluator が best node を選択** → 次 stage の root となる
+- 各 stage 完了時に **replication runs** を走らせ mean/std を確保
+
+#### Node Types（Figure 2）
+
+| Type | 生成条件 | 役割 |
+|------|---------|------|
+| Buggy | 実行エラー or VLM 不合格 | debug 候補 |
+| Non-buggy | 実行成功 + VLM 合格 | refinement 候補 |
+| **Hyperparameter** | Stage 2 | hp 探索 |
+| **Ablation** | Stage 4 | component 削除評価 |
+| **Replication** | 各 stage 末 | 異なる seed で mean/std 計算 |
+| **Aggregation** | replication 群の末端 | 新実験せず結果集約のみ |
+
+#### Search Mechanics (§3.2.2)
+
+- 各 iteration で複数ノードを**並列 expand**
+- **debug_prob** の確率で buggy node を優先選択（error resolution 優先）
+- それ以外は **best-first search** で non-buggy node を選ぶ (metrics + training dynamics + plot quality)
+- **max_debug_depth** を超えた分岐は放棄
+- 各 node = { 実験 script, 実行 trace, metrics, LLM feedback, plot 生成 script, figure path list, VLM feedback, 最終ステータス }
+
+### 2.3 Paper Write-Up (§3.4 + Figure 1)
+
+**v1 から大改革**: v1 の incremental Aider-based iteration を廃し、
+**single-pass generation + reflection stage** に変更（推論モデル o1 系を想定）。
+
+構成:
+
+1. **Plotting + VLM Feedback**: numpy で保存された metrics を python で可視化 → VLM が批評
+   - 不明瞭 label / missing legend / 誤解を招く可視化 → node を "buggy" に格下げ
+2. **Manuscript Template**: LaTeX template (workshop-size, 4-page limit 等)
+3. **Manuscript**: single-pass で全セクション draft
+4. **LLM Paper Reviewing (reflection)**: VLM が fig-caption alignment / visual clarity / fig 重複を検査
+5. **Citation rounds**: `--num_cite_rounds 20` で Semantic Scholar 経由で citations を集め refining
+
+#### Command
+```bash
+python launch_scientist_bfts.py \
+  --load_ideas "ai_scientist/ideas/my_research_topic.json" \
+  --load_code \
+  --add_dataset_ref \
+  --model_writeup     o1-preview-2024-09-12 \
+  --model_citation    gpt-4o-2024-11-20 \
+  --model_review      gpt-4o-2024-11-20 \
+  --model_agg_plots   o3-mini-2025-01-31 \
+  --num_cite_rounds 20
+```
+
+## 3. 出力物とディレクトリ構造
+
+```
+experiments/
+ └── timestamp_ideaname/
+     ├── logs/
+     │   └── 0-run/
+     │       └── unified_tree_viz.html        # 探索木の interactive 可視化
+     └── timestamp_ideaname.pdf                # 最終 manuscript (20-30 min)
+ai_scientist/
+ └── ideas/
+     ├── my_research_topic.md                  # input
+     └── my_research_topic.json                # ideation output
+bfts_config.yaml                              # 探索設定
+```
+
+**bfts_config.yaml の主要 param**:
+- `num_workers`: 並列 worker 数
+- `steps`: 最大 node 展開数
+- `num_seeds`: 独立 seed 数（< 3 なら num_workers と同じ、≥ 3 なら 3）
+- `max_debug_depth`: 1 node あたりの debug 最大試行
+- `debug_prob`: buggy 優先確率
+- `num_drafts`: Stage 1 の root 数（独立 tree の本数）
+
+## 4. Follow-up Research Tracking
+
+**v2 paper 本文内では明示的な follow-up 追跡機構は記述されていない**。
+Single-shot execution を前提とし、「本 manuscript で何が未解決か」は paper 本文の
+Discussion / Limitations セクションに LLM が書き込むのみ。
+
+Related Work (§6) で競合として CycleResearcher (Weng et al., 2025) を挙げ、
+これが ideation → draft 中心で実験を除外している点を対比。
+
+## 5. Limitations（自己申告、§5）
+
+1. **Workshop 止まり**: ICLR/ICML/NeurIPS main track 水準には未達（workshop accept 率 60-80% vs main 20-30%）
+2. **Citation hallucination**: 引用の不正確性が頻発
+3. **Methodological rigor の不足**: main conference に求められる深さが欠ける
+4. **Novel hypothesis 創出の弱さ**: LLM-generated ideas は novel だが feasibility が低い (Si et al., 2025)
+5. **Foundation model 依存**: 成功率は完全に LLM の能力に律速される
+
+## 6. 我々の p2-verified.jsonl 論文化への示唆
+
+| AI-Scientist-v2 の機構 | 我々への applicability |
+|----------------------|----------------------|
+| **Experiment Progress Manager** による 4-stage coordination | ★ jsonl token → 論文の pipeline を明示的 stage 化できる。我々は「検証 → narrative 収集 → 章立て → draft → refinement」の 5-stage 化が良い |
+| **Tree-based experimentation** | ✗ 我々は単一 session の linear な検証の後処理なので tree は不要。stage 内 linear で十分 |
+| **VLM feedback for figures** | △ 我々は図が少ない（主に表）。除外可 |
+| **Single-pass writeup + reflection** | ★★ これを採用する。**Aider-based 反復は我々の文脈（local LLM）では過重**、reasoning model (Claude Opus + extended thinking) で single-pass + reflection が適切 |
+| **Citation rounds with Semantic Scholar** | △ 外部研究引用は少数。代わりに **internal citation** (自 PR/issue/commit) を強化すべき |
+| **LaTeX page length constraint を prompt に含める** | ★ 文字数上限を明示すると冗長性が抑制される |
+| **logs/0-run/ の構造化保存** | ★★ evidence archive の直接の参照パターンになる |
+| **bfts_config.yaml** による設定の外部化 | ★ paperize.yaml を用意、model 指定・k_rounds・section 構成等を外部化 |
+
+### Key takeaway
+
+AI-Scientist-v2 の中核貢献は **Experiment Progress Manager (EPM)** と **tree search**。
+我々の要件では tree 探索は不要だが、**EPM 相当の stage coordinator**（orchestrator） が
+writeup の複雑さを管理する設計は採用すべき。
+
+具体的には:
+- jsonl の token をグルーピングして**複数の "research arc"** として認識
+- 各 arc に対し 4 段の stage（observation / narrative / draft / refinement）を EPM 管理
+- Best-node selection の代わりに **先行 PR #637 の Verifier で論文 draft を quality gate**
+
+## 7. 再現性確認
+
+**実運用コスト**:
+- Ideation: 数ドル
+- 実験 run: Claude 3.5 Sonnet で $15-$20 / run
+- Writing phase: default model で約 $5 / run
+
+我々の用途（1 session 1 paper）では **write phase のみ必要**。実験 phase (agentic tree search) は
+既に Verifier 検証で代替済み。
+
+**依存**:
+- OpenAI / Gemini / AWS Bedrock (Claude) の API key
+- Semantic Scholar API key (optional)
+- conda + poppler + chktex
+- Python 3.11
+
+我々の文脈では: **Claude Code が既に備える機能で writeup 相当を代替可能**（WebFetch, LaTeX生成, pandoc 呼び出し）。
+
+## 8. 結論
+
+AI-Scientist-v2 から採用すべき要素:
+1. **Stage-based orchestration** (EPM 相当)
+2. **Single-pass writeup + reflection stage**（Aider-style iteration を避ける）
+3. **Page length constraint in prompt**
+4. **構造化保存** (`logs/` に相当するディレクトリ)
+5. **外部設定 file**（`paperize.yaml`）
+
+我々の文脈で不要な要素:
+1. Tree search（既に検証済みの token 群が入力なので探索不要）
+2. VLM feedback（図が少ない）
+3. Ideation phase（既に実行された検証の後処理が我々の要件）
+
+## References
+
+- [arXiv:2504.08066 — The AI Scientist-v2: Workshop-Level Automated Scientific Discovery via Agentic Tree Search](https://arxiv.org/abs/2504.08066)
+- [GitHub: SakanaAI/AI-Scientist-v2](https://github.com/SakanaAI/AI-Scientist-v2)
+- [Sakana Blog: AI Scientist First Publication](https://sakana.ai/ai-scientist-first-publication/)
+- Local PDF snapshot (webfetch result, 8.5 MB, pages 1-20 read)

--- a/docs/research/autonomous-research-pipelines/02-paper-orchestra.md
+++ b/docs/research/autonomous-research-pipelines/02-paper-orchestra.md
@@ -1,0 +1,308 @@
+# Survey 2: PaperOrchestra (Google Cloud AI Research, 2026-04)
+
+> **Parent Issue**: #642
+> **Survey Sub-Issue**: SS2
+> **Status**: 深堀サーベイ完了 (2026-04-20)
+> **Primary Sources**:
+> - Paper: [arXiv:2604.05018](https://arxiv.org/abs/2604.05018) (Song, Song, Pfister, Yoon — Google Cloud AI Research)
+> - Project page: [paper_orchestra (yiwen-song.github.io)](https://yiwen-song.github.io/paper_orchestra/)
+> - Open-source implementation: [GitHub Ar9av/PaperOrchestra](https://github.com/Ar9av/PaperOrchestra)
+
+---
+
+## 1. What is it
+
+**Raw experimental materials → submission-ready LaTeX manuscript** に特化した
+multi-agent framework。AI-Scientist-v2 が **end-to-end (ideation + experimentation + writeup)**
+を扱うのに対し、**PaperOrchestra は writeup に focus** し、入力はすでに終わった実験の
+メモ（ideas + logs）を前提とする。
+
+**我々の要件（jsonl にある検証済みトークン → 論文 PDF）に最も直接的にマッチ**。
+
+### 代表的成果
+
+- **Literature review 品質 win rate**: baseline 比 **+50〜+68 pp**
+- **Overall manuscript 品質**: **+14〜+38 pp**
+- **引用質**: 1 論文あたり 45.7-48.0 citations（baseline 9.8-14.2）
+- **計算コスト**: **60-70 LLM API calls / ~39.6 min / paper**
+- **Refined manuscript の効果**: refined vs non-refined で **79-81% win rate**
+- **simulated acceptance 改善**: +19 pp (CVPR), +22 pp (ICLR)
+
+## 2. Architecture: 5-Agent Pipeline
+
+```
+         ┌──────────────┐
+         │ Outline      │ 構造化 JSON blueprint
+         │ Agent        │ + 可視化戦略 + 2-phase literature search 戦略
+         └──────┬───────┘
+                │
+      ┌─────────┴─────────┐
+      │                   │         (並列実行)
+      ▼                   ▼
+┌──────────┐        ┌──────────────┐
+│ Plotting │        │ Literature   │
+│ Agent    │        │ Review Agent │
+│ (~20-30) │        │   (~20-30)   │
+└────┬─────┘        └──────┬───────┘
+     │                     │
+     └──────────┬──────────┘
+                │
+                ▼
+         ┌──────────────┐
+         │ Section      │ 全 LaTeX section を single multimodal call で draft
+         │ Writing      │
+         └──────┬───────┘
+                │
+                ▼
+         ┌──────────────┐
+         │ Content      │ AgentReview で simulated peer review
+         │ Refinement   │ (~5-7 calls, 厳しい halt rule)
+         └──────┬───────┘
+                │
+                ▼
+        submission-ready
+         LaTeX + PDF
+```
+
+### 2.1 Outline Agent
+
+**入力**:
+- `idea.md` (Sparse Idea format — 研究 concept の要約)
+- `experimental_log.md` (App. D.3 format — 構造化実験結果)
+- `template.tex` (conference template)
+- `conference_guidelines.md` (submission rules, page limit)
+
+**出力 (JSON blueprint)**:
+- **Visualization specifications**: どの figure を生成するか
+- **2-phase literature search strategies**:
+  - Macro-level: intro 用（分野全体）
+  - Micro-level: related work 用（特定アルゴリズム比較）
+- **Section-level writing plans**: citation hint 付き
+
+### 2.2 Plotting Agent
+
+- **PaperBanana** (Zhu et al., 2026) を使った academic illustration
+- **VLM critic** が生成画像を評価し iterative refinement
+- Design objective（label 明瞭性、axis 整合、color consistency 等）を満たすまで繰り返す
+
+### 2.3 Literature Review Agent
+
+**Plotting Agent と並列実行**:
+
+1. **LLM + web search** で candidate papers を発見
+2. **Semantic Scholar API** で存在確認:
+   - Fuzzy title match (Levenshtein distance)
+   - Abstract retrieval
+   - **Temporal cutoff enforcement**（投稿 deadline 以降は除外）
+3. 検証不能な参照は破棄
+4. **Constraint**: 「集めた literature pool の **90% 以上**が実際に cite されていること」
+
+**Anti-hallucination**: Semantic Scholar で存在確認された論文のみ引用に使う。
+
+### 2.4 Section Writing Agent
+
+- **Single multimodal call** で abstract / methodology / experiments / conclusion を一気に draft
+- 数値表は **experimental log から直接抽出**（LLM が数値を生成しない）
+- 生成 figure を LaTeX source に splice
+
+### 2.5 Content Refinement Agent
+
+**AgentReview による simulated peer review**:
+
+**Accept 条件**（厳密）:
+- **全体 score が増加**、または
+- **全体 score が同点かつ sub-axis 合計が net non-negative**
+
+**Revert and halt 条件**:
+- **全体 score が減少** → 即座に revert し halt
+
+**重要な anti-hallucination rule**:
+- 「reviewer が存在しない data を要求した場合、無視する」と explicit instruction
+- **data 捏造を構造的に防止**
+
+**約 5-7 calls** で refinement 完了。
+
+## 3. Open-Source Implementation: Skills-Based Architecture
+
+GitHub の Ar9av/PaperOrchestra は **extraordinary relevant**:
+
+### 3.1 設計思想
+
+> "There are no API keys, no SDK dependencies, no embedded LLM calls.
+> The skills are instruction documents plus deterministic helpers;
+> your coding agent does all LLM reasoning and web search using its own tools."
+
+**これは我々の Claude Code + .claude/skills/ の構造と完全に一致する**。
+
+### 3.2 Skills 一覧（各 skill = SKILL.md + references/ + scripts/）
+
+| Skill | 役割 |
+|-------|------|
+| `paper-orchestra` | Orchestrator（全体制御） |
+| `outline-agent` | Outline Agent |
+| `plotting-agent` | Plotting Agent |
+| `literature-review-agent` | Literature Review Agent |
+| `section-writing-agent` | Section Writing Agent |
+| `content-refinement-agent` | Content Refinement Agent |
+| `paper-writing-bench` | Benchmark utilities |
+| `paper-autoraters` | Automated evaluators |
+
+各 skill:
+- **SKILL.md**: dense instruction document
+- **references/**: paper の App. F prompts を verbatim、JSON schemas、rubrics、halt rules
+- **scripts/**: schema validation / fuzzy matching / BibTeX formatting / LaTeX sanity checks
+
+### 3.3 入出力
+
+```
+workspace/
+├── inputs/
+│   ├── idea.md                   # research concept (Sparse Idea format)
+│   ├── experimental_log.md       # 構造化実験結果 (App. D.3)
+│   ├── template.tex              # conference LaTeX template
+│   ├── conference_guidelines.md  # submission rules
+│   └── figures/                  # optional pre-existing visualizations
+└── outputs/
+    ├── outline.json
+    ├── literature.bib
+    ├── sections/*.tex
+    ├── figures/*.pdf
+    └── paper.pdf
+```
+
+### 3.4 Agent Research Aggregator（★特筆すべき preprocessor）
+
+「**scattered な research 痕跡 → idea.md + experimental_log.md**」への 4-phase 前処理:
+
+| Phase | 処理 | 実装 |
+|-------|------|------|
+| **1. Discovery** | `.claude/`, `.cursor/`, `.antigravity/`, `.openclaw/` を deterministic scan | scripts |
+| **2. Extraction** | LLM が batch (~50KB/ea) を処理、`extraction-prompt.md`。未検証は `[UNVERIFIED]` tag | LLM |
+| **3. Synthesis** | 単一 LLM call で redundant records を merge、複数 project 分離 | LLM |
+| **4. Formatting** | 決定論的に `idea.md` / `experimental_log.md` に変換 | scripts |
+
+**我々の `.claude/metrics/p2-verified.jsonl` からの narrative extraction** は
+このパターンがそのまま使える。
+
+### 3.5 Install / Invocation
+
+```bash
+# Symlink インストール
+ln -sf ~/paper-orchestra/skills/$skill ~/.claude/skills/$skill
+
+# 自然言語で呼び出し
+"Run the paper-orchestra pipeline on ./workspace"
+"Write a paper from my work in ~/my-project"
+```
+
+Supported hosts: **Claude Code**, Cursor, Antigravity, Cline, Aider, OpenCode
+
+## 4. Anti-Hallucination の二重防御
+
+1. **Lit Review Agent**: Semantic Scholar 検証で citation 捏造を防ぐ
+2. **Content Refinement Agent**: reviewer 要求に対し「data が存在しなければ無視」ルール
+
+→ AI-Scientist-v2 の citation error 問題（workshop paper で頻発）を正面から解決。
+
+## 5. PaperWritingBench
+
+**評価 benchmark**:
+- 200 top-tier AI conference papers を **reverse engineer** して (Sparse Idea, Experimental Log) pair に
+- CVPR 2025 (100) + ICLR 2025 (100)
+- **Paper Autoraters** (App. F.3):
+  - Citation F1 (precision/recall grades P0-P1)
+  - Literature review quality (6-axis)
+  - Section-by-section paper quality
+  - Side-by-side literature review comparison
+
+**Human evaluation**: 11 AI researchers による side-by-side 比較。
+
+## 6. 我々の要件への示唆
+
+### 6.1 完全に mappable な要素
+
+| PaperOrchestra | 我々のプロジェクト | Mapping |
+|---------------|----------------------|---------|
+| `idea.md` | Parent Issue body + 関連 research plan | 容易に作成可能 |
+| `experimental_log.md` | `p2-verified.jsonl` + commit messages + `research/verifier-gt/*.json` | **直接適用可能** |
+| `template.tex` | 自作 template（internal report 形式で開始） | 軽量で OK |
+| `conference_guidelines.md` | 「internal research report 形式、~5 page、Verifier evidence 必須」 | 我々の規約 |
+| `outline-agent` skill | `.claude/skills/paperize/` に配置 | 採用 |
+| `literature-review-agent` skill | **internal citation** (自 PR/commit/issue) に変換 | 適応が必要 |
+| `section-writing-agent` skill | そのまま採用 | 採用 |
+| `content-refinement-agent` skill | **我々の Verifier pairwise (PR #637) を自然に統合** | ★ dog-fooding |
+| `agent-research-aggregator` | **p2-verified.jsonl 読み取り + git log 抽出** | ★★ 実質同じ |
+
+### 6.2 AgentReview の halt rule = 我々の Verifier と自然に対応
+
+| PaperOrchestra AgentReview | 我々の Verifier pairwise |
+|---------------------------|------------------------|
+| "score 増加または同点 + sub-axis net non-negative" で accept | winner=A and margin > threshold |
+| "score 減少" で即座に halt | winner=B → revert |
+| ~5-7 refinement iterations | k_rounds=3 + bidirectional |
+
+### 6.3 我々に特化した変更点
+
+| 差分 | 理由 |
+|------|------|
+| **Web 検索・Semantic Scholar 省略** | 内部研究なので外部引用は optional。代わりに **internal citation** (PR/issue/commit hash) を第一級化 |
+| **PaperBanana 不要** | 図は matplotlib で十分 |
+| **benchmark 不要** | PaperWritingBench は公開論文向け |
+| **`p2-verified.jsonl` を入力の一等市民に** | 我々独自の「検証トークン列」。PaperOrchestra は experimental_log.md を想定するので、**preprocessing で変換** |
+
+## 7. 直接的な採用案
+
+我々の `/paperize` skill は **PaperOrchestra の skills-based 設計を忠実に写像**できる:
+
+```
+.claude/skills/paperize/
+├── SKILL.md                     # orchestrator skill
+├── references/
+│   ├── outline-prompt.md
+│   ├── section-writing-prompt.md
+│   ├── refinement-prompt.md
+│   ├── halt-rules.md
+│   ├── json-schemas/*.json
+│   └── rubrics.md
+└── scripts/
+    ├── p2-to-experimental-log.sh  # jsonl → experimental_log.md
+    ├── collect-commit-context.sh  # commit msg / PR / issue 収集
+    ├── verifier-refinement.py     # Verifier pairwise で AgentReview を代替
+    └── latex-sanity-check.sh
+```
+
+呼び出し: `/paperize docs/papers/2026-04-20-<slug>`
+
+これは **6 論文を実装した skill を我々に移植する** という形になる。再発明ではない。
+
+## 8. 結論
+
+**PaperOrchestra は我々の要件に最も直接的に写像できる先行研究**。
+
+### 採用すべき要素（全て）
+
+1. **5-agent 構造** (Outline → [Plotting ∥ LitReview] → Writing → Refinement)
+2. **Skills-based architecture**（Claude Code に自然）
+3. **Content Refinement の halt rule** (score non-decrease 制約)
+4. **Anti-hallucination rules** (存在しない data を生成しない)
+5. **Agent Research Aggregator** の 4-phase preprocessing（jsonl → experimental_log 変換に応用）
+
+### 適応すべき要素
+
+1. **Lit Review**: 外部 → 内部（自 PR/issue/commit）に入れ替え
+2. **PaperBanana**: 省略（matplotlib で充分）
+3. **Semantic Scholar**: 省略（内部 citation graph を自作）
+
+### Dog-fooding の好機
+
+- Content Refinement Agent = **我々の Verifier pairwise (PR #637)**
+- 「**論文を書く AI が、書いた論文を同じ AI で verify する**」という自己言及的構造
+- agent-manifesto の **P2 (検証の独立性)** の実践になる（Claude Opus で書き、Qwen で検証）
+
+## References
+
+- [arXiv:2604.05018 — PaperOrchestra](https://arxiv.org/abs/2604.05018)
+- [Project page (yiwen-song.github.io)](https://yiwen-song.github.io/paper_orchestra/)
+- [GitHub: Ar9av/PaperOrchestra (open-source impl)](https://github.com/Ar9av/PaperOrchestra)
+- [MarkTechPost (2026-04-08)](https://www.marktechpost.com/2026/04/08/google-ai-research-introduces-paperorchestra-a-multi-agent-framework-for-automated-ai-research-paper-writing/)
+- [Dev|Journal article](https://earezki.com/ai-news/2026-04-09-google-ai-research-introduces-paperorchestra-a-multi-agent-framework-for-automated-ai-research-paper-writing/)

--- a/docs/research/autonomous-research-pipelines/03-auto-research-claw.md
+++ b/docs/research/autonomous-research-pipelines/03-auto-research-claw.md
@@ -1,0 +1,347 @@
+# Survey 3: AutoResearchClaw (aiming-lab, 2026)
+
+> **Parent Issue**: #642
+> **Survey Sub-Issue**: SS3
+> **Status**: 深堀サーベイ完了 (2026-04-20)
+> **Primary Source**: [GitHub: aiming-lab/AutoResearchClaw](https://github.com/aiming-lab/AutoResearchClaw)
+
+---
+
+## 1. What is it
+
+**"Fully autonomous & self-evolving research from idea to paper"**。
+AI-Scientist-v2 と同じ end-to-end scope だが、v2 より新しく、
+**self-healing / multi-agent debate / HITL (Human-in-the-Loop)** に強み。
+
+Tagline: "Chat an Idea. Get a Paper. 🦞"
+
+**我々の文脈で特に注目すべき点**:
+- 6 カテゴリの **Knowledge Base** による follow-up 追跡
+- **MetaClaw** による **cross-run 学習**（前の run の lessons を次の run が使う）
+- **30-day time decay** による知識退役（P3 と自然に対応）
+- **SmartPause**: 動的な介入タイミング判定
+- ACP-compatible で **Claude Code, Codex CLI, Gemini CLI, Copilot CLI 等**で動作
+
+## 2. 23-Stage 8-Phase Pipeline
+
+| Phase | Stages | 主要機能 |
+|-------|--------|---------|
+| **A Scoping** | 1-2 | topic → problem tree, research questions 抽出 |
+| **B Literature** | 3-6 | OpenAlex / Semantic Scholar / arXiv から論文収集・スクリーニング・knowledge cards 構築 |
+| **C Synthesis** | 7-8 | Multi-agent debate (Innovator / Pragmatist / Contrarian) で hypothesis 生成 |
+| **D Design** | 9-11 | Hardware-aware experiment design, code 生成, resource 計画 |
+| **E Execution** | 12-13 | Sandbox 実行, NaN/Inf fast-fail, **self-healing 最大 10 round** |
+| **F Analysis** | 14-15 | Multi-agent 分析 → **PROCEED / REFINE / PIVOT** 自律判定 |
+| **G Writing** | 16-19 | Outline → draft → peer review → revise (length guard + anti-disclaimer) |
+| **H Finalization** | 20-23 | Quality gate (NeurIPS checklist, AI-slop detection), archive, LaTeX export, citation verify |
+
+### 2.1 各 Phase の Stage 詳細（抜粋）
+
+#### Phase A: Scoping
+- Stage 1 (TOPIC_INIT): topic を structured problem tree に分解
+- Stage 2 (PROBLEM_DECOMPOSE): research questions を抽出
+
+#### Phase B: Literature Discovery
+- Stage 3 (SEARCH_STRATEGY): Multi-source query expansion
+- Stage 4 (LITERATURE_COLLECT): OpenAlex + Semantic Scholar + arXiv から取得
+- Stage 5 (LITERATURE_SCREEN) **[GATE]**: relevance filtering
+- Stage 6 (KNOWLEDGE_EXTRACT): Knowledge cards 構築
+
+#### Phase C: Knowledge Synthesis
+- Stage 7 (SYNTHESIS): Cluster findings, identify gaps
+- Stage 8 (HYPOTHESIS_GEN): **Multi-agent debate** で testable hypotheses
+
+#### Phase D: Experiment Design
+- Stage 9 (EXPERIMENT_DESIGN) **[GATE]**: Hardware-aware planning
+- Stage 10 (CODE_GENERATION): GPU/MPS/CPU adaptive Python
+- Stage 11 (RESOURCE_PLANNING): compute needs 推定
+
+#### Phase E: Execution
+- Stage 12 (EXPERIMENT_RUN): sandbox 実行 + NaN/Inf detection
+- Stage 13 (ITERATIVE_REFINE): **Self-healing loop**（後述）
+
+#### Phase F: Analysis & Decision
+- Stage 14 (RESULT_ANALYSIS): Multi-agent perspective analysis
+- Stage 15 (RESEARCH_DECISION): **PROCEED / REFINE / PIVOT** 自律判定（後述）
+
+#### Phase G: Paper Writing
+- Stage 16 (PAPER_OUTLINE): Conference template 構造
+- Stage 17 (PAPER_DRAFT): Section-by-section (5,000-6,500 words)
+- Stage 18 (PEER_REVIEW): Evidence-methodology consistency
+- Stage 19 (PAPER_REVISION): Length guard + anti-disclaimer
+
+#### Phase H: Finalization
+- Stage 20 (QUALITY_GATE) **[GATE]**: 4-layer audit (NeurIPS checklist, AI-slop detection)
+- Stage 21 (KNOWLEDGE_ARCHIVE): **Lessons を 30-day decay で保存**
+- Stage 22 (EXPORT_PUBLISH): LaTeX + BibTeX compile
+- Stage 23 (CITATION_VERIFY): **4-layer citation integrity** (arXiv ID → CrossRef/DataCite DOI → title match → LLM relevance)
+
+## 3. Knowledge Base（★我々への示唆が大）
+
+6 カテゴリで永続的に追跡:
+
+| Category | 追跡内容 |
+|----------|---------|
+| **Decisions** | rationale, stage, timestamp, approval status |
+| **Experiments** | runs, metrics, failure modes, repair history |
+| **Findings** | key results, novel insights, anomalies |
+| **Literature** | collected papers, extraction metadata, relevance scores |
+| **Questions** | **unresolved research directions, branching paths** ← follow-up 宿題相当 |
+| **Reviews** | peer feedback, evidence gaps, revision notes |
+
+**Backend**: markdown or obsidian; root dir configurable。
+**30-day time-decay**: MetaClaw integration で次の run が前の lessons を使う（間接的な forgetting）。
+
+→ 我々の P3 学習ライフサイクル（観察→仮説→検証→統合→**退役**）の「退役」部分と
+完全に対応。30-day decay は我々の "アーカイブしてから忘れる" に直接 mappable。
+
+## 4. Self-Healing Repair Loop（Stage 13）
+
+最大 **10 rounds** の repair:
+
+1. Sandbox で code 実行 → NaN/Inf fast-fail
+2. AST-validated code + **immutable harness** で invalid mutation を防止
+3. 失敗時: **error context 付き LLM repair prompt**
+4. Rerun; ≥2 条件完了 → `min_completion_rate: 0.5` 閾値で proceed
+5. Partial result capture
+
+**config.arc.yaml**:
+```yaml
+repair:
+  enabled: true
+  max_cycles: 3
+  min_completion_rate: 0.5
+  # Optional: "Route repairs through OpenCode Beast Mode" for complex failures
+```
+
+## 5. PROCEED / REFINE / PIVOT 判定（Stage 15）
+
+Stage 15 で自律判定:
+
+- **PROCEED**: 結果が hypothesis を支持 → Stage 16 へ
+- **REFINE**: parameters 調整可、hypothesis 有効 → **Stage 13 に戻る**（hp 変更）
+- **PIVOT**: 根本的問題 → **Stage 8 に戻る**（hypothesis 再生成）
+
+**Artifacts auto-versioned** — 各 loop 反復が record される。
+Decision rationale は Knowledge Base に log。
+
+→ **我々の Verifier pairwise PASS / CONDITIONAL / FAIL と完全に一致**。
+/evolve の既存 3 judgment とも整合する。
+
+## 6. Anti-Fabrication: VerifiedRegistry（★最重要）
+
+**5 つの層で捏造を防ぐ**:
+
+1. **Experiment Diagnosis & Repair (Stage 13)**: 失敗 → repair → completion 検証
+2. **Claim Verification (Stage 23)**: 4-layer citation integrity + AI-generated text から inline claim 抽出
+3. **Cross-Reference Check**: ungrounded claim を flag → **hallucinated refs 自動削除**
+4. **Paper Guard (Stage 20)**: 4-layer audit + **AI-slop detection** + evidence-claim consistency scoring
+5. **Unverified Sanitization**: 実験で tie できない数値は redact
+
+さらに **Sentinel Watchdog**（background monitor）が常時走行:
+- NaN/Inf detection
+- paper-evidence consistency
+- citation relevance scoring
+
+→ PaperOrchestra の anti-hallucination rule を **システム全体に拡張した版**。
+
+## 7. HITL Co-Pilot: 6 Intervention Modes
+
+| Mode | Command | 介入頻度 |
+|------|---------|---------|
+| **Full Auto** | `--auto-approve` | なし |
+| **Gate Only** | `--mode gate-only` | 3 gates (Stages 5, 9, 20) |
+| **Checkpoint** | `--mode checkpoint` | 8 phase boundaries |
+| **Co-Pilot** | `--mode co-pilot` | Critical stages のみ |
+| **Step-by-Step** | `--mode step-by-step` | 全 stage 後 |
+| **Custom** | `--mode custom` | `stage_policies` config で per-stage |
+
+### Key Co-Pilot 特徴
+
+- **Idea Workshop** (7-8): hypothesis を共同 brainstorm
+- **Baseline Navigator** (9): baseline 提案 + human 追加削除 + reproducibility checklist
+- **Paper Co-Writer** (16-19): section ごとに human edit
+- **SmartPause**: **confidence-driven dynamic intervention** — auto で「人間 input が有効」と判定した時だけ pause
+- **Cost Guardrails**: budget monitoring (50% / 80% / 100% threshold で pause)
+- **Intervention Learning (ALHF)**: review pattern から次回 pause 判定を最適化
+- **3 Adapters**: CLI / WebSocket / MCP
+
+→ SmartPause は **我々の「force / warn / skill-driven」3 層制御の上位版**。
+
+## 8. 出力: `artifacts/rc-YYYYMMDD-HHMMSS-<hash>/deliverables/`
+
+```
+deliverables/
+├── paper_draft.md              # 5000-6500 words 全 section
+├── paper.tex                   # NeurIPS/ICLR/ICML template
+├── references.bib              # real BibTeX (auto-pruned)
+├── verification_report.json    # 4-layer citation integrity
+├── experiment_runs/            # code + results + JSON metrics
+├── charts/                     # error bars + CIs 付き figures
+├── reviews.md                  # multi-agent peer review
+├── evolution/                  # self-learning lessons (30-day decay)
+└── [other config artifacts]
+```
+
+→ 我々の `docs/papers/YYYY-MM-DD-<slug>/` 構造設計の直接のリファレンス。
+
+## 9. Directory Structure（researchclaw パッケージ）
+
+```
+researchclaw/
+├── cli.py, config.py, prompts.py, quality.py, report.py, writing_guide.py
+├── agents/            # Agent implementations
+├── skills/            # Skill modules
+├── llm/               # LLM interfaces
+├── memory/            # Memory / state
+├── knowledge/         # Knowledge base
+├── literature/        # Academic lit management
+├── pipeline/          # Pipeline
+├── experiment/        # Experimental features
+├── dashboard/         # UI
+├── server/            # Server infra
+├── collaboration/     # Multi-agent collab
+├── feedback/          # Feedback
+├── hitl/              # Human-in-the-loop
+├── mcp/               # MCP integration
+├── metaclaw_bridge/   # MetaClaw integration
+├── overleaf/          # Overleaf integration
+├── docker/            # Container configs
+├── data/, utils/, voice/, web/, wizard/, templates/
+└── evolution.py, evolution_aevolve.py  # 進化的アルゴリズム
+```
+
+特筆: **evolution.py + evolution_aevolve.py** — 我々の `/evolve` と同じ名前。
+アルゴリズム的 self-improvement を指す。
+
+## 10. 呼び出し / Commands
+
+### Setup
+```bash
+pip install -e .
+researchclaw setup   # Interactive: OpenCode, Docker, LaTeX checks
+researchclaw init    # Interactive: LLM provider, config.arc.yaml
+```
+
+### Run
+```bash
+researchclaw run --topic "Your research idea" --auto-approve
+researchclaw run --topic "..." --mode co-pilot
+```
+
+### Runtime interaction (separate terminal)
+```bash
+researchclaw attach artifacts/rc-2026-xxx
+researchclaw status artifacts/rc-2026-xxx
+researchclaw approve artifacts/rc-2026-xxx --message "LGTM"
+researchclaw reject artifacts/rc-2026-xxx --reason "Missing baseline"
+researchclaw guide artifacts/rc-2026-xxx --stage 9 --message "Use ResNet-50"
+```
+
+### Skills
+```bash
+researchclaw skills list
+researchclaw skills install /path/to/skill/
+researchclaw skills validate ./my-skill
+```
+
+## 11. 我々への示唆
+
+### 11.1 完全に mappable な要素
+
+| AutoResearchClaw | 我々のプロジェクト | 採用状況 |
+|-----------------|----------------------|---------|
+| **Knowledge Base 6 categories** | `todos.md` を 6 category 化 or evidence/ 内 6 ファイル | ★★★ 採用 |
+| **30-day time-decay** | ephemeral jsonl の退役期限化 | ★★★ 採用 |
+| **MetaClaw lessons arc-* files** | `evidence/lessons.md` で前回の paperize の反省を記録 | ★ 採用 (軽量版) |
+| **PROCEED / REFINE / PIVOT** | Verifier の 3 判定と一致 | ★★★ 既に整合 |
+| **Anti-fabrication 5 layer** | Verifier + evidence/ + unverified tag | ★★ 採用 (軽量版) |
+| **`[UNVERIFIED]` tag** | PaperOrchestra でも同じ | ★★ 採用 |
+| **Sentinel Watchdog background monitor** | 我々の hook と近い | △ 要検討 |
+| **HITL SmartPause** | 我々の「force / warn / skill」3 層と同じ思想 | ★★ 採用 |
+| **evolution/ directory** | 我々の /evolve と名前一致 | ★ 命名整合 |
+
+### 11.2 我々が省略すべき要素
+
+- **Phase A-E 全て**（我々は experiment が既に終わっている）
+- **Multi-agent debate**（我々は検証済み結果を formalize するだけ）
+- **Self-healing repair loop**（検証は既に終わっている）
+- **OpenAlex / Semantic Scholar / arXiv**（外部論文が主題ではない）
+- **NeurIPS/ICLR template**（internal report 形式で十分）
+- **Dashboard / WebSocket / Overleaf**（overengineering）
+
+### 11.3 我々の `/paperize` 設計への直接的取り込み
+
+Knowledge Base の 6-category 構造を **todos.md のテンプレート**として採用:
+
+```markdown
+# Research Follow-ups — <paperize-slug>
+
+## Decisions
+- [DEC-001] 2026-04-20 #641 hook 追加を pair-wise verifier で承認 (margin 0.82)
+
+## Experiments  
+- [EXP-001] 2026-04-18 commit faithfulness n=52 → Gemma 84.6% vs Qwen 53.8%
+
+## Findings
+- [FIN-001] Gemma が agent-manifesto ドメインで顕著に優位 (Δ +31pp)
+- [FIN-002] 1/√K decay continues to K=64
+
+## Literature
+- [LIT-001] Kwok et al. 2026 — LLM-as-a-Verifier (reproduction successful)
+
+## Questions (← Follow-up 宿題)
+- [Q-001] Chatbot Arena (#626) を HF 認証後に実施
+- [Q-002] Gemini 2.5 Flash 転移性 (#616) を API 調達後に実施
+- [Q-003] criteria_detail の P2 token への拡張 (issue 未起票)
+
+## Reviews
+- [REV-001] PR #641 Verifier 検証 (score: 0.82 margin, 3/3 criteria)
+```
+
+### 11.4 30-day decay の実装案
+
+`todos.md` の `Questions` category に timestamp を持たせ、**30 日経過したものは
+`evidence/expired-questions.md` に移動する script** を用意する。これが P3 退役の
+構造的強制になる。
+
+## 12. 結論
+
+AutoResearchClaw は我々の要件の **end-to-end 版**。我々に必要な要素は:
+
+### 採用する要素
+1. **Knowledge Base 6 category 構造** → `todos.md` テンプレートの骨格
+2. **30-day time-decay** → `todos.md` → `expired/` への自動移動
+3. **PROCEED / REFINE / PIVOT** の呼称を我々の判定と統一
+4. **[UNVERIFIED] tag** で data の出所を明示
+5. **`artifacts/rc-YYYYMMDD-HHMMSS-<hash>/`** のディレクトリ命名を参考に
+
+### 不採用の要素
+1. Phase A-F (我々は writeup のみ)
+2. Multi-agent debate (既に検証済み結果の formalize が目的)
+3. OpenAlex/arXiv 連携 (外部引用中心ではない)
+4. Dashboard / WebSocket (overengineering)
+
+## 13. 3 先行研究の統合総括
+
+| 項目 | AI-Scientist-v2 | PaperOrchestra | AutoResearchClaw |
+|------|-----------------|----------------|------------------|
+| **焦点** | end-to-end | writeup 専用 | end-to-end + HITL |
+| **skills 構造** | モノリシック | **skills-based** ★ | skills + modules |
+| **Input** | markdown topic | idea + exp log | topic 1 行 |
+| **核心** | tree search | 5-agent pipeline | 23-stage + KB |
+| **Anti-hallu.** | 弱（reported citation error） | 強（Sem Scholar + AgentReview） | 最強（5 層 + watchdog） |
+| **Follow-up** | なし | なし | **Knowledge Base 6 cat** ★ |
+| **Decay** | なし | なし | **30-day** ★ |
+| **Open source** | ✅ | ✅ (Ar9av 実装) | ✅ |
+| **我々への適用性** | △ | ★★★ | ★★ (KB のみ) |
+
+→ **PaperOrchestra の skills-based pipeline + AutoResearchClaw の Knowledge Base** が
+我々の最適解と判定。
+
+## References
+
+- [GitHub: aiming-lab/AutoResearchClaw](https://github.com/aiming-lab/AutoResearchClaw)
+- [researchclaw package source](https://github.com/aiming-lab/AutoResearchClaw/tree/main/researchclaw)
+- [README_JA (Japanese)](https://github.com/aiming-lab/AutoResearchClaw/blob/main/docs/README_JA.md)
+- [SHOWCASE.md](https://github.com/aiming-lab/AutoResearchClaw/blob/main/docs/showcase/SHOWCASE.md)

--- a/docs/research/autonomous-research-pipelines/04-integrated-design.md
+++ b/docs/research/autonomous-research-pipelines/04-integrated-design.md
@@ -1,0 +1,450 @@
+# Integrated Design: `/paperize` Skill
+
+> **Parent Issue**: #642
+> **Sub-Issue**: #643 (SS4)
+> **Status**: 統合設計 v1 (2026-04-20)
+> **Traceability**: 各設計要素に [S1], [S2], [S3] で survey record への source link を付与
+
+## 凡例（Source Tag）
+
+| Tag | Source | 記録 |
+|-----|--------|------|
+| **[S1]** | AI-Scientist-v2 (SakanaAI) | [01-ai-scientist-v2.md](./01-ai-scientist-v2.md) |
+| **[S2]** | PaperOrchestra (Google Cloud AI) | [02-paper-orchestra.md](./02-paper-orchestra.md) |
+| **[S3]** | AutoResearchClaw (aiming-lab) | [03-auto-research-claw.md](./03-auto-research-claw.md) |
+| **[P]** | agent-manifesto project 固有（新規） | — |
+
+各設計要素は source tag + section ref（例: [S2 §2.5]）で trace back 可能。
+**§N.M は survey record（01-*.md/02-*.md/03-*.md）内のセクション番号**を指す。
+原論文・原 GitHub 内の section ではない（survey 経由でアクセスする）。
+
+---
+
+## 1. 設計目標
+
+| # | 目標 | Source |
+|---|------|--------|
+| G1 | `.claude/metrics/p2-verified.jsonl` を読み込み submission-ready LaTeX → PDF を生成 | [P] ユーザ要件 |
+| G2 | 後続の宿題（follow-up）を構造化して永続化 | [P] ユーザ要件 |
+| G3 | jsonl を安全にフラッシュ（削除でなくアーカイブ後に空化） | [P] ユーザ要件 |
+| G4 | 捏造（データ/引用）を構造的に防ぐ | [S2 §4], [S3 §6] |
+| G5 | Claude Code の skill 機構に自然に統合 | [S2 §3.1] |
+| G6 | T6（人間の最終決定権）を尊重、強制より警告主体 | [P] CLAUDE.md L1 |
+| G7 | Verifier (PR #637) との dog-fooding | [S2 §2.5] |
+
+---
+
+## 2. Source Mapping Table（★中核）
+
+設計要素ごとに、どの先行研究のどのセクションから来たかを明示:
+
+| 設計要素 | 採用/改変 | Primary Source | Secondary | 注記 |
+|---------|----------|---------------|-----------|------|
+| **5-agent pipeline (Outline / Plotting / LitRev / Writing / Refinement)** | 採用（一部改変） | [S2 §2] | — | 骨格として採用。Plotting は軽量化、LitRev は内部化 |
+| **Skills-based architecture** (SKILL.md + references/ + scripts/) | 採用 | [S2 §3.1] | — | Claude Code に最も自然 |
+| **Outline Agent** — JSON blueprint 出力 | 採用 | [S2 §2.1] | — | 出力形式そのまま |
+| **Plotting Agent** — PaperBanana + VLM critic | **軽量化** | [S2 §2.2] | — | matplotlib で十分。VLM は省略 |
+| **Literature Review Agent** — Semantic Scholar + 90% cite rule | **内部化** | [S2 §2.3] | [S1 §2.3] | 外部論文でなく内部 PR/issue/commit の graph。90% cite rule は同じ比率で internal citation に適用 |
+| **Section Writing Agent** — single multimodal call | 採用 | [S2 §2.4] | [S1 §2.3] | S1 の "single-pass + reflection" 思想と同じ |
+| **Content Refinement Agent** — AgentReview halt rule | **Verifier で代替** | [S2 §2.5] | — | 我々の Verifier pairwise (PR #637) で AgentReview を代替。P2 検証独立性 |
+| **Halt rule: 「score 減少で即座に halt」** | 採用 | [S2 §2.5] | [S3 §5] | AgentReview 準拠。Verifier の winner=B margin<0 で halt |
+| **Anti-hallucination: 存在しない data 要求無視** | 採用 | [S2 §4] | — | system prompt に明示 |
+| **Knowledge Base 6 category (todos.md 構造)** | 採用 | [S3 §3] | — | Decisions/Experiments/Findings/Literature/Questions/Reviews |
+| **30-day time-decay for Questions** | 採用 | [S3 §3] | — | `evidence/expired-questions.md` に移動 |
+| **`[UNVERIFIED]` tag** | 採用 | [S2 §3.4] | [S3 §6] | 両者が同機構 |
+| **Agent Research Aggregator 4-phase** | 採用 | [S2 §3.4] | — | jsonl → experimental_log.md 変換の骨格 |
+| **Evidence archive directory** | 採用 | [S1 §3], [S3 §8] | — | `docs/papers/<slug>/evidence/` |
+| **Single-pass writeup + reflection** | 採用 | [S1 §2.3] | [S2 §2.5] | Aider 的逐次編集を避ける |
+| **Page length constraint in prompt** | 採用 | [S1 §2.3] | — | 冗長性抑制 |
+| **paperize.yaml 外部設定** | 採用 | [S1 §3] | [S3 §4] | bfts_config.yaml / config.arc.yaml 相当 |
+| **PROCEED / REFINE / PIVOT 判定** | **既存整合** | [S3 §5] | — | 我々の Verifier 判定 PASS/CONDITIONAL/FAIL と直接対応 |
+| **HITL SmartPause** | **採用（弱）** | [S3 §7] | — | commit hook は warn のみ（block せず）。T6 尊重 |
+| **Cost Guardrails** | 見送り | [S3 §7] | — | 我々は local LLM 中心、API 課金 warning は不要 |
+| **23-stage pipeline** | 不採用 | [S3 §2] | — | 我々は writeup-only、tree search 不要 |
+| **Tree-based experimentation** | 不採用 | [S1 §2.2] | [S3] | 既に検証済みトークン列が入力 |
+| **Multi-agent debate (Innovator/Pragmatist/Contrarian)** | 不採用 | [S3 §2] | — | hypothesis generation 不要 |
+| **VLM for figures** | 不採用 | [S1 §2.3], [S2 §2.2] | — | 成果物は table 中心 |
+| **OpenAlex / arXiv / Semantic Scholar** | 見送り | [S2 §2.3], [S3 §2] | — | 内部 citation に集中 |
+| **NeurIPS / ICLR template** | **内部 template で代替** | [S3 §8] | — | internal report 形式（LNCS-like 軽量） |
+| **Dashboard / WebSocket / Overleaf** | 不採用 | [S3 §9] | — | overengineering |
+| **Sentinel Watchdog background monitor** | 不採用 | [S3 §6] | — | commit hook で代用 |
+| **MetaClaw cross-run learning (arc-* skill files)** | **軽量版採用** | [S3 §3] | — | `evidence/lessons.md` に前回の /paperize の反省を 1 行ずつ |
+
+**網羅性チェック**: 上記 30 項目で、3 サーベイ記録の主要機構を全て cover（採用/改変/不採用の明示）。
+
+---
+
+## 3. 統合アーキテクチャ（採用要素のみ）
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Pre-Agent: Aggregator                            Source: [S2 §3.4] │
+│  Phase 1 Discovery:  scan p2-verified.jsonl                │
+│  Phase 2 Extraction: LLM reads commits/PRs/issues          │
+│  Phase 3 Synthesis:  merge redundant tokens                │
+│  Phase 4 Formatting: → experimental_log.md + idea.md      │
+└────────────────────┬────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Agent 1: Outline                                Source: [S2 §2.1] │
+│  入力: idea.md + experimental_log.md + template.tex        │
+│  出力: outline.json (section plan + visualization plan +   │
+│        internal citation hints)                            │
+└────────────────────┬────────────────────────────────────────┘
+                     │
+        ┌────────────┴────────────┐    (並列 [S2 §2.2-2.3])
+        ▼                          ▼
+┌──────────────┐            ┌─────────────────────┐
+│ Agent 2:     │            │ Agent 3:            │
+│ Plotting     │            │ Internal Citation   │
+│ (matplotlib) │            │  (PR/issue/commit   │
+│              │            │   graph 構築)       │
+│ Source:      │            │ Source: [S2 §2.3]   │
+│ [S2 §2.2]    │            │ 改変: 外部 → 内部   │
+│ 改変: VLM 省略│            └──────────┬──────────┘
+└──────┬───────┘                       │
+       │                               │
+       └───────────────┬───────────────┘
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Agent 4: Section Writing                   Source: [S2 §2.4] │
+│  Single-pass multimodal call                Source: [S1 §2.3]│
+│  Page length constraint                     Source: [S1 §2.3]│
+│  Anti-hallucination: 存在しない data 要求無視 Source: [S2 §4]│
+│  [UNVERIFIED] tag                           Source: [S2 §3.4]│
+└────────────────────┬────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Agent 5: Refinement (Verifier pairwise)   Source: [S2 §2.5]  │
+│  我々の Verifier (PR #637) で AgentReview を代替             │
+│  Halt rule:                                                 │
+│   - winner=A, margin>0 → accept                            │
+│   - winner=B → revert + halt              Source: [S2 §2.5] │
+│  k_rounds=3, bidirectional                Source: [P] PR#617│
+└────────────────────┬────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Post-Agent: Archiver                       Source: [S3 §8]   │
+│  LaTeX compile → paper.pdf                                  │
+│  todos.md 更新 (Knowledge Base 6 cat)       Source: [S3 §3] │
+│  evidence/*.jsonl (p2-verified snapshot)                    │
+│  jsonl をフラッシュ（空にする）              Source: [P]    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. File Structure
+
+```
+.claude/skills/paperize/
+├── SKILL.md                                  # orchestrator skill
+├── references/
+│   ├── outline-prompt.md                     # [S2 §2.1] Outline Agent prompt
+│   ├── section-writing-prompt.md             # [S2 §2.4] Writing Agent prompt
+│   ├── refinement-prompt.md                  # [S2 §2.5] Refinement Agent prompt
+│   ├── halt-rules.md                         # [S2 §2.5] halt conditions
+│   ├── anti-hallucination-rules.md           # [S2 §4]
+│   ├── page-length-rules.md                  # [S1 §2.3]
+│   ├── knowledge-base-schema.md              # [S3 §3] todos.md 6 cat
+│   ├── internal-citation-rules.md            # [S2 §2.3] adapted
+│   ├── schemas/
+│   │   ├── outline.schema.json               # [S2 §2.1]
+│   │   ├── experimental-log.schema.json      # [S2 §2.1]
+│   │   └── todos.schema.json                 # [S3 §3]
+│   ├── rubrics.md                            # [S2 §2.5] evaluation rubrics
+│   └── template/
+│       ├── paper.tex                         # internal report template
+│       └── guidelines.md                     # [P] internal 規約
+└── scripts/
+    ├── aggregate-jsonl.sh                    # [S2 §3.4] Phase 1-4 Aggregator
+    ├── collect-commit-context.sh             # [S2 §3.4] Phase 2
+    ├── build-internal-citation-graph.sh      # [S2 §2.3] internal 版
+    ├── verifier-refinement.py                # [S2 §2.5] + PR #637 統合
+    ├── latex-sanity-check.sh                 # [S3 §6] AI-slop detection 軽量版
+    ├── compile-paper.sh                      # pandoc / latexmk
+    ├── update-todos.py                       # [S3 §3] Knowledge Base 更新
+    ├── decay-expired-questions.py            # [S3 §3] 30-day decay
+    └── flush-jsonl.sh                        # [P] jsonl を空化
+```
+
+出力:
+```
+docs/papers/YYYY-MM-DD-<slug>/                # [S3 §8] に対応
+├── paper.tex                                 # [S3 §8]
+├── paper.pdf                                 # [S1 §3]
+├── todos.md                                  # [S3 §3] 6 cat
+├── outline.json                              # [S2 §2.1]
+├── evidence/
+│   ├── p2-verified-snapshot.jsonl            # [P] 元 jsonl のコピー
+│   ├── commits.md                            # [S2 §3.4]
+│   ├── sources.md                            # [S2 §3.4]
+│   ├── lessons.md                            # [S3 §3] MetaClaw 軽量版
+│   └── expired-questions.md                  # [S3 §3] decayed
+└── metadata.json                             # [P] 再現性: model/k/timestamp
+```
+
+---
+
+## 5. `paperize.yaml` Schema
+
+```yaml
+# [S1 §3] bfts_config.yaml / [S3 §4] config.arc.yaml を参照
+
+# --- 入力指定 ---
+input:
+  jsonl_path: .claude/metrics/p2-verified.jsonl
+  git_range: HEAD~20..HEAD                    # 関連 commit の収集範囲
+  issue_labels: [research, verifier]           # 関連 issue の絞り込み
+  pr_merged_since: 7d                          # 直近 N 日の PR
+
+# --- 論文設定 ---
+paper:
+  template: internal-report                    # [P] or neurips / iclr
+  max_pages: 8                                 # [S1 §2.3] page length constraint
+  slug_format: "{date}-{primary-topic}"
+
+# --- Agent 設定 ---
+agents:
+  outline:
+    model: claude-opus-4-7                     # [S1 §2.3] reasoning model
+    max_tokens: 8000
+  section_writing:
+    model: claude-opus-4-7
+    extended_thinking: true                    # [S1 §2.3] reflection 相当
+  refinement:
+    verifier: logprob/qwen                     # [P] PR #637
+    k_rounds: 3                                # [P] PR #636
+    bidirectional: true                        # [P] PR #617
+    halt_on_margin_below: 0.0                  # [S2 §2.5] winner=B で halt
+    max_iterations: 7                          # [S2] "5-7 calls"
+
+# --- Follow-up 管理 ---
+follow_up:
+  todos_file: todos.md                         # [S3 §3]
+  categories:                                  # [S3 §3] 6 cat
+    - decisions
+    - experiments
+    - findings
+    - literature
+    - questions
+    - reviews
+  decay_days: 30                               # [S3 §3]
+
+# --- 強制 ---
+enforcement:
+  mode: warn                                   # [P] T6: warn / block / skip
+  jsonl_flush_on_complete: true                # [P] G3
+  git_commit_on_complete: true                 # [P] 成果物を追跡
+  require_evaluator_independent: true          # [P] P2
+```
+
+---
+
+## 6. Trigger 機構（3 層）
+
+| 層 | 機構 | 強さ | Source |
+|----|------|------|--------|
+| **L1: 明示実行** | `/paperize` スキル呼び出し | ユーザ駆動 | [S2 §3.5] |
+| **L2: commit hook (warn)** | `scripts/paperize-reminder.sh`: jsonl ≥ N entries / ≥ N days で stderr 警告 | 弱（block せず） | [S3 §7] SmartPause 軽量版 |
+| **L3: session end (reminder)** | Stop hook: 未処理 jsonl をリマインド | 弱 | [S3 §7] |
+
+**L2/L3 はあくまで reminder — T6 (人間の最終決定権) を尊重して block はしない** ([P] CLAUDE.md L1)。
+
+---
+
+## 7. Agent 5 (Refinement) の Verifier 統合設計（★dog-fooding の中核）
+
+### 7.1 置換関係
+
+| PaperOrchestra AgentReview | 我々の Verifier pairwise | 実装 |
+|--------------------------|-------------------------|------|
+| manuscript を review | proposal_a = revised manuscript, proposal_b = current manuscript | [S2 §2.5] 写像 |
+| 「score 増加または同点 + sub-axis net non-negative」で accept | winner=A と margin > 0 | [S2 §2.5] 写像 |
+| 「score 減少」で revert + halt | winner=B で revert + halt | [S2 §2.5] 写像 |
+| ~5-7 iterations | `max_iterations: 7` | [S2] |
+
+### 7.2 criteria（論文品質判定）
+
+[S2 §2.5] と [S3 §6] を統合:
+
+| # | criterion | description | Source |
+|---|-----------|-------------|--------|
+| R1 | clarity | Is the revision clearer and better structured? | [S2 §2.5] |
+| R2 | evidence_consistency | Are claims backed by evidence archive data only? | [S3 §6] VerifiedRegistry |
+| R3 | citation_integrity | Do internal citations (PR/issue/commit) resolve? | [S2 §2.3] |
+| R4 | length_compliance | Does it satisfy `max_pages` constraint? | [S1 §2.3] |
+
+### 7.3 Loop 制御
+
+```python
+# scripts/verifier-refinement.py ([S2 §2.5] + PR #637)
+for iteration in range(max_iterations):
+    revised = section_writing_agent.refine(current_draft, review_comments)
+    result = verifier_local.pairwise_compare(
+        problem="Evaluating manuscript refinement.",
+        proposal_a=revised,
+        proposal_b=current_draft,
+        criteria=[R1, R2, R3, R4],
+        k_rounds=3,
+        bidirectional=True,
+    )
+    if result['winner'] == 'A' and result['margin'] > 0.0:
+        current_draft = revised       # accept
+    else:
+        break                         # halt (revert は current_draft 保持で自然)
+```
+
+### 7.4 evaluatorIndependent
+
+- Worker (Claude Opus 4.7) と Verifier (Qwen3.5-4B) は別モデルファミリ
+- → `.claude/metrics/p2-verified.jsonl` に `evaluator_independent=true` の token を書き込み
+- → p2-verify-on-commit.sh が通る ([P] PR #641 と同じ経路)
+
+**自己言及的**: paperize が書く論文は、paperize 自身の evaluatorIndependent 要件を満たす必要がある
+→ 構造が自己強制する → **P2 (検証の独立性) の実例**。
+
+---
+
+## 8. Knowledge Base: `todos.md` 詳細設計
+
+[S3 §3] 6 category を採用。各 entry に timestamp と 30-day decay ([S3 §3]):
+
+```markdown
+# Research Follow-ups — {paperize-slug}
+
+> Generated by /paperize on {timestamp}
+> Source: {commit-hashes}, {pr-numbers}, {issue-numbers}
+> Next decay scan: {timestamp + 30 days}
+
+## Decisions
+<!-- 採用した設計判断 (rationale, stage, approval status) -->
+- [DEC-001] {date} {description} — approval: {T6 tag}
+
+## Experiments
+<!-- 実施した実験 (runs, metrics, failure modes) -->
+- [EXP-001] {date} {n} samples, k={k}, model={model}, accuracy={x}
+
+## Findings
+<!-- 主要な発見 (novel insights, anomalies) -->
+- [FIN-001] {date} {description}
+
+## Literature
+<!-- 引用した文献 (internal: PR/issue/commit; external: arxiv) -->
+- [LIT-001] {date} {source} — relevance: high/medium
+
+## Questions  ← Follow-up 宿題
+<!-- 未解決 (unresolved directions, branching paths) -->
+- [Q-001] {date} {description} — expires {timestamp + 30d}
+
+## Reviews
+<!-- 本論文に対する peer review (Verifier margin, reviewer feedback) -->
+- [REV-001] {date} Verifier pairwise margin={x}, k_rounds={k}
+```
+
+### Decay 処理
+
+`scripts/decay-expired-questions.py`:
+1. `todos.md` を parse
+2. `Questions` category の各 entry の `expires` date を確認
+3. 期限切れを `evidence/expired-questions.md` に移動
+4. `todos.md` から削除
+
+**呼び出しタイミング**:
+- `/paperize` 実行の最初（前回の expired を整理してから開始）
+- cron hook で週次（optional）
+
+---
+
+## 9. 棄却代替案（rejected alternatives）
+
+設計過程で検討したが採用しなかった選択肢:
+
+| 代替案 | 却下理由 | 出典 |
+|--------|---------|------|
+| Tree search を軽量化して採用 | 我々は writeup-only。探索対象（hypothesis）が既に確定している | [S1] 不要 |
+| VLM figure critic | 我々の成果物は table 中心、figure は少数 | [S1 §2.3] |
+| PaperBanana diagram 生成 | matplotlib で十分 | [S2 §2.2] |
+| Semantic Scholar 連携 | 内部 citation に集中、外部は optional | [S2 §2.3] |
+| OpenAlex / arXiv 連携 | 同上 | [S3 §2] |
+| Multi-agent debate (Innovator/Pragmatist/Contrarian) | hypothesis generation 不要 | [S3 §2] |
+| 23-stage pipeline | 8 phase のうち 6 phase が不要（experiment 関連） | [S3 §2] |
+| NeurIPS/ICLR template 強制 | internal report 形式の方が我々の文脈に合う | [S3 §8] |
+| Dashboard / Overleaf | overengineering、pandoc で十分 | [S3 §9] |
+| HITL 全機能 (Co-Pilot, Gate-Only, Step-by-Step) | 我々は「warn + skill」の軽量 2 層で足りる | [S3 §7] |
+| AI-Scientist-v2 の Aider-based 逐次編集 | V2 自身が single-pass + reflection に切り替えた | [S1 §2.3] |
+| Citation hallucination 許容 | anti-hallucination を最初から採用 | [S1 §5] が指摘 |
+| commit hook で block (強制) | T6 尊重 ([P] CLAUDE.md)、warn に留める | [P], [S3 §7] |
+
+---
+
+## 10. 実装 Sub-Issue 分割案
+
+本 SS4 で **設計** は確定。**実装** は別 Sub-Issues に分割:
+
+| Sub-Issue | タスク | 依存 |
+|-----------|-------|------|
+| SS5 | `scripts/aggregate-jsonl.sh` (Aggregator 4-phase) [S2 §3.4] 実装 | SS4 |
+| SS6 | `.claude/skills/paperize/SKILL.md` orchestrator + references 実装 | SS5 |
+| SS7 | `scripts/verifier-refinement.py` [S2 §2.5] + PR #637 統合 | SS6 |
+| SS8 | `scripts/update-todos.py` + `decay-expired-questions.py` [S3 §3] | SS6 |
+| SS9 | `scripts/compile-paper.sh` + LaTeX template [S1 §2.3] | SS6 |
+| SS10 | commit hook (warn) + Stop hook [S3 §7] ... **L1 承認要** | SS6, 人間 setup スクリプト |
+| SS11 | End-to-end smoke test: 過去 PR #641 の jsonl エントリを paperize | SS5-9 |
+
+---
+
+## 11. Gate 判定 (SS4 用)
+
+本 SS4 の成果物:
+
+1. ✅ **Source Mapping Table (§2)** — 30 設計要素を 3 サーベイに trace back
+2. ✅ **統合アーキテクチャ (§3)** — 採用/改変/不採用を図で明示
+3. ✅ **File Structure (§4)** — skills/paperize/ 配置
+4. ✅ **paperize.yaml Schema (§5)** — config 型定義
+5. ✅ **Trigger 機構 (§6)** — 3 層 (explicit/warn/reminder)
+6. ✅ **Verifier 統合設計 (§7)** — dog-fooding の実装スケッチ
+7. ✅ **todos.md 詳細 (§8)** — Knowledge Base 6 cat
+8. ✅ **棄却代替案 (§9)** — 13 項目
+9. ✅ **実装 Sub-Issue 分割 (§10)** — SS5-11
+
+### Gate 判定: **PASS 候補**
+
+- Source Mapping 完備 ✅
+- 3 サーベイに網羅的に trace back 可 ✅
+- 棄却判断も明示 ✅
+
+**次のアクション**: SS5-11 の順で実装 (別ラウンドで順次)。
+
+---
+
+## 12. Traceability Integrity Check
+
+以下は自動検証したい項目（future work）:
+
+```bash
+# 各 Source Tag が存在するファイルに対応するか
+grep -oE '\[S[123][^]]*\]' 04-integrated-design.md | sort -u
+# 期待: S1 §2.1/§2.2/§2.3/§3/§5, S2 §2/§2.1-2.5/§3.1/§3.4/§3.5/§4,
+#       S3 §2/§3/§4/§5/§6/§7/§8/§9  (全 28 tag, 2026-04-20 audit で 0 broken 確認)
+
+# 各サーベイ記録の該当 section が実在するか（grep の存在確認）
+for s in 01 02 03; do
+  grep -c "^## " docs/research/autonomous-research-pipelines/$s-*.md
+done
+```
+
+→ 別スクリプト `scripts/validate-source-tags.sh` で将来自動化（SS10 の一部として検討）。
+
+---
+
+## References
+
+- 先行サーベイ 3 件（本ディレクトリ内）
+- Verifier 実装: `scripts/verifier_local.py`, PR #617, #637
+- Verifier 論文: [Kwok et al. 2026] `research/LLM-as-a-Verifier_*.pdf`
+- PaperOrchestra 実装: [Ar9av/PaperOrchestra](https://github.com/Ar9av/PaperOrchestra)
+- AutoResearchClaw: [aiming-lab/AutoResearchClaw](https://github.com/aiming-lab/AutoResearchClaw)

--- a/docs/research/autonomous-research-pipelines/README.md
+++ b/docs/research/autonomous-research-pipelines/README.md
@@ -1,0 +1,83 @@
+# Autonomous Research Pipelines — Survey Records
+
+> **Parent Issue**: #642
+> **Purpose**: `.claude/metrics/p2-verified.jsonl` 論文化フローの設計に向けた先行研究サーベイ
+> **Status**: 3 システムのサーベイ完了 (2026-04-20)、設計は別 issue で継続
+
+## 目的
+
+`p2-verified.jsonl`（git 非追跡の検証トークン log）が存在する時に:
+1. 調査研究の最終結果を LaTeX → PDF に論文化
+2. 後続の宿題 (follow-up) を保存
+3. jsonl をフラッシュ
+
+するフローを構造的に強制したい。設計前に先行研究を深堀し、共通要素・差分要素を把握する。
+
+## サーベイ対象 (3 システム)
+
+| # | System | Source | Focus |
+|---|--------|--------|-------|
+| 1 | **AI-Scientist-v2** | SakanaAI, arXiv 2504.08066 (2025-04) | end-to-end, agentic tree search |
+| 2 | **PaperOrchestra** | Google Cloud AI, arXiv 2604.05018 (2026-04) | writeup 専用, skills-based |
+| 3 | **AutoResearchClaw** | aiming-lab, GitHub | end-to-end + HITL + Knowledge Base |
+
+## 個別サーベイ記録
+
+1. [AI-Scientist-v2 深堀サーベイ](./01-ai-scientist-v2.md)
+2. [PaperOrchestra 深堀サーベイ](./02-paper-orchestra.md)
+3. [AutoResearchClaw 深堀サーベイ](./03-auto-research-claw.md)
+
+## 横断比較
+
+| 項目 | AI-Scientist-v2 | PaperOrchestra | AutoResearchClaw |
+|------|-----------------|----------------|------------------|
+| **焦点** | end-to-end | writeup 専用 | end-to-end + HITL |
+| **skills 構造** | モノリシック | **skills-based** ★ | skills + modules |
+| **Input** | markdown topic | idea.md + exp_log.md | topic 1 行 |
+| **核心機構** | 4-stage tree search + EPM | 5-agent pipeline | 23-stage + Knowledge Base |
+| **Anti-hallucination** | 弱 | 強 (Sem Scholar + AgentReview) | 最強 (5 層 + Sentinel) |
+| **Follow-up tracking** | なし | なし | ★ Knowledge Base 6 cat |
+| **Decay mechanism** | なし | なし | ★ 30-day |
+| **Refinement halt rule** | reflection 1 回 | score non-decrease 厳格 | PROCEED/REFINE/PIVOT |
+| **Verifier 写像性** | △ | ★★★ | ★★ |
+| **Claude Code 互換** | △ | ★★★ | ★★ |
+| **我々への適用性** | △ | ★★★ | ★★ |
+
+## 我々の設計への採用マトリクス
+
+### 中核骨格 → PaperOrchestra
+- 5-agent pipeline (Outline → [Plotting ∥ LitReview] → Writing → Refinement)
+- Skills-based architecture（`.claude/skills/paperize/` に自然 mapping）
+- AgentReview halt rule（score non-decrease）
+- `[UNVERIFIED]` tag
+
+### Follow-up 追跡 → AutoResearchClaw
+- Knowledge Base 6 category 構造を `todos.md` に採用
+  (Decisions / Experiments / Findings / Literature / Questions / Reviews)
+- 30-day time decay
+- PROCEED / REFINE / PIVOT 判定 → 我々の既存 Verifier 判定と一致
+
+### Orchestration 思想 → AI-Scientist-v2
+- Experiment Progress Manager 相当の stage coordinator
+- Single-pass writeup + reflection stage（Aider-style iteration は避ける）
+- Page length constraint を prompt に
+- 外部設定 file（`paperize.yaml`）
+
+## Dog-Fooding 機会
+
+- **Content Refinement Agent = 我々の Verifier pairwise (PR #637)**
+  - 書く AI (Claude Opus) と verify する AI (Qwen logprob) が別モデル → P2 (検証の独立性) を自然に満たす
+  - AgentReview の halt rule を直接 Verifier margin に mapping
+
+## Next Steps
+
+[#642 の Sub-Issue SS4] で 3 サーベイを統合した設計決定へ:
+1. `/paperize` skill の SKILL.md 骨格
+2. `references/` に配置する prompt / rubric / halt rule 定義
+3. `scripts/` に配置する deterministic helpers
+4. Trigger 機構（commit hook / session end / 明示実行）の判断
+5. `paperize.yaml` の schema
+
+## References
+
+3 サーベイ記録の末尾 References セクション参照。

--- a/scripts/aggregate-jsonl.sh
+++ b/scripts/aggregate-jsonl.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# @traces [S2 §3.4] PaperOrchestra Agent Research Aggregator (Phase 1 + 4)
+#
+# Phase 1 (Discovery) + Phase 4 (Formatting) — deterministic portions only.
+# Phase 2 (Extraction) and Phase 3 (Synthesis) are LLM-driven; they consume
+# the manifest emitted here.
+#
+# Usage:
+#   scripts/aggregate-jsonl.sh <output-dir> [jsonl-path] [git-range]
+#
+# Output:
+#   <output-dir>/manifest.json
+#   <output-dir>/evidence/p2-verified-snapshot.jsonl
+#   <output-dir>/evidence/commits.md   (human-readable summary)
+#   <output-dir>/evidence/sources.md   (touched-file index)
+
+set -euo pipefail
+
+OUTPUT_DIR="${1:?usage: aggregate-jsonl.sh <output-dir> [jsonl-path] [git-range]}"
+JSONL_PATH="${2:-.claude/metrics/p2-verified.jsonl}"
+GIT_RANGE="${3:-HEAD~20..HEAD}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[aggregate] ERROR: jq required" >&2; exit 2
+fi
+if [ ! -f "$JSONL_PATH" ]; then
+  echo "[aggregate] ERROR: jsonl not found: $JSONL_PATH" >&2; exit 2
+fi
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "[aggregate] ERROR: not in a git repository" >&2; exit 2
+fi
+
+mkdir -p "$OUTPUT_DIR/evidence"
+
+# ---------- Phase 1: Discovery ----------
+
+# 1a: snapshot jsonl for evidence
+cp "$JSONL_PATH" "$OUTPUT_DIR/evidence/p2-verified-snapshot.jsonl"
+
+# 1b: verifications array (normalize fields across schema drift)
+VERIFS_JSON=$(jq -s '[.[] | {
+  epoch: (.epoch // null),
+  timestamp: (.timestamp // null),
+  files: (.files // []),
+  verdict: (.verdict // "UNKNOWN"),
+  evaluator: (.evaluator // null),
+  evaluator_independent: (.evaluator_independent // null),
+  k_rounds: (.k_rounds // null),
+  pass_rate: (.pass_rate // null),
+  margin: (.margin // null),
+  criteria: (.criteria // []),
+  source: (.source // null)
+}]' "$JSONL_PATH")
+
+VERIF_COUNT=$(echo "$VERIFS_JSON" | jq 'length')
+PASS_COUNT=$(echo "$VERIFS_JSON" | jq '[.[] | select(.verdict=="PASS")] | length')
+
+# 1c: distinct files across all verifications
+FILES_TOUCHED_JSON=$(echo "$VERIFS_JSON" | jq '[.[].files[]] | unique')
+
+# 1d: git log in range → commits array
+#     body excluded at this phase (fetched on-demand in Phase 2)
+if ! git rev-parse "$GIT_RANGE" >/dev/null 2>&1; then
+  echo "[aggregate] WARN: git range $GIT_RANGE invalid, falling back to HEAD~5..HEAD" >&2
+  GIT_RANGE="HEAD~5..HEAD"
+fi
+
+COMMITS_RAW=$(git log --format='%H%x1f%s%x1f%an%x1f%aI' "$GIT_RANGE" 2>/dev/null || true)
+COMMITS_JSON="[]"
+if [ -n "$COMMITS_RAW" ]; then
+  COMMITS_JSON=$(printf '%s\n' "$COMMITS_RAW" \
+    | jq -R 'split("\u001f") | {
+        sha: .[0], subject: .[1], author: .[2], date: .[3]
+      }' \
+    | jq -s '.')
+fi
+
+# ---------- Phase 4: Formatting ----------
+
+# 4a: manifest.json (single source of truth for Phase 2/3 LLM)
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+jq -n \
+  --arg generated_at "$TIMESTAMP" \
+  --arg jsonl_path "$JSONL_PATH" \
+  --arg git_range "$GIT_RANGE" \
+  --argjson verifications "$VERIFS_JSON" \
+  --argjson files_touched "$FILES_TOUCHED_JSON" \
+  --argjson commits "$COMMITS_JSON" \
+  --argjson verif_count "$VERIF_COUNT" \
+  --argjson pass_count "$PASS_COUNT" \
+  '{
+    schema_version: "1",
+    generated_at: $generated_at,
+    input: {
+      jsonl_path: $jsonl_path,
+      git_range: $git_range
+    },
+    summary: {
+      verification_count: $verif_count,
+      pass_count: $pass_count,
+      distinct_file_count: ($files_touched | length),
+      commit_count: ($commits | length)
+    },
+    verifications: $verifications,
+    files_touched: $files_touched,
+    commits: $commits
+  }' > "$OUTPUT_DIR/manifest.json"
+
+# 4b: human-readable commits.md
+{
+  echo "# Commits in range: $GIT_RANGE"
+  echo ""
+  echo "$COMMITS_JSON" | jq -r '.[] | "- \(.date | .[0:10])  `\(.sha | .[0:8])`  \(.subject) — \(.author)"'
+} > "$OUTPUT_DIR/evidence/commits.md"
+
+# 4c: human-readable sources.md (file → verification count)
+{
+  echo "# Files touched across $VERIF_COUNT verifications"
+  echo ""
+  echo "$VERIFS_JSON" \
+    | jq -r '[.[].files[]] | group_by(.) | map({file: .[0], n: length}) | sort_by(-.n) | .[] | "- (\(.n)) \(.file)"'
+} > "$OUTPUT_DIR/evidence/sources.md"
+
+echo "[aggregate] manifest:  $OUTPUT_DIR/manifest.json"
+echo "[aggregate] verifs=$VERIF_COUNT pass=$PASS_COUNT files=$(echo "$FILES_TOUCHED_JSON" | jq 'length') commits=$(echo "$COMMITS_JSON" | jq 'length')"

--- a/scripts/compile-paper.sh
+++ b/scripts/compile-paper.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# @traces [S1 §2.3] single-pass writeup compilation
+#
+# compile-paper.sh — render paper.tex → paper.pdf.
+#
+# Strategy: try latexmk first (fastest reliable), fall back to tectonic, then
+# to raw pdflatex. If none available, exit 1 with a clear message.
+#
+# Usage:
+#   scripts/compile-paper.sh input.tex output.pdf
+
+set -euo pipefail
+
+IN_TEX="${1:?usage: compile-paper.sh <input.tex> <output.pdf>}"
+OUT_PDF="${2:?usage: compile-paper.sh <input.tex> <output.pdf>}"
+
+if [ ! -f "$IN_TEX" ]; then
+  echo "[compile] ERROR: input not found: $IN_TEX" >&2; exit 2
+fi
+
+BUILD_DIR=$(dirname "$OUT_PDF")/.latex-build
+mkdir -p "$BUILD_DIR"
+
+IN_ABS=$(cd "$(dirname "$IN_TEX")" && pwd)/$(basename "$IN_TEX")
+OUT_ABS=$(cd "$(dirname "$OUT_PDF")" && pwd)/$(basename "$OUT_PDF")
+BUILD_ABS=$(cd "$BUILD_DIR" && pwd)
+
+if command -v latexmk >/dev/null 2>&1; then
+  echo "[compile] using latexmk"
+  (cd "$(dirname "$IN_TEX")" && latexmk -pdf -interaction=nonstopmode -halt-on-error \
+    -output-directory="$BUILD_ABS" "$(basename "$IN_TEX")") || {
+      echo "[compile] latexmk failed (see $BUILD_ABS/*.log)" >&2; exit 3;
+    }
+elif command -v tectonic >/dev/null 2>&1; then
+  echo "[compile] using tectonic"
+  tectonic -o "$BUILD_ABS" "$IN_ABS" || {
+    echo "[compile] tectonic failed" >&2; exit 3;
+  }
+elif command -v pdflatex >/dev/null 2>&1; then
+  echo "[compile] using pdflatex (2 passes)"
+  (cd "$(dirname "$IN_TEX")" && pdflatex -interaction=nonstopmode -halt-on-error \
+    -output-directory="$BUILD_ABS" "$(basename "$IN_TEX")" >/dev/null &&
+   pdflatex -interaction=nonstopmode -halt-on-error \
+    -output-directory="$BUILD_ABS" "$(basename "$IN_TEX")" >/dev/null) || {
+      echo "[compile] pdflatex failed (see $BUILD_ABS/*.log)" >&2; exit 3;
+    }
+else
+  echo "[compile] ERROR: none of {latexmk, tectonic, pdflatex} available" >&2
+  echo "[compile] install via:  brew install --cask mactex-no-gui   or   brew install tectonic" >&2
+  exit 2
+fi
+
+BASENAME=$(basename "$IN_TEX" .tex)
+SRC_PDF="$BUILD_ABS/$BASENAME.pdf"
+if [ ! -f "$SRC_PDF" ]; then
+  echo "[compile] ERROR: expected output not produced: $SRC_PDF" >&2; exit 3
+fi
+
+cp "$SRC_PDF" "$OUT_ABS"
+echo "[compile] wrote: $OUT_ABS"

--- a/scripts/decay-expired-questions.py
+++ b/scripts/decay-expired-questions.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+decay-expired-questions.py — move stale `questions` from todos.md to expired log.
+
+Traces: [S3 §3] 30-day time decay.
+
+Rules:
+  - Only `## questions` entries are subject to decay.
+  - An entry with `decay_at` < today is moved out of todos.md into
+    <output-dir>/evidence/expired-questions.md.
+  - Other categories (decisions, findings, etc.) are never decayed.
+
+Usage:
+  scripts/decay-expired-questions.py --todos path/to/todos.md \\
+                                     --evidence-dir path/to/evidence
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+CATEGORIES = ["decisions", "experiments", "findings", "literature", "questions", "reviews"]
+
+
+def _split_sections(todos_text: str) -> tuple[str, dict[str, list[str]], str]:
+    """Return (frontmatter_block, sections_lines_by_cat, trailing)."""
+    m = re.match(r"\A(---\n.*?\n---\n)", todos_text, re.DOTALL)
+    frontmatter = m.group(1) if m else ""
+    body = todos_text[len(frontmatter):]
+
+    sections: dict[str, list[str]] = {c: [] for c in CATEGORIES}
+    current = None
+    lines = body.splitlines()
+    header_re = re.compile(r"^##\s+(\w+)\s*$")
+    preamble: list[str] = []
+    for line in lines:
+        h = header_re.match(line.strip())
+        if h and h.group(1) in CATEGORIES:
+            current = h.group(1)
+            continue
+        if current is None:
+            preamble.append(line)
+        else:
+            sections[current].append(line)
+
+    # rejoin preamble as trailing-free header block
+    return frontmatter, sections, "\n".join(preamble)
+
+
+_ENTRY_RE = re.compile(r"^-\s+\[(\d{4}-\d{2}-\d{2})\]\s+")
+_DECAY_RE = re.compile(r"decay_at\s*=\s*(\d{4}-\d{2}-\d{2})")
+
+
+def _partition_questions(q_lines: list[str], today: date) -> tuple[list[str], list[str]]:
+    """Walk indented entry blocks, split into (alive, expired)."""
+    blocks: list[list[str]] = []
+    cur: list[str] = []
+    for line in q_lines:
+        if _ENTRY_RE.match(line.strip()) and cur:
+            blocks.append(cur)
+            cur = [line]
+        else:
+            cur.append(line)
+    if cur:
+        blocks.append(cur)
+
+    alive: list[str] = []
+    expired: list[str] = []
+    for block in blocks:
+        joined = "\n".join(block)
+        m = _DECAY_RE.search(joined)
+        if not m:
+            alive.extend(block)
+            continue
+        try:
+            d = date.fromisoformat(m.group(1))
+        except ValueError:
+            alive.extend(block)
+            continue
+        if d < today:
+            expired.extend(block)
+        else:
+            alive.extend(block)
+    return alive, expired
+
+
+def _render_todos(frontmatter: str, preamble: str, sections: dict[str, list[str]]) -> str:
+    out = [frontmatter, preamble.rstrip(), ""]
+    for cat in CATEGORIES:
+        lines = sections[cat]
+        trimmed = "\n".join(lines).strip("\n")
+        if not trimmed:
+            out.append(f"## {cat}\n\n_(empty)_\n")
+        else:
+            out.append(f"## {cat}\n")
+            out.append(trimmed)
+            out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--todos", type=Path, required=True, help="path to todos.md")
+    parser.add_argument("--evidence-dir", type=Path, required=True,
+                        help="path to evidence/ directory (expired-questions.md written here)")
+    parser.add_argument("--today", type=str, default=None,
+                        help="override today (ISO date, for testing)")
+    args = parser.parse_args()
+
+    if not args.todos.exists():
+        raise SystemExit(f"todos not found: {args.todos}")
+
+    today = date.fromisoformat(args.today) if args.today else date.today()
+
+    text = args.todos.read_text()
+    fm, sections, preamble = _split_sections(text)
+    alive, expired = _partition_questions(sections["questions"], today)
+    sections["questions"] = alive
+
+    args.todos.write_text(_render_todos(fm, preamble, sections))
+
+    if expired:
+        args.evidence_dir.mkdir(parents=True, exist_ok=True)
+        expired_path = args.evidence_dir / "expired-questions.md"
+        ts = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+        header = [
+            "# Expired Questions",
+            "",
+            f"Decayed at {ts} (today = {today.isoformat()})",
+            "",
+        ]
+        prior = expired_path.read_text() if expired_path.exists() else ""
+        expired_path.write_text("\n".join(header) + "\n".join(expired) + "\n\n" + prior)
+        print(f"[decay] moved {sum(1 for L in expired if _ENTRY_RE.match(L.strip()))} questions → {expired_path}")
+    else:
+        print("[decay] no expired questions")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup-paperize-hooks.sh
+++ b/scripts/setup-paperize-hooks.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# setup-paperize-hooks.sh — /paperize warn-mode hooks セットアップ（人間が実行）
+#
+# L1 safety: LLM は .claude/hooks/ と .claude/settings.json を直接書けない
+# (l1-file-guard.sh 強制)。人間が本スクリプトを実行することで hook を設置する。
+#
+# Installs:
+#   1. .claude/hooks/paperize-jsonl-warn.sh  (SessionStart)
+#      p2-verified.jsonl に N 件 (>0) 未処理エントリがあれば stderr に警告
+#   2. .claude/hooks/paperize-stop-reminder.sh  (Stop)
+#      セッション終了時に jsonl エントリがあれば /paperize 起動を促す
+#
+# Idempotent: 既に登録済みならスキップ。
+#
+# 使用方法:
+#   bash scripts/setup-paperize-hooks.sh
+#
+# @traces P3, T2, D1
+
+set -euo pipefail
+
+BASE="$(git rev-parse --show-toplevel)"
+HOOK_DIR="$BASE/.claude/hooks"
+SETTINGS="$BASE/.claude/settings.json"
+WARN_HOOK="$HOOK_DIR/paperize-jsonl-warn.sh"
+STOP_HOOK="$HOOK_DIR/paperize-stop-reminder.sh"
+
+mkdir -p "$HOOK_DIR"
+
+# ---------- Hook file 1: SessionStart warn ----------
+cat > "$WARN_HOOK" <<'HOOK_EOF'
+#!/usr/bin/env bash
+# paperize-jsonl-warn.sh — SessionStart hook.
+# p2-verified.jsonl に未処理エントリがあれば警告する。
+# @traces P3, D1
+
+set -euo pipefail
+BASE="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+JSONL="$BASE/.claude/metrics/p2-verified.jsonl"
+[ -f "$JSONL" ] || exit 0
+N=$(grep -c '' "$JSONL" 2>/dev/null || echo 0)
+[ "$N" -gt 0 ] 2>/dev/null || exit 0
+
+PAPERIZE_MODE=$(yq -r '.enforcement.mode // "warn"' "$BASE/paperize.yaml" 2>/dev/null || echo "warn")
+case "$PAPERIZE_MODE" in
+  skip) exit 0 ;;
+esac
+
+echo "[paperize] p2-verified.jsonl に $N 件の未処理検証トークンがあります" >&2
+echo "[paperize] /paperize で論文化 → todos.md 保存 → jsonl flush を実行できます" >&2
+HOOK_EOF
+chmod +x "$WARN_HOOK"
+
+# ---------- Hook file 2: Stop reminder ----------
+cat > "$STOP_HOOK" <<'HOOK_EOF'
+#!/usr/bin/env bash
+# paperize-stop-reminder.sh — Stop hook.
+# セッション終了時に jsonl エントリがあれば /paperize 起動を促す。
+# @traces P3, D1
+
+set -euo pipefail
+BASE="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+JSONL="$BASE/.claude/metrics/p2-verified.jsonl"
+[ -f "$JSONL" ] || exit 0
+N=$(grep -c '' "$JSONL" 2>/dev/null || echo 0)
+[ "$N" -gt 0 ] 2>/dev/null || exit 0
+
+PAPERIZE_MODE=$(yq -r '.enforcement.mode // "warn"' "$BASE/paperize.yaml" 2>/dev/null || echo "warn")
+case "$PAPERIZE_MODE" in
+  skip) exit 0 ;;
+esac
+
+echo "[paperize] セッション終了: p2-verified.jsonl に $N 件の検証トークンが蓄積中" >&2
+echo "[paperize] 次セッション開始前に /paperize 実行を推奨" >&2
+HOOK_EOF
+chmod +x "$STOP_HOOK"
+
+echo "[setup] installed: $WARN_HOOK"
+echo "[setup] installed: $STOP_HOOK"
+
+# ---------- Register in settings.json ----------
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[setup] ERROR: jq required for settings.json edit" >&2; exit 2
+fi
+
+# idempotent check
+ALREADY_SS=$(jq '[.hooks.SessionStart[0].hooks[] | .command] | map(select(contains("paperize-jsonl-warn"))) | length' "$SETTINGS")
+ALREADY_STOP=$(jq '[.hooks.Stop // [] | .[0].hooks[]? | .command] | map(select(contains("paperize-stop-reminder"))) | length' "$SETTINGS" 2>/dev/null || echo 0)
+
+NEEDS_UPDATE=false
+if [ "$ALREADY_SS" = "0" ]; then NEEDS_UPDATE=true; fi
+if [ "$ALREADY_STOP" = "0" ]; then NEEDS_UPDATE=true; fi
+
+if [ "$NEEDS_UPDATE" = "false" ]; then
+  echo "[setup] hooks already registered in settings.json (idempotent skip)"
+  exit 0
+fi
+
+TMP=$(mktemp)
+jq '
+  .hooks.SessionStart[0].hooks |= (
+    if any(.command | contains("paperize-jsonl-warn")) then .
+    else . + [{"type":"command","command":"bash $CLAUDE_PROJECT_DIR/.claude/hooks/paperize-jsonl-warn.sh"}]
+    end
+  )
+  | .hooks.Stop = (
+    if (.hooks.Stop // null) == null then
+      [{"matcher":"","hooks":[{"type":"command","command":"bash $CLAUDE_PROJECT_DIR/.claude/hooks/paperize-stop-reminder.sh"}]}]
+    elif any(.hooks.Stop[0].hooks[]?; .command | contains("paperize-stop-reminder")) then .hooks.Stop
+    else
+      (.hooks.Stop[0].hooks += [{"type":"command","command":"bash $CLAUDE_PROJECT_DIR/.claude/hooks/paperize-stop-reminder.sh"}] | .hooks.Stop)
+    end
+  )
+' "$SETTINGS" > "$TMP"
+
+# sanity: output must parse
+jq empty "$TMP" || { echo "[setup] ERROR: jq produced invalid JSON"; rm -f "$TMP"; exit 3; }
+
+mv "$TMP" "$SETTINGS"
+echo "[setup] registered hooks in $SETTINGS"
+echo "[setup] done. Next: commit .claude/settings.json と 2 hook files (compatible change)."

--- a/scripts/smoke-paperize.sh
+++ b/scripts/smoke-paperize.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# smoke-paperize.sh — end-to-end integration smoke for /paperize pipeline.
+#
+# Placed under scripts/ (not tests/) because steps 4-5 depend on external
+# services (llama-server, LaTeX compiler) and are conditionally deferred.
+# Not part of test-all.sh.
+#
+# Scope:
+#   [A] aggregate-jsonl.sh            deterministic, always run
+#   [B] update-todos.py               deterministic
+#   [C] decay-expired-questions.py    deterministic
+#   [D] verifier-refinement.py        deferred unless LLAMA_SERVER=1
+#   [E] compile-paper.sh              deferred unless LATEX=1
+#
+# Usage:
+#   bash scripts/smoke-paperize.sh
+#   LLAMA_SERVER=1 bash scripts/smoke-paperize.sh   # include verifier
+#   LATEX=1 bash scripts/smoke-paperize.sh          # include pdf compile
+
+set -euo pipefail
+
+BASE="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BASE"
+
+PASS=0
+FAIL=0
+DEFERRED=0
+
+pass()     { echo "  [ok]    $1"; PASS=$((PASS+1)); }
+fail()     { echo "  [fail]  $1"; FAIL=$((FAIL+1)); }
+deferred() { echo "  [defer] $1"; DEFERRED=$((DEFERRED+1)); }
+
+WORK="${TMPDIR:-/tmp}/paperize-smoke-$$"
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "=== /paperize integration smoke ==="
+echo "Work dir: $WORK"
+echo ""
+
+# --- Precondition: jsonl (real or fixture) ---
+JSONL=".claude/metrics/p2-verified.jsonl"
+if [ ! -f "$JSONL" ] || [ ! -s "$JSONL" ]; then
+  echo "[pre] real jsonl missing; using fixture"
+  JSONL="$WORK/fixture.jsonl"
+  cat > "$JSONL" <<'EOF'
+{"epoch":1776663606,"files":[".claude/hooks/example.sh"],"verdict":"PASS","evaluator":"logprob/qwen","evaluator_independent":true,"margin":0.818}
+{"epoch":1776663800,"files":["scripts/aggregate-jsonl.sh"],"verdict":"PASS","source":"self-review"}
+EOF
+fi
+
+# --- [A] aggregate-jsonl.sh ---
+echo "[A] aggregate-jsonl.sh"
+OUT="$WORK/docs/papers/test-slug"
+if bash scripts/aggregate-jsonl.sh "$OUT" "$JSONL" "HEAD~3..HEAD" > "$WORK/aggregate.log" 2>&1; then
+  pass "exit 0"
+else
+  fail "non-zero exit"
+  cat "$WORK/aggregate.log"
+  exit 1
+fi
+
+[ -f "$OUT/manifest.json" ]                         && pass "manifest.json"   || fail "manifest.json missing"
+[ -f "$OUT/evidence/p2-verified-snapshot.jsonl" ]   && pass "snapshot jsonl"  || fail "snapshot missing"
+[ -f "$OUT/evidence/commits.md" ]                   && pass "commits.md"      || fail "commits.md missing"
+[ -f "$OUT/evidence/sources.md" ]                   && pass "sources.md"      || fail "sources.md missing"
+
+VC=$(jq '.summary.verification_count' "$OUT/manifest.json")
+if [ "$VC" -ge 1 ]; then pass "verification_count=$VC (>=1)"; else fail "verification_count=$VC"; fi
+
+SCHEMA=$(jq -r '.schema_version' "$OUT/manifest.json")
+[ "$SCHEMA" = "1" ] && pass "schema_version=1" || fail "schema_version=$SCHEMA"
+
+# --- [B] update-todos.py ---
+echo "[B] update-todos.py"
+echo '{"category":"decisions","text":"adopted K=3","source":{"commit":"9159f62c"},"compatibility":"compatible change"}
+{"category":"questions","text":"Does the halt rule generalize to N>128?"}
+{"category":"findings","text":"Bidirectional cancels position bias +10.9pp","source":{"pr":637}}' \
+  | python3 scripts/update-todos.py \
+      --manifest "$OUT/manifest.json" \
+      --output "$OUT/todos.md" \
+      --decay-days 30 > "$WORK/update-todos.log" 2>&1 \
+  && pass "exit 0" \
+  || { fail "non-zero exit"; cat "$WORK/update-todos.log"; }
+
+grep -q "## decisions" "$OUT/todos.md"   && pass "todos.md has ## decisions"  || fail "missing ## decisions"
+grep -q "## questions" "$OUT/todos.md"   && pass "todos.md has ## questions"  || fail "missing ## questions"
+grep -q "decay_at=" "$OUT/todos.md"      && pass "decay_at stamped"           || fail "decay_at missing"
+
+# --- [C] decay-expired-questions.py ---
+echo "[C] decay-expired-questions.py (synthetic future date)"
+FUTURE=$(date -v+60d -u +%Y-%m-%d 2>/dev/null || date -d "+60 days" +%Y-%m-%d)
+python3 scripts/decay-expired-questions.py \
+  --todos "$OUT/todos.md" \
+  --evidence-dir "$OUT/evidence" \
+  --today "$FUTURE" > "$WORK/decay.log" 2>&1 \
+  && pass "exit 0" \
+  || { fail "non-zero exit"; cat "$WORK/decay.log"; }
+
+if [ -f "$OUT/evidence/expired-questions.md" ]; then
+  grep -q "Does the halt rule generalize" "$OUT/evidence/expired-questions.md" \
+    && pass "question moved to expired-questions.md" \
+    || fail "question not moved"
+else
+  fail "expired-questions.md not created"
+fi
+
+if grep -q "Does the halt rule generalize" "$OUT/todos.md"; then
+  fail "question still in todos.md after decay"
+else
+  pass "question removed from todos.md"
+fi
+
+# --- [D] verifier-refinement.py (external: llama-server) ---
+echo "[D] verifier-refinement.py"
+if [ "${LLAMA_SERVER:-0}" = "1" ]; then
+  echo "Paper version A (baseline with UNVERIFIED tags)." > "$WORK/paper-a.tex"
+  echo "Paper version B (claims supported with internal citation commit 9159f62c)." > "$WORK/paper-b.tex"
+  if python3 scripts/verifier-refinement.py \
+      --paper-a "$WORK/paper-a.tex" --paper-b "$WORK/paper-b.tex" \
+      --k-rounds 1 --out "$WORK/verdict.json" > "$WORK/verifier.log" 2>&1; then
+    pass "exit 0"
+    WIN=$(jq -r .winner "$WORK/verdict.json")
+    HALT=$(jq -r .halt "$WORK/verdict.json")
+    pass "verdict: winner=$WIN halt=$HALT"
+  else
+    fail "non-zero exit"
+    cat "$WORK/verifier.log"
+  fi
+else
+  deferred "LLAMA_SERVER=1 not set (requires llama-server on :8090)"
+fi
+
+# --- [E] compile-paper.sh (external: LaTeX) ---
+echo "[E] compile-paper.sh"
+if [ "${LATEX:-0}" = "1" ] && (command -v latexmk || command -v tectonic || command -v pdflatex) >/dev/null 2>&1; then
+  cat > "$WORK/tiny.tex" <<'EOF'
+\documentclass{article}
+\begin{document}
+Hello paperize smoke.
+\end{document}
+EOF
+  if bash scripts/compile-paper.sh "$WORK/tiny.tex" "$WORK/tiny.pdf" > "$WORK/compile.log" 2>&1 && [ -f "$WORK/tiny.pdf" ]; then
+    pass "tiny.pdf produced"
+  else
+    fail "compile failed"
+    tail -20 "$WORK/compile.log"
+  fi
+else
+  deferred "LATEX=1 not set or no compiler (install latexmk/tectonic/pdflatex)"
+fi
+
+# --- Summary ---
+echo ""
+echo "=== summary ==="
+echo "  pass=$PASS  fail=$FAIL  deferred=$DEFERRED"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/update-todos.py
+++ b/scripts/update-todos.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+update-todos.py — Knowledge Base 6-category todos.md writer / updater.
+
+Traces: [S3 §3] AutoResearchClaw Knowledge Base.
+Schema: .claude/skills/paperize/references/schemas/todos.schema.json
+
+Inputs:
+  - manifest.json (aggregate-jsonl.sh output) — source of new entries
+  - existing todos.md (optional) — entries preserved unless superseded
+
+Output:
+  - todos.md (YAML front-matter + markdown sections by category)
+
+The LLM Phase 2/3 produces candidate entries in a side channel; this script
+merges them with existing todos, applies decay_days, and writes the final
+todos.md deterministically.
+
+Entry format (JSON, one per line) on stdin OR --entries-json:
+  {"category":"decisions","text":"K=3 adopted","source":{"commit":"9159f62c"},
+   "compatibility":"compatible change"}
+
+Usage:
+  echo '{"category":"questions","text":"margin threshold tuning?"}' \\
+    | scripts/update-todos.py --manifest path/to/manifest.json \\
+                              --output path/to/todos.md [--decay-days 30]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+CATEGORIES = ["decisions", "experiments", "findings", "literature", "questions", "reviews"]
+SCHEMA_VERSION = "1"
+
+
+def _parse_entry(obj: dict, today: date, decay_days: int) -> dict:
+    cat = obj.get("category")
+    if cat not in CATEGORIES:
+        raise ValueError(f"invalid category: {cat!r} (must be one of {CATEGORIES})")
+    text = obj.get("text")
+    if not text:
+        raise ValueError("entry missing 'text'")
+    entry = {
+        "category": cat,
+        "recorded_at": obj.get("recorded_at") or today.isoformat(),
+        "text": text,
+    }
+    if "source" in obj and obj["source"]:
+        entry["source"] = obj["source"]
+    if "compatibility" in obj and obj["compatibility"]:
+        entry["compatibility"] = obj["compatibility"]
+    # decay only applies to `questions` by design
+    if cat == "questions":
+        decay_at = obj.get("decay_at")
+        if not decay_at:
+            rec = date.fromisoformat(entry["recorded_at"])
+            decay_at = (rec + timedelta(days=decay_days)).isoformat()
+        entry["decay_at"] = decay_at
+    return entry
+
+
+def _render_source(src: dict | None) -> str:
+    if not src:
+        return ""
+    parts = []
+    if "commit" in src:
+        parts.append(f"commit `{src['commit'][:8]}`")
+    if "pr" in src:
+        parts.append(f"PR #{src['pr']}")
+    if "issue" in src:
+        parts.append(f"issue #{src['issue']}")
+    if "file" in src:
+        parts.append(f"file `{src['file']}`")
+    return " / ".join(parts)
+
+
+def _render_markdown(entries: list[dict], manifest_path: str, decay_days: int) -> str:
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    header = [
+        "---",
+        f"schema_version: \"{SCHEMA_VERSION}\"",
+        f"generated_at: {now}",
+        f"source_manifest: {manifest_path}",
+        f"decay_days: {decay_days}",
+        "---",
+        "",
+        "# Follow-up todos (Knowledge Base)",
+        "",
+    ]
+    by_cat: dict[str, list[dict]] = {c: [] for c in CATEGORIES}
+    for e in entries:
+        by_cat[e["category"]].append(e)
+
+    body: list[str] = []
+    for cat in CATEGORIES:
+        items = by_cat[cat]
+        if not items:
+            body.append(f"## {cat}\n\n_(empty)_\n")
+            continue
+        body.append(f"## {cat}\n")
+        items.sort(key=lambda x: x["recorded_at"], reverse=True)
+        for e in items:
+            line = f"- [{e['recorded_at']}] {e['text']}"
+            extras = []
+            src = _render_source(e.get("source"))
+            if src:
+                extras.append(src)
+            if "compatibility" in e:
+                extras.append(e["compatibility"])
+            if "decay_at" in e:
+                extras.append(f"decay_at={e['decay_at']}")
+            if extras:
+                line += "  \n  - " + "  \n  - ".join(extras)
+            body.append(line)
+        body.append("")
+    return "\n".join(header + body).rstrip() + "\n"
+
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+
+
+def _parse_existing(path: Path) -> list[dict]:
+    """Best-effort parse of prior todos.md entry lines.
+
+    Non-deterministic manual edits are preserved only if they match our format.
+    We parse lines starting with `- [YYYY-MM-DD] ` under `## <category>` headers.
+    """
+    if not path.exists():
+        return []
+    text = path.read_text()
+    text = _FRONTMATTER_RE.sub("", text, count=1)
+    entries: list[dict] = []
+    current_cat = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        m = re.match(r"^##\s+(\w+)\s*$", stripped)
+        if m:
+            current_cat = m.group(1) if m.group(1) in CATEGORIES else None
+            continue
+        if not current_cat:
+            continue
+        m = re.match(r"^-\s+\[(\d{4}-\d{2}-\d{2})\]\s+(.*)$", stripped)
+        if m:
+            entries.append({
+                "category": current_cat,
+                "recorded_at": m.group(1),
+                "text": m.group(2).strip(),
+            })
+    return entries
+
+
+def _dedup(entries: list[dict]) -> list[dict]:
+    seen = set()
+    out = []
+    for e in entries:
+        key = (e["category"], e.get("recorded_at"), e["text"])
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(e)
+    return out
+
+
+def _load_stdin_entries(today: date, decay_days: int) -> list[dict]:
+    if sys.stdin.isatty():
+        return []
+    out = []
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        out.append(_parse_entry(json.loads(line), today, decay_days))
+    return out
+
+
+def _load_json_entries(path: Path, today: date, decay_days: int) -> list[dict]:
+    data = json.loads(path.read_text())
+    if not isinstance(data, list):
+        raise SystemExit(f"{path}: expected JSON array of entries")
+    return [_parse_entry(obj, today, decay_days) for obj in data]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True,
+                        help="path to manifest.json (for source_manifest header)")
+    parser.add_argument("--output", type=Path, required=True,
+                        help="path to todos.md (read + write)")
+    parser.add_argument("--entries-json", type=Path, default=None,
+                        help="JSON file with array of entry objects (in addition to stdin)")
+    parser.add_argument("--decay-days", type=int, default=30,
+                        help="days after which `questions` expire (default 30)")
+    args = parser.parse_args()
+
+    if not args.manifest.exists():
+        raise SystemExit(f"manifest not found: {args.manifest}")
+
+    today = date.today()
+
+    entries = _parse_existing(args.output)
+    entries.extend(_load_stdin_entries(today, args.decay_days))
+    if args.entries_json:
+        entries.extend(_load_json_entries(args.entries_json, today, args.decay_days))
+
+    for e in entries:
+        if e["category"] == "questions" and "decay_at" not in e:
+            rec = date.fromisoformat(e["recorded_at"])
+            e["decay_at"] = (rec + timedelta(days=args.decay_days)).isoformat()
+
+    entries = _dedup(entries)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(_render_markdown(entries, str(args.manifest), args.decay_days))
+    print(f"[update-todos] wrote {args.output} ({len(entries)} entries)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verifier-refinement.py
+++ b/scripts/verifier-refinement.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+verifier-refinement.py — /paperize Phase 4 Refinement halt-rule evaluator.
+
+Wraps scripts/verifier_local.pairwise_compare() with the AgentReview halt rule:
+  - winner = B              → halt (keep A, B rejected)
+  - winner = A, margin <= 0 → halt (no net improvement)
+  - winner = A, margin > 0  → accept B
+
+Traces: [S2 §2.5] PaperOrchestra AgentReview + PR #637 logprob pairwise.
+
+Stateless: one A/B comparison per invocation. Iteration / max_iterations
+is owned by the SKILL.md orchestrator.
+
+Usage:
+  scripts/verifier-refinement.py \\
+    --paper-a path/to/paper-v1.tex \\
+    --paper-b path/to/paper-v2.tex \\
+    [--criteria factual_grounding,citation_integrity,narrative_coherence] \\
+    [--k-rounds 3] [--halt-threshold 0.0] [--unidirectional]
+
+Output: JSON to stdout with {winner, margin, criteria, halt, halt_reason, ...}
+Exit code: 0 always (halt decision is in JSON, not exit code).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import verifier_local  # noqa: E402
+
+
+DEFAULT_CRITERIA = [
+    {
+        "id": "factual_grounding",
+        "name": "Factual Grounding",
+        "description": (
+            "Numeric claims, experimental results, and assertions in the paper "
+            "are supported by evidence present in manifest.json or evidence/. "
+            "Unsupported claims must carry [UNVERIFIED] tag."
+        ),
+    },
+    {
+        "id": "citation_integrity",
+        "name": "Citation Integrity",
+        "description": (
+            "Internal citations to PRs / issues / commits include an 8-char SHA "
+            "or issue number. External citations are pre-declared in paperize.yaml."
+        ),
+    },
+    {
+        "id": "narrative_coherence",
+        "name": "Narrative Coherence",
+        "description": (
+            "Section ordering follows the outline, logical flow is preserved, "
+            "and the conclusion is entailed by the body."
+        ),
+    },
+]
+
+
+PROBLEM_PROMPT = (
+    "Two revisions of an internal research paper (paper.tex content) are "
+    "compared against three axes. Prefer the version with stronger factual "
+    "grounding, higher citation integrity, and clearer narrative. Pure style "
+    "or wording preferences are not differentiators."
+)
+
+
+def run(
+    paper_a_path: Path,
+    paper_b_path: Path,
+    criteria: list[dict],
+    k_rounds: int,
+    bidirectional: bool,
+    halt_threshold: float,
+) -> dict:
+    trace_a = paper_a_path.read_text()
+    trace_b = paper_b_path.read_text()
+
+    if not verifier_local.ensure_server():
+        raise RuntimeError(
+            "llama-server unreachable at http://localhost:8090. "
+            "Start it before running /paperize refinement."
+        )
+
+    result = verifier_local.pairwise_compare(
+        problem=PROBLEM_PROMPT,
+        trace_a=trace_a,
+        trace_b=trace_b,
+        criteria=criteria,
+        k_rounds=k_rounds,
+        bidirectional=bidirectional,
+    )
+
+    winner = result["winner"]
+    margin = result.get("margin", result["total_a"] - result["total_b"])
+
+    if winner == "B":
+        halt = True
+        halt_reason = "winner_is_B"
+    elif margin <= halt_threshold:
+        halt = True
+        halt_reason = f"margin_below_threshold (margin={margin:.4f} <= {halt_threshold})"
+    else:
+        halt = False
+        halt_reason = None
+
+    return {
+        "paper_a": str(paper_a_path),
+        "paper_b": str(paper_b_path),
+        "winner": winner,
+        "margin": round(float(margin), 6),
+        "total_a": round(float(result["total_a"]), 6),
+        "total_b": round(float(result["total_b"]), 6),
+        "criteria": [
+            {
+                "id": c["criterion"],
+                "winner": c["winner"],
+                "mean_a": c["mean_a"],
+                "mean_b": c["mean_b"],
+            }
+            for c in result["criteria_results"]
+        ],
+        "k_rounds": result.get("k_rounds", k_rounds),
+        "bidirectional": result.get("bidirectional", bidirectional),
+        "halt": halt,
+        "halt_reason": halt_reason,
+        "halt_threshold": halt_threshold,
+    }
+
+
+def _parse_criteria(spec: str | None) -> list[dict]:
+    if not spec:
+        return DEFAULT_CRITERIA
+    wanted = [s.strip() for s in spec.split(",") if s.strip()]
+    by_id = {c["id"]: c for c in DEFAULT_CRITERIA}
+    out = []
+    for w in wanted:
+        if w not in by_id:
+            raise SystemExit(f"unknown criterion: {w} (known: {list(by_id)})")
+        out.append(by_id[w])
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    parser.add_argument("--paper-a", type=Path, required=True, help="path to version A (current)")
+    parser.add_argument("--paper-b", type=Path, required=True, help="path to version B (revised)")
+    parser.add_argument("--criteria", type=str, default=None,
+                        help="comma-separated criterion ids (default: all 3)")
+    parser.add_argument("--k-rounds", type=int, default=3, help="independent rounds (default 3)")
+    parser.add_argument("--halt-threshold", type=float, default=0.0,
+                        help="margin threshold below which halt triggers (default 0.0)")
+    parser.add_argument("--unidirectional", action="store_true",
+                        help="disable bidirectional averaging (default: bidirectional)")
+    parser.add_argument("--out", type=Path, default=None,
+                        help="write result JSON here in addition to stdout")
+    args = parser.parse_args()
+
+    for p in (args.paper_a, args.paper_b):
+        if not p.exists():
+            raise SystemExit(f"not found: {p}")
+
+    result = run(
+        paper_a_path=args.paper_a,
+        paper_b_path=args.paper_b,
+        criteria=_parse_criteria(args.criteria),
+        k_rounds=args.k_rounds,
+        bidirectional=not args.unidirectional,
+        halt_threshold=args.halt_threshold,
+    )
+
+    out_json = json.dumps(result, indent=2, ensure_ascii=False)
+    print(out_json)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(out_json + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`.claude/metrics/p2-verified.jsonl` に蓄積された検証トークンを、LaTeX 論文 + follow-up todos.md + evidence/ に変換し、jsonl を空化する `/paperize` skill を追加する。

3 先行研究 (AI-Scientist-v2, PaperOrchestra, AutoResearchClaw) を深堀サーベイし、explicit traceability 付きで統合設計。PaperOrchestra 5-agent pipeline を骨格、AutoResearchClaw の Knowledge Base 6-cat を follow-up に、AI-Scientist-v2 の paperize.yaml 外部設定パターンを採用。

## Contents

### 設計 phase (#642)
- `docs/research/autonomous-research-pipelines/` — 3 サーベイ記録 + 統合設計
  - `01-ai-scientist-v2.md` / `02-paper-orchestra.md` / `03-auto-research-claw.md`
  - `04-integrated-design.md` — 30 設計要素 × source tag [S1/S2/S3/P] (28 unique tags, 0 broken)

### Implementation phase (#643, SS5–SS11)
- **SS5** `scripts/aggregate-jsonl.sh` — Phase 1 Discovery + Phase 4 Formatting
- **SS6** `.claude/skills/paperize/` — SKILL.md + paperize.yaml.example + references/
- **SS7** `scripts/verifier-refinement.py` — AgentReview halt rule wrapper
- **SS8** `scripts/update-todos.py` + `decay-expired-questions.py` — 6-cat KB + 30-day decay
- **SS9** `scripts/compile-paper.sh` + `references/template/{paper.tex,guidelines.md}`
- **SS10** `scripts/setup-paperize-hooks.sh` + 2 hooks (L1 via human execution)
- **SS11** `scripts/smoke-paperize.sh` — 14/14 pass deterministic, 2 deferred (llama-server, LaTeX)

## Traceability

| Source | Role |
|--------|------|
| [S1] AI-Scientist-v2 | paperize.yaml (bfts_config) + single-pass writeup + page limit |
| [S2] PaperOrchestra | 5-agent pipeline + Aggregator 4-phase + AgentReview halt rule |
| [S3] AutoResearchClaw | Knowledge Base 6-cat + 30-day decay |
| [P] internal | LaTeX template + enforcement modes |

詳細: `docs/research/autonomous-research-pipelines/04-integrated-design.md` §1 Source Mapping Table

## Compatibility

**conservative extension** + **compatible change** (hooks activation)

- 新 skill / 新 scripts: 追加のみ (conservative extension)
- settings.json: SessionStart hooks 配列に 1 件追加、Stop hooks 配列を新設 (compatible change)
- 既存 workflow を壊す変更なし

## Test plan

- [x] `bash scripts/smoke-paperize.sh` → pass=14 fail=0 deferred=2
- [x] `aggregate-jsonl.sh` on real jsonl (43 verifs, 5 commits, 115 files)
- [x] `update-todos.py` + `decay-expired-questions.py` round-trip
- [x] `verifier-refinement.py --help` (wiring only; full run requires llama-server)
- [x] setup-paperize-hooks.sh — user-executed, hooks activated on branch
- [ ] full e2e (requires llama-server on :8090 + LaTeX compiler)

## Follow-up

- llama-server / LaTeX をホスト環境にインストールして e2e 実行 → `LLAMA_SERVER=1 LATEX=1 bash scripts/smoke-paperize.sh`
- 最初の /paperize 実走 (過去の p2-verified.jsonl 43 件 → paper.pdf)
- Gate judgment on #643 SS4 by maintainer

Closes #643.
Parent: #642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)