### PR TITLE
research: GT labeling 500+ infrastructure scripts (#671)

### DIFF
--- a/docs/research/routellm-phase3/analysis/codex-brief-671.md
+++ b/docs/research/routellm-phase3/analysis/codex-brief-671.md
@@ -1,0 +1,222 @@
+# Codex Implementation Brief — #671 GT Labeling 500+ Infrastructure
+
+Parent: #639 | Sub-6 | Worktree: `agent-manifesto-research-671` on branch `research/671-gt-labeling-500`
+
+## 目的
+
+mDeBERTa router の GT hold-out calibration ECE 0.2702 (n=20) を改善するための **infrastructure scripts** を用意する。実際の human annotation (2-3 annotator × 500 items) は外部作業のため本 PR の scope 外。
+
+本 PR は「後で human annotator に渡す準備 + 返ってきた label を model に反映する pipeline」のコードを提供する。
+
+## Scope (Codex-implementable)
+
+### ✅ 本 PR で実装
+1. sampling 拡大 (現 100 → 500 target、既存 100 との dedup)
+2. annotator kit 生成 (markdown template, JSON schema, 分類ガイド)
+3. agreement 測定 (Cohen's kappa, Fleiss' kappa)
+4. calibration re-measurement (labeled GT → mDeBERTa ECE/MCE)
+5. GT → corrections.jsonl 変換 (retrain_cli.py 統合)
+6. runbook (annotator 手順 + reviewer 手順)
+
+### ❌ 本 PR の scope 外
+- 実際の 500 件 human annotation (外部作業、2-4 週)
+- retrained mDeBERTa v2 (label 完了後の別 PR)
+- 実 Cohen's kappa 測定結果 (label 完了後)
+
+## 成果物 (6 ファイル)
+
+### 1. `docs/research/routellm-phase3/classifier/sample_for_gt.py` (既存を改修)
+
+既存の機能を保ちつつ以下を追加:
+- `--n 500` (default 100 のまま、CLI 引数で拡大可能)
+- `--exclude <existing.jsonl>` で既存 candidates を dedup (by `session_id` + `prompt` 先頭 200 文字)
+- `--backend {lr,mdeberta}` でクラス分類器切替（default: `lr` 既存動作、`mdeberta` は `http://localhost:9001/classify` に POST）
+- 出力 id は既存の max(gt-XXX) から連番で続ける（`gt-100`, `gt-101`, ...）
+
+### 2. `docs/research/routellm-phase3/classifier/annotator_kit.py` (新規)
+
+annotator 毎の作業ファイルを生成:
+```
+uv run python3 annotator_kit.py \
+  --candidates ../label-data/gt-candidates-500.jsonl \
+  --annotators alice bob carol \
+  --output-dir ../label-data/annotations/
+```
+
+出力 (per annotator):
+- `../label-data/annotations/alice.jsonl` — 全 500 件、`gt_label: null`, `annotator: "alice"`
+- `../label-data/annotations/alice.md` — 人間可読な markdown (prompt 全文 + predicted_label + taxonomy reference + 埋め込み可能な label field)
+- `../label-data/annotations/README.md` — 共通手順 (taxonomy §4 A1-A6 参照、禁止事項、返却方法)
+
+taxonomy reference は `docs/research/routellm-phase3/analysis/architecture-survey.md` §4 を参照しているが、architecture-survey にその節が無ければ `label-guide.md` として新規作成してもよい（taxonomy: 5 ラベル `local_confident / local_probable / cloud_required / hybrid / unknown` の定義 + 判断基準）。
+
+### 3. `docs/research/routellm-phase3/classifier/kappa.py` (新規)
+
+複数 annotator の JSONL を読み込み、agreement 指標を計算:
+```
+uv run python3 kappa.py \
+  --annotations ../label-data/annotations/alice.jsonl \
+                ../label-data/annotations/bob.jsonl \
+                ../label-data/annotations/carol.jsonl \
+  --output ../analysis/annotator-agreement.json
+```
+
+- 2 annotator: Cohen's kappa
+- 3+ annotator: Fleiss' kappa
+- 5x5 confusion matrix per pair
+- majority vote (3+ の場合) 生成
+- LLM pseudo-GT (Opus) との agreement (classifier との closed-loop でない独立性測定)
+
+### 4. `docs/research/routellm-phase3/classifier/calibrate_from_gt.py` (新規)
+
+labeled GT vs mDeBERTa predictions で ECE/MCE を再測定:
+```
+uv run python3 calibrate_from_gt.py \
+  --labeled ../label-data/gt-labeled-majority.jsonl \
+  --model-dir ../model-mdeberta \
+  --serve-url http://localhost:9001 \
+  --output ../analysis/mdeberta-calibration-gt500.md
+```
+
+serve_encoder.py が稼働していれば `/classify` 経由で predictions を取得、未稼働の場合は `model-dir` から直接 model load。
+
+出力:
+- per-label ECE / MCE
+- reliability diagram (matplotlib が利用可能な場合のみ、ASCII art fallback)
+- overall ECE
+- n 件数 + confidence distribution
+
+### 5. `docs/research/routellm-phase3/classifier/gt_to_corrections.py` (新規)
+
+majority vote 後の GT を retrain_cli.py 用 corrections.jsonl 形式に変換:
+```
+uv run python3 gt_to_corrections.py \
+  --labeled ../label-data/gt-labeled-majority.jsonl \
+  --output ../label-data/corrections-gt500.jsonl \
+  --only-disagreements  # optional: classifier predicted_label != gt_label のみ
+```
+
+corrections.jsonl schema (retrain_cli.py 互換):
+```json
+{"prompt": "...", "label": "local_probable", "corrected_from": "cloud_required", "ts": "..."}
+```
+
+### 6. `docs/research/routellm-phase3/analysis/gt-labeling-runbook.md` (新規)
+
+運用 runbook。目次:
+1. Sampling (sample_for_gt.py で 500 candidates 生成)
+2. Annotator Kit Setup (annotator_kit.py、annotator への配布手順、taxonomy guide)
+3. Annotation Review (返却 JSONL の merge、diff 検出)
+4. Agreement Analysis (kappa.py、Gate: Cohen's kappa ≥ 0.75)
+5. Recalibration (calibrate_from_gt.py、Gate: ECE ≤ 0.10)
+6. Retrain (gt_to_corrections.py → retrain_cli.py、新 model GT hold-out 検証 → rollback 判定)
+7. Troubleshooting (重複 id、annotator disagreement 調停、低 agreement case)
+
+## Gate 基準
+
+**本 PR (infrastructure)**:
+- [ ] `sample_for_gt.py --n 500 --exclude gt-candidates.jsonl` 実行時に 500 件生成 + 既存 100 と dedup (schema-level test で確認、実データ無しでも OK)
+- [ ] `annotator_kit.py` で 3 annotator 分の JSONL + markdown 生成
+- [ ] `kappa.py` に synthetic data (完全一致 / 部分一致) で unit test 追加 (pytest ではなく単純な `if __name__ == "__main__"` ブロック内の assertion でよい)
+- [ ] `calibrate_from_gt.py` が labeled jsonl から ECE 計算 (synthetic label で動作確認)
+- [ ] `gt_to_corrections.py` が schema 準拠の corrections.jsonl 出力
+- [ ] runbook が全 step カバー
+
+**#671 Issue Gate (label 完了後)**:
+- Cohen's kappa ≥ 0.75 + ECE ≤ 0.10 + routing accuracy ≥ 95%
+
+## 制約 (L1/L2/P3)
+
+- **L1**: HTTP 通信 (serve_encoder /classify) は `localhost` 固定、subprocess shell=False
+- **L1**: annotator JSONL に機微情報 (APIキー等) が含まれる可能性を考慮、runbook に「prompt 内容の外部流出防止」注意を記載
+- **P3**: 既存 `sample_for_gt.py` の default 動作を保つ (n=100, backend=lr)。`--n 500` + `--backend mdeberta` は opt-in → conservative extension
+- **P3**: 既存 `retrain_cli.py` の corrections.jsonl schema は変更しない → conservative extension
+
+## 検証コマンド (Codex が自己検証に使う)
+
+```bash
+cd /Users/nirarin/work/agent-manifesto-research-671
+
+# 1. syntax
+bash -c "python3 -c 'import ast; [ast.parse(open(f).read()) for f in [
+  \"docs/research/routellm-phase3/classifier/sample_for_gt.py\",
+  \"docs/research/routellm-phase3/classifier/annotator_kit.py\",
+  \"docs/research/routellm-phase3/classifier/kappa.py\",
+  \"docs/research/routellm-phase3/classifier/calibrate_from_gt.py\",
+  \"docs/research/routellm-phase3/classifier/gt_to_corrections.py\",
+]]; print(\"PASS syntax\")'"
+
+# 2. no shell=True
+rg --no-heading 'shell=True' docs/research/routellm-phase3/classifier/ && echo "FAIL" || echo "PASS: no shell=True"
+
+# 3. synthetic kappa test (unit test inside kappa.py main)
+# kappa.py に --test フラグで synthetic case (identical/disagreeing) を検証する機能を入れる
+python3 docs/research/routellm-phase3/classifier/kappa.py --test
+
+# 4. synthetic annotator kit generation
+mkdir -p /tmp/gt-test
+python3 -c "
+import json
+entries = [{
+    'id': f'gt-{i:03d}',
+    'session_id': f'sess-{i}',
+    'prompt': f'test prompt {i}',
+    'prompt_len': 20,
+    'predicted_label': 'cloud_required',
+    'predicted_confidence': 0.85,
+    'predicted_probs': {'cloud_required': 0.85, 'hybrid': 0.1, 'local_probable': 0.03, 'local_confident': 0.01, 'unknown': 0.01},
+    'conf_bin': 'vhigh',
+    'length_bin': 'short',
+    'gt_label': None,
+    'annotator_notes': None,
+} for i in range(10)]
+with open('/tmp/gt-test/candidates.jsonl', 'w') as f:
+    for e in entries: f.write(json.dumps(e) + '\n')
+"
+python3 docs/research/routellm-phase3/classifier/annotator_kit.py \
+  --candidates /tmp/gt-test/candidates.jsonl \
+  --annotators alice bob \
+  --output-dir /tmp/gt-test/annotations/
+ls /tmp/gt-test/annotations/
+
+# 5. synthetic calibration test
+python3 -c "
+import json
+entries = [{
+    'id': f'gt-{i:03d}',
+    'prompt': f'test {i}',
+    'gt_label': 'cloud_required' if i < 7 else 'local_probable',
+    'predicted_label': 'cloud_required',
+    'predicted_confidence': 0.85,
+    'predicted_probs': {'cloud_required': 0.85, 'hybrid': 0.1, 'local_probable': 0.03, 'local_confident': 0.01, 'unknown': 0.01},
+} for i in range(10)]
+with open('/tmp/gt-test/labeled.jsonl', 'w') as f:
+    for e in entries: f.write(json.dumps(e) + '\n')
+"
+# Skip model-dependent tests; just check script runs with --help
+python3 docs/research/routellm-phase3/classifier/calibrate_from_gt.py --help
+python3 docs/research/routellm-phase3/classifier/gt_to_corrections.py --help
+```
+
+## 非対象 (Codex にやらせない)
+
+- 実際の 500 件 sampling 実行 (model weights が worktree に無いため)
+- 実際の Opus pseudo-GT 生成 (LLM API call は Codex の作業外)
+- `retrain_cli.py` 本体の改修 (既存互換維持)
+- annotator への実際の配布 (外部作業)
+
+## Manifest 準拠
+
+commit message に:
+- `conservative extension` (既存 `sample_for_gt.py` default 動作維持、新規スクリプトのみ追加)
+- Issue reference: `refs #671`
+
+## 参照ファイル (Codex が読むべき)
+
+- `docs/research/routellm-phase3/classifier/sample_for_gt.py` (改修対象)
+- `docs/research/routellm-phase3/classifier/opus_labels.py` (pseudo-GT 既存実装)
+- `docs/research/routellm-phase3/classifier/retrain_cli.py` (corrections.jsonl schema)
+- `docs/research/routellm-phase3/classifier/calibration.py` (ECE 既存実装の reuse)
+- `docs/research/routellm-phase3/analysis/architecture-survey.md` (taxonomy §4 定義)
+- `.claude/rules/l1-safety.md`
+- `.claude/rules/p3-governed-learning.md`

--- a/docs/research/routellm-phase3/analysis/gt-labeling-runbook.md
+++ b/docs/research/routellm-phase3/analysis/gt-labeling-runbook.md
@@ -1,0 +1,104 @@
+# GT Labeling Runbook
+
+## 1. Sampling
+
+Generate a new GT candidate batch from the worktree root:
+
+```bash
+python3 docs/research/routellm-phase3/classifier/sample_for_gt.py \
+  --real-prompts docs/research/routellm-phase3/label-data/real-prompts.jsonl \
+  --model-dir docs/research/routellm-phase3/model \
+  --output docs/research/routellm-phase3/label-data/gt-candidates-500.jsonl \
+  --n 500 \
+  --exclude docs/research/routellm-phase3/label-data/real-gt-candidates.jsonl
+```
+
+- Default behavior stays unchanged when `--n`, `--exclude`, and `--backend` are omitted.
+- Use `--backend mdeberta --serve-url http://localhost:9001` only when the local encoder service is running.
+- Review the output for duplicate prompts before distribution.
+
+## 2. Annotator Kit Setup
+
+Create per-annotator packets:
+
+```bash
+python3 docs/research/routellm-phase3/classifier/annotator_kit.py \
+  --candidates docs/research/routellm-phase3/label-data/gt-candidates-500.jsonl \
+  --annotators alice bob carol \
+  --output-dir docs/research/routellm-phase3/label-data/annotations
+```
+
+- Taxonomy reference: `docs/research/routellm-phase3/analysis/label-guide.md`
+- Distribute one JSONL and one Markdown packet per annotator.
+- Prompts may contain sensitive content. Do not upload them to external tools, hosted LLMs, chat systems, or shared drives beyond the approved review path.
+
+## 3. Annotation Review
+
+- Collect returned `*.jsonl` files in a single review directory.
+- Confirm each file preserves `id`, `prompt`, `session_id`, and `predicted_*`.
+- Diff `gt_label` and `annotator_notes` only.
+- Reject packets with broken JSONL rows, missing labels, or rewritten ids.
+
+## 4. Agreement Analysis
+
+Run agreement analysis after at least two packets are complete:
+
+```bash
+python3 docs/research/routellm-phase3/classifier/kappa.py \
+  --annotations \
+    docs/research/routellm-phase3/label-data/annotations/alice.jsonl \
+    docs/research/routellm-phase3/label-data/annotations/bob.jsonl \
+    docs/research/routellm-phase3/label-data/annotations/carol.jsonl \
+  --pseudo-gt docs/research/routellm-phase3/label-data/gt-opus.jsonl \
+  --output docs/research/routellm-phase3/analysis/annotator-agreement.json
+```
+
+- Gate: Cohen's kappa or Fleiss' kappa must be `>= 0.75`.
+- Use the emitted majority-vote JSONL as the reviewer baseline for final GT.
+- If the gate fails, escalate disputed items for adjudication instead of silently averaging.
+
+## 5. Recalibration
+
+Re-measure mDeBERTa calibration against majority GT:
+
+```bash
+python3 docs/research/routellm-phase3/classifier/calibrate_from_gt.py \
+  --labeled docs/research/routellm-phase3/label-data/gt-labeled-majority.jsonl \
+  --model-dir docs/research/routellm-phase3/model-mdeberta \
+  --serve-url http://localhost:9001 \
+  --output docs/research/routellm-phase3/analysis/mdeberta-calibration-gt500.md
+```
+
+- If the local service is unavailable, the script falls back to loading `model-dir` directly.
+- Gate: overall ECE must be `<= 0.10`.
+- Keep the markdown report with the run artifacts.
+
+## 6. Retrain
+
+Convert GT into retraining corrections and then use the existing retrain pipeline:
+
+```bash
+python3 docs/research/routellm-phase3/classifier/gt_to_corrections.py \
+  --labeled docs/research/routellm-phase3/label-data/gt-labeled-majority.jsonl \
+  --output docs/research/routellm-phase3/label-data/corrections-gt500.jsonl \
+  --only-disagreements
+
+python3 docs/research/routellm-phase3/classifier/retrain_cli.py \
+  --base-train docs/research/routellm-phase3/label-data/train.jsonl \
+  --base-eval docs/research/routellm-phase3/label-data/eval.jsonl \
+  --corrections docs/research/routellm-phase3/label-data/corrections-gt500.jsonl \
+  --model-dir docs/research/routellm-phase3/model-mdeberta
+```
+
+- The corrections schema remains the existing `retrain_cli.py` contract.
+- Validate the new model on GT hold-out before rollout.
+- If routing accuracy regresses or ECE rises above gate, rollback to the previous model backup.
+
+## 7. Troubleshooting
+
+- Duplicate ids: rerun sampling with the correct `--exclude` file. Do not hand-edit ids after distribution.
+- Duplicate prompts: investigate dedup keys (`session_id` + prompt prefix) before issuing a new batch.
+- Annotator disagreement: escalate only the disputed subset for reviewer adjudication and preserve original labels.
+- Low agreement: re-check taxonomy interpretation, packet version, and whether annotators used external tools.
+- Calibration report missing diagram: matplotlib is optional; ASCII fallback is acceptable.
+- Localhost classification failure: verify the service is bound to `127.0.0.1`/`localhost` only.

--- a/docs/research/routellm-phase3/analysis/label-guide.md
+++ b/docs/research/routellm-phase3/analysis/label-guide.md
@@ -1,0 +1,33 @@
+# GT Label Guide
+
+This guide is the fallback taxonomy reference for GT labeling packets used in Issue #671.
+
+## Labels
+
+### `local_confident`
+
+Choose this when the task is narrow, self-contained, and should complete reliably in the local environment without orchestration or deep external reasoning.
+
+### `local_probable`
+
+Choose this when the task is still likely local, but uncertainty remains because the prompt is moderately open-ended, context-heavy, or could require limited judgment.
+
+### `cloud_required`
+
+Choose this when the task needs deeper reasoning, multi-step orchestration, broader context synthesis, or stronger model capability than the local path should handle.
+
+### `hybrid`
+
+Choose this when the task mixes local execution with stronger remote reasoning, or when routing may depend on decomposition between local tool work and cloud reasoning.
+
+### `unknown`
+
+Choose this when the prompt is out-of-distribution, underspecified, unsafe to classify confidently, or does not map cleanly onto the known routing taxonomy.
+
+## Decision Heuristics
+
+1. Prefer the narrowest label that still preserves safety.
+2. If a wrong local route would create material risk, bias toward `cloud_required` or `hybrid`.
+3. Use `unknown` instead of forcing a weak fit.
+4. Keep `annotator_notes` short and factual. Record the uncertainty source, not a long essay.
+5. Do not use predicted labels as ground truth. They are hints only.

--- a/docs/research/routellm-phase3/classifier/annotator_kit.py
+++ b/docs/research/routellm-phase3/classifier/annotator_kit.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+annotator_kit.py — Generate per-annotator JSONL/Markdown work packets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+LABELS = [
+    "local_confident",
+    "local_probable",
+    "cloud_required",
+    "hybrid",
+    "unknown",
+]
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def write_jsonl(path: Path, entries: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(entry, ensure_ascii=False) for entry in entries) + "\n")
+
+
+def markdown_for_annotator(annotator: str, entries: list[dict], taxonomy_ref: str) -> str:
+    lines = [
+        f"# GT Labeling Packet: {annotator}",
+        "",
+        "Read the taxonomy guide before labeling.",
+        f"Reference: `{taxonomy_ref}`",
+        "",
+        "Allowed labels:",
+        "",
+    ]
+    for label in LABELS:
+        lines.append(f"- `{label}`")
+    lines.extend(
+        [
+            "",
+            "For each item, decide the final `gt_label`, keep notes brief, and do not edit `id` or `prompt`.",
+            "",
+        ]
+    )
+
+    for index, entry in enumerate(entries, start=1):
+        probs = entry.get("predicted_probs") or {}
+        prob_text = ", ".join(f"{label}={probs.get(label, 0.0)}" for label in LABELS)
+        lines.extend(
+            [
+                f"## {index}. {entry['id']}",
+                "",
+                f"- `session_id`: `{entry.get('session_id')}`",
+                f"- `predicted_label`: `{entry.get('predicted_label')}`",
+                f"- `predicted_confidence`: `{entry.get('predicted_confidence')}`",
+                f"- `predicted_probs`: {prob_text}",
+                f"- `length_bin`: `{entry.get('length_bin')}`",
+                "",
+                "### Prompt",
+                "",
+                "```text",
+                entry["prompt"],
+                "```",
+                "",
+                "### Fill Before Return",
+                "",
+                f"- `gt_label`: `[{ '|'.join(LABELS) }]`",
+                "- `annotator_notes`: ``",
+                "",
+            ]
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def shared_readme(taxonomy_ref: str, annotators: list[str]) -> str:
+    lines = [
+        "# GT Annotation Kit",
+        "",
+        "This directory contains one JSONL and one Markdown packet per annotator.",
+        "",
+        "## Procedure",
+        "",
+        "1. Read the taxonomy guide before editing anything.",
+        "2. Fill only `gt_label` and `annotator_notes` in your JSONL copy.",
+        "3. Keep `id`, `prompt`, `predicted_*`, and `session_id` unchanged.",
+        "4. Return the completed JSONL file to the reviewer.",
+        "",
+        "## Taxonomy",
+        "",
+        f"- Primary reference: `{taxonomy_ref}`",
+        "- Labels: `local_confident`, `local_probable`, `cloud_required`, `hybrid`, `unknown`",
+        "",
+        "## Prohibited",
+        "",
+        "- Do not share prompts outside the review team.",
+        "- Do not paste prompt contents into external tools or hosted LLMs.",
+        "- Do not rename files or rewrite record ids.",
+        "",
+        "## Annotators",
+        "",
+    ]
+    lines.extend(f"- `{annotator}`" for annotator in annotators)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidates", type=Path, required=True)
+    parser.add_argument("--annotators", nargs="+", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--taxonomy-ref",
+        default="../analysis/label-guide.md",
+        help="Path shown inside generated markdown/readme.",
+    )
+    args = parser.parse_args()
+
+    candidates = load_jsonl(args.candidates)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    for annotator in args.annotators:
+        entries = []
+        for entry in candidates:
+            cloned = dict(entry)
+            cloned["gt_label"] = None
+            cloned["annotator"] = annotator
+            if "annotator_notes" not in cloned:
+                cloned["annotator_notes"] = None
+            entries.append(cloned)
+
+        jsonl_path = args.output_dir / f"{annotator}.jsonl"
+        md_path = args.output_dir / f"{annotator}.md"
+        write_jsonl(jsonl_path, entries)
+        md_path.write_text(markdown_for_annotator(annotator, entries, args.taxonomy_ref))
+        print(f"[annotator-kit] wrote {jsonl_path}")
+        print(f"[annotator-kit] wrote {md_path}")
+
+    readme_path = args.output_dir / "README.md"
+    readme_path.write_text(shared_readme(args.taxonomy_ref, args.annotators))
+    print(f"[annotator-kit] wrote {readme_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/research/routellm-phase3/classifier/calibrate_from_gt.py
+++ b/docs/research/routellm-phase3/classifier/calibrate_from_gt.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+calibrate_from_gt.py — Measure calibration against labeled GT.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+LABELS = [
+    "local_confident",
+    "local_probable",
+    "cloud_required",
+    "hybrid",
+    "unknown",
+]
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def validate_localhost_url(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"unsupported serve url scheme: {url}")
+    if parsed.hostname not in {"127.0.0.1", "localhost"}:
+        raise ValueError(f"serve url must point to localhost: {url}")
+    return url.rstrip("/")
+
+
+def try_predict_via_server(entries: list[dict], serve_url: str) -> list[dict] | None:
+    serve_url = validate_localhost_url(serve_url)
+    predictions = []
+    try:
+        for entry in entries:
+            request = urllib.request.Request(
+                serve_url + "/classify",
+                data=json.dumps({"prompt": entry["prompt"]}).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            predictions.append(
+                {
+                    "predicted_label": payload["label"],
+                    "predicted_confidence": float(payload["confidence"]),
+                    "predicted_probs": {label: float(payload["probs"].get(label, 0.0)) for label in LABELS},
+                    "source": "serve_url",
+                }
+            )
+    except (urllib.error.URLError, KeyError, ValueError):
+        return None
+    return predictions
+
+
+def predict_direct(entries: list[dict], model_dir: Path) -> list[dict]:
+    import torch
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    meta = json.load(open(model_dir / "encoder_metadata.json"))
+    labels = meta["labels"]
+    tokenizer = AutoTokenizer.from_pretrained(
+        str(model_dir / "encoder_model"),
+        trust_remote_code=True,
+        fix_mistral_regex=True,
+    )
+    model = AutoModelForSequenceClassification.from_pretrained(
+        str(model_dir / "encoder_model"),
+        trust_remote_code=True,
+    )
+
+    if torch.backends.mps.is_available():
+        device = "mps"
+    elif torch.cuda.is_available():
+        device = "cuda"
+    else:
+        device = "cpu"
+
+    model.to(device)
+    model.eval()
+
+    predictions = []
+    with torch.no_grad():
+        for entry in entries:
+            tokens = tokenizer(entry["prompt"], return_tensors="pt", truncation=True, max_length=512)
+            tokens = {name: tensor.to(device) for name, tensor in tokens.items()}
+            logits = model(**tokens).logits
+            probs = torch.softmax(logits, dim=-1).squeeze(0).detach().cpu().tolist()
+            label_id = max(range(len(probs)), key=probs.__getitem__)
+            predictions.append(
+                {
+                    "predicted_label": labels[label_id],
+                    "predicted_confidence": float(probs[label_id]),
+                    "predicted_probs": {labels[idx]: float(value) for idx, value in enumerate(probs)},
+                    "source": "model_dir",
+                }
+            )
+    return predictions
+
+
+def confidence_bins() -> list[tuple[float, float]]:
+    return [(0.0, 0.2), (0.2, 0.4), (0.4, 0.6), (0.6, 0.8), (0.8, 1.01)]
+
+
+def compute_bin_metrics(entries: list[dict]) -> tuple[list[dict], float, float]:
+    n_total = max(1, len(entries))
+    ece = 0.0
+    mce = 0.0
+    bins = []
+
+    for lower, upper in confidence_bins():
+        bucket = [
+            entry
+            for entry in entries
+            if lower <= float(entry["predicted_confidence"]) < upper
+        ]
+        count = len(bucket)
+        if count == 0:
+            bins.append({"bin": f"[{lower:.1f},{min(upper, 1.0):.1f})", "n": 0})
+            continue
+        accuracy = sum(1 for entry in bucket if entry["predicted_label"] == entry["gt_label"]) / count
+        mean_confidence = sum(float(entry["predicted_confidence"]) for entry in bucket) / count
+        gap = abs(accuracy - mean_confidence)
+        ece += (count / n_total) * gap
+        mce = max(mce, gap)
+        bins.append(
+            {
+                "bin": f"[{lower:.1f},{min(upper, 1.0):.1f})",
+                "n": count,
+                "accuracy": round(accuracy, 4),
+                "mean_confidence": round(mean_confidence, 4),
+                "gap": round(gap, 4),
+            }
+        )
+    return bins, ece, mce
+
+
+def compute_per_label(entries: list[dict]) -> dict[str, dict]:
+    results = {}
+    for label in LABELS:
+        label_entries = [entry for entry in entries if entry["gt_label"] == label]
+        if not label_entries:
+            continue
+        bins, ece, mce = compute_bin_metrics(label_entries)
+        predicted_confidences = [
+            entry["predicted_probs"].get(label, 0.0)
+            for entry in entries
+            if entry["predicted_label"] == label
+        ]
+        results[label] = {
+            "n": len(label_entries),
+            "ece": round(ece, 4),
+            "mce": round(mce, 4),
+            "mean_confidence_when_predicted": round(sum(predicted_confidences) / len(predicted_confidences), 4)
+            if predicted_confidences
+            else None,
+            "bins": bins,
+        }
+    return results
+
+
+def ascii_reliability(bins: list[dict]) -> str:
+    lines = ["bin            n   acc   conf  gap  chart"]
+    for item in bins:
+        if item["n"] == 0:
+            lines.append(f"{item['bin']:<13} {item['n']:>3}   -     -    -")
+            continue
+        acc_blocks = "#" * max(1, int(round(item["accuracy"] * 10)))
+        conf_blocks = "." * max(1, int(round(item["mean_confidence"] * 10)))
+        lines.append(
+            f"{item['bin']:<13} {item['n']:>3} {item['accuracy']:.2f} {item['mean_confidence']:.2f} {item['gap']:.2f} {acc_blocks}|{conf_blocks}"
+        )
+    return "\n".join(lines)
+
+
+def maybe_plot_reliability(bins: list[dict], output: Path) -> str | None:
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return None
+
+    xs = []
+    ys = []
+    for item in bins:
+        if item["n"] == 0:
+            continue
+        xs.append(item["mean_confidence"])
+        ys.append(item["accuracy"])
+
+    if not xs:
+        return None
+
+    output_path = output.with_suffix(".png")
+    fig, ax = plt.subplots(figsize=(5, 5))
+    ax.plot([0, 1], [0, 1], linestyle="--", color="gray")
+    ax.scatter(xs, ys, color="tab:blue")
+    ax.set_xlabel("Mean confidence")
+    ax.set_ylabel("Accuracy")
+    ax.set_title("Reliability diagram")
+    fig.tight_layout()
+    fig.savefig(output_path)
+    plt.close(fig)
+    return output_path.name
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--labeled", type=Path, required=True)
+    parser.add_argument("--model-dir", type=Path, required=True)
+    parser.add_argument("--serve-url", default="http://localhost:9001")
+    parser.add_argument("--output", type=Path, default=Path("../analysis/mdeberta-calibration-gt500.md"))
+    args = parser.parse_args()
+
+    labeled = [entry for entry in load_jsonl(args.labeled) if entry.get("gt_label") in LABELS]
+    predictions = try_predict_via_server(labeled, args.serve_url)
+    if predictions is None:
+        predictions = predict_direct(labeled, args.model_dir)
+
+    merged = []
+    for entry, prediction in zip(labeled, predictions):
+        combined = dict(entry)
+        combined.update(prediction)
+        merged.append(combined)
+
+    bins, overall_ece, overall_mce = compute_bin_metrics(merged)
+    per_label = compute_per_label(merged)
+    prediction_counts = {label: 0 for label in LABELS}
+    for entry in merged:
+        prediction_counts[entry["predicted_label"]] += 1
+
+    image_name = maybe_plot_reliability(bins, args.output)
+    lines = [
+        "# mDeBERTa GT Calibration",
+        "",
+        f"- n: {len(merged)}",
+        f"- overall_ece: {overall_ece:.4f}",
+        f"- overall_mce: {overall_mce:.4f}",
+        f"- prediction_source: {merged[0]['source'] if merged else 'n/a'}",
+        "",
+        "## Confidence Distribution",
+        "",
+    ]
+    lines.extend(f"- {label}: {prediction_counts[label]}" for label in LABELS)
+    lines.extend(
+        [
+            "",
+            "## Reliability",
+            "",
+            "```text",
+            ascii_reliability(bins),
+            "```",
+            "",
+        ]
+    )
+    if image_name:
+        lines.extend([f"Matplotlib diagram: `{image_name}`", ""])
+    lines.extend(["## Per-label ECE / MCE", ""])
+    for label in LABELS:
+        metrics = per_label.get(label)
+        if not metrics:
+            continue
+        mean_pred = metrics["mean_confidence_when_predicted"]
+        mean_pred_text = "n/a" if mean_pred is None else f"{mean_pred:.4f}"
+        lines.extend(
+            [
+                f"### {label}",
+                "",
+                f"- n: {metrics['n']}",
+                f"- ece: {metrics['ece']:.4f}",
+                f"- mce: {metrics['mce']:.4f}",
+                f"- mean_confidence_when_predicted: {mean_pred_text}",
+                "",
+            ]
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(lines))
+    print(f"[calibrate-from-gt] wrote {args.output}")
+    print(f"[calibrate-from-gt] overall_ece={overall_ece:.4f} overall_mce={overall_mce:.4f} n={len(merged)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/research/routellm-phase3/classifier/gt_to_corrections.py
+++ b/docs/research/routellm-phase3/classifier/gt_to_corrections.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+gt_to_corrections.py — Convert labeled GT JSONL into retrain_cli.py corrections.jsonl.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--labeled", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--only-disagreements", action="store_true")
+    args = parser.parse_args()
+
+    labeled = load_jsonl(args.labeled)
+    ts = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    corrections = []
+
+    for entry in labeled:
+        gt_label = entry.get("gt_label")
+        predicted_label = entry.get("predicted_label")
+        prompt = entry.get("prompt")
+        if not gt_label or not prompt:
+            continue
+        if args.only_disagreements and gt_label == predicted_label:
+            continue
+        corrections.append(
+            {
+                "prompt": prompt,
+                "label": gt_label,
+                "corrected_from": predicted_label,
+                "ts": ts,
+            }
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(json.dumps(entry, ensure_ascii=False) for entry in corrections) + "\n")
+    print(f"[gt-to-corrections] wrote {len(corrections)} entries → {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/research/routellm-phase3/classifier/kappa.py
+++ b/docs/research/routellm-phase3/classifier/kappa.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+kappa.py — Inter-annotator agreement metrics for GT labeling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+LABELS = [
+    "local_confident",
+    "local_probable",
+    "cloud_required",
+    "hybrid",
+    "unknown",
+]
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def confusion_matrix(left: dict[str, str], right: dict[str, str]) -> list[list[int]]:
+    matrix = [[0 for _ in LABELS] for _ in LABELS]
+    for item_id in sorted(set(left) & set(right)):
+        matrix[LABELS.index(left[item_id])][LABELS.index(right[item_id])] += 1
+    return matrix
+
+
+def cohen_kappa(left: dict[str, str], right: dict[str, str]) -> float:
+    item_ids = sorted(set(left) & set(right))
+    if not item_ids:
+        return 0.0
+    agreement = sum(1 for item_id in item_ids if left[item_id] == right[item_id]) / len(item_ids)
+
+    left_counts = Counter(left[item_id] for item_id in item_ids)
+    right_counts = Counter(right[item_id] for item_id in item_ids)
+    expected = sum((left_counts[label] / len(item_ids)) * (right_counts[label] / len(item_ids)) for label in LABELS)
+    if expected == 1.0:
+        return 1.0
+    return (agreement - expected) / (1.0 - expected)
+
+
+def fleiss_kappa(assignments: dict[str, list[str]]) -> float:
+    if not assignments:
+        return 0.0
+
+    counts_per_item = []
+    for labels in assignments.values():
+        counts = [labels.count(label) for label in LABELS]
+        counts_per_item.append(counts)
+
+    n_items = len(counts_per_item)
+    n_raters = sum(counts_per_item[0])
+    if n_raters <= 1:
+        return 1.0
+
+    p_j = [sum(item[label_idx] for item in counts_per_item) / (n_items * n_raters) for label_idx in range(len(LABELS))]
+    p_bar = sum(
+        (sum(count * count for count in item) - n_raters) / (n_raters * (n_raters - 1))
+        for item in counts_per_item
+    ) / n_items
+    p_e = sum(probability * probability for probability in p_j)
+    if p_e == 1.0:
+        return 1.0
+    return (p_bar - p_e) / (1.0 - p_e)
+
+
+def majority_vote(records: list[dict[str, str]], source_entries: dict[str, dict]) -> list[dict]:
+    votes: dict[str, list[str]] = defaultdict(list)
+    for record in records:
+        votes[record["id"]].append(record["gt_label"])
+
+    majority = []
+    for item_id in sorted(votes):
+        counter = Counter(votes[item_id])
+        winner, winner_count = sorted(counter.items(), key=lambda item: (-item[1], item[0]))[0]
+        entry = dict(source_entries[item_id])
+        entry["gt_label"] = winner
+        entry["majority_count"] = winner_count
+        entry["vote_counts"] = {label: counter.get(label, 0) for label in LABELS}
+        majority.append(entry)
+    return majority
+
+
+def agreement_against_reference(reference: dict[str, str], target: dict[str, str]) -> float | None:
+    item_ids = sorted(set(reference) & set(target))
+    if not item_ids:
+        return None
+    return sum(1 for item_id in item_ids if reference[item_id] == target[item_id]) / len(item_ids)
+
+
+def parse_annotation_file(path: Path) -> tuple[str, list[dict]]:
+    entries = load_jsonl(path)
+    annotator = entries[0].get("annotator") if entries else path.stem
+    rows = []
+    for entry in entries:
+        label = entry.get("gt_label")
+        if label not in LABELS:
+            continue
+        rows.append({"id": entry["id"], "gt_label": label, "entry": entry})
+    return annotator or path.stem, rows
+
+
+def run_test_mode() -> None:
+    perfect_a = {"x": "cloud_required", "y": "hybrid", "z": "unknown"}
+    perfect_b = {"x": "cloud_required", "y": "hybrid", "z": "unknown"}
+    disagree_a = {"x": "cloud_required", "y": "hybrid", "z": "unknown", "w": "local_confident"}
+    disagree_b = {"x": "local_confident", "y": "hybrid", "z": "local_probable", "w": "cloud_required"}
+    triple = {
+        "a": ["cloud_required", "cloud_required", "cloud_required"],
+        "b": ["hybrid", "hybrid", "hybrid"],
+        "c": ["local_confident", "local_probable", "local_confident"],
+    }
+
+    assert abs(cohen_kappa(perfect_a, perfect_b) - 1.0) < 1e-9
+    assert cohen_kappa(disagree_a, disagree_b) < 0.5
+    assert fleiss_kappa(triple) > 0.4
+    print("PASS kappa --test")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--annotations", nargs="+", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--majority-output", type=Path)
+    parser.add_argument("--pseudo-gt", type=Path)
+    parser.add_argument("--test", action="store_true")
+    args = parser.parse_args()
+
+    if args.test:
+        run_test_mode()
+        return
+
+    if not args.annotations or not args.output:
+        parser.error("--annotations and --output are required unless --test is used")
+
+    annotator_rows: dict[str, dict[str, str]] = {}
+    source_entries: dict[str, dict] = {}
+    flat_records: list[dict[str, str]] = []
+
+    for path in args.annotations:
+        annotator, rows = parse_annotation_file(path)
+        annotator_rows[annotator] = {row["id"]: row["gt_label"] for row in rows}
+        for row in rows:
+            source_entries.setdefault(row["id"], row["entry"])
+            flat_records.append({"id": row["id"], "gt_label": row["gt_label"]})
+
+    pairwise = []
+    annotators = sorted(annotator_rows)
+    for idx, left_name in enumerate(annotators):
+        for right_name in annotators[idx + 1 :]:
+            left = annotator_rows[left_name]
+            right = annotator_rows[right_name]
+            pairwise.append(
+                {
+                    "annotators": [left_name, right_name],
+                    "cohen_kappa": round(cohen_kappa(left, right), 4),
+                    "confusion_matrix": confusion_matrix(left, right),
+                }
+            )
+
+    assignments: dict[str, list[str]] = defaultdict(list)
+    for annotator in annotators:
+        for item_id, label in annotator_rows[annotator].items():
+            assignments[item_id].append(label)
+
+    majority = majority_vote(flat_records, source_entries)
+    majority_labels = {entry["id"]: entry["gt_label"] for entry in majority}
+
+    pseudo_gt_agreement = None
+    if args.pseudo_gt:
+        pseudo_entries = load_jsonl(args.pseudo_gt)
+        pseudo_map = {
+            entry["id"]: entry["gt_label"]
+            for entry in pseudo_entries
+            if entry.get("gt_label") in LABELS
+        }
+        pseudo_gt_agreement = {
+            "majority_vote": agreement_against_reference(pseudo_map, majority_labels),
+            "per_annotator": {
+                annotator: agreement_against_reference(pseudo_map, labels)
+                for annotator, labels in annotator_rows.items()
+            },
+        }
+
+    report = {
+        "annotators": annotators,
+        "n_items": len(assignments),
+        "pairwise": pairwise,
+        "fleiss_kappa": round(fleiss_kappa(assignments), 4) if len(annotators) >= 3 else None,
+        "majority_vote": [
+            {
+                "id": entry["id"],
+                "gt_label": entry["gt_label"],
+                "majority_count": entry["majority_count"],
+                "vote_counts": entry["vote_counts"],
+            }
+            for entry in majority
+        ],
+        "pseudo_gt_agreement": pseudo_gt_agreement,
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n")
+    print(f"[kappa] wrote {args.output}")
+
+    if args.majority_output or len(annotators) >= 3:
+        majority_output = args.majority_output or args.output.with_suffix(".majority.jsonl")
+        majority_output.write_text("\n".join(json.dumps(entry, ensure_ascii=False) for entry in majority) + "\n")
+        print(f"[kappa] wrote {majority_output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/research/routellm-phase3/classifier/sample_for_gt.py
+++ b/docs/research/routellm-phase3/classifier/sample_for_gt.py
@@ -17,133 +17,271 @@ from __future__ import annotations
 import argparse
 import json
 import random
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import Counter, defaultdict
 from pathlib import Path
-from collections import defaultdict
 
 import joblib
 import numpy as np
 
 
-LABEL_TO_ID = {"local_confident": 0, "local_probable": 1, "cloud_required": 2, "hybrid": 3, "unknown": 4}
+LABEL_TO_ID = {
+    "local_confident": 0,
+    "local_probable": 1,
+    "cloud_required": 2,
+    "hybrid": 3,
+    "unknown": 4,
+}
 ID_TO_LABEL = {v: k for k, v in LABEL_TO_ID.items()}
+TARGET_LABEL_PCT = {
+    "local_confident": 0.05,
+    "local_probable": 0.20,
+    "cloud_required": 0.23,
+    "hybrid": 0.38,
+    "unknown": 0.14,
+}
 
 
-def main():
+def conf_bin(confidence: float) -> str:
+    if confidence < 0.30:
+        return "low"
+    if confidence < 0.50:
+        return "mid"
+    if confidence < 0.70:
+        return "high"
+    if confidence < 0.90:
+        return "vhigh"
+    return "peak"
+
+
+def length_bin(length: int) -> str:
+    if length < 100:
+        return "short"
+    if length < 500:
+        return "medium"
+    if length < 2000:
+        return "long"
+    return "xlong"
+
+
+def prompt_key(entry: dict) -> tuple[str | None, str]:
+    return entry.get("session_id"), entry.get("prompt", "")[:200]
+
+
+def load_jsonl(path: Path | None) -> list[dict]:
+    if path is None or not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def next_gt_index(existing_entries: list[dict]) -> int:
+    max_index = -1
+    for entry in existing_entries:
+        identifier = str(entry.get("id", ""))
+        if identifier.startswith("gt-"):
+            suffix = identifier[3:]
+            if suffix.isdigit():
+                max_index = max(max_index, int(suffix))
+    return max_index + 1
+
+
+def predict_lr(model_dir: Path, prompts: list[str]) -> tuple[np.ndarray, np.ndarray]:
+    from sentence_transformers import SentenceTransformer
+
+    meta = json.load(open(model_dir / "metadata.json"))
+    clf = joblib.load(model_dir / "clf.joblib")
+    encoder = SentenceTransformer(meta["encoder"])
+    encoded = encoder.encode(
+        [f"query: {prompt}" for prompt in prompts],
+        convert_to_numpy=True,
+        batch_size=32,
+        show_progress_bar=False,
+    )
+    probs = clf.predict_proba(encoded)
+    return probs.argmax(axis=1), probs
+
+
+def _validate_localhost_url(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"unsupported serve url scheme: {url}")
+    if parsed.hostname not in {"127.0.0.1", "localhost"}:
+        raise ValueError(f"serve url must point to localhost: {url}")
+    return url
+
+
+def predict_mdeberta(prompts: list[str], serve_url: str) -> tuple[np.ndarray, np.ndarray]:
+    serve_url = _validate_localhost_url(serve_url)
+    labels = [ID_TO_LABEL[i] for i in range(len(ID_TO_LABEL))]
+    probs_rows: list[list[float]] = []
+
+    for prompt in prompts:
+        request = urllib.request.Request(
+            serve_url.rstrip("/") + "/classify",
+            data=json.dumps({"prompt": prompt}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"failed to classify prompt via {serve_url}: {exc}") from exc
+
+        probs = payload.get("probs")
+        if not isinstance(probs, dict):
+            raise RuntimeError("invalid /classify response: missing probs")
+        probs_rows.append([float(probs.get(label, 0.0)) for label in labels])
+
+    matrix = np.array(probs_rows, dtype=float)
+    return matrix.argmax(axis=1), matrix
+
+
+def proportional_targets(n: int) -> dict[str, int]:
+    targets = {label: max(1, int(n * pct)) for label, pct in TARGET_LABEL_PCT.items()}
+    total = sum(targets.values())
+    if total < n:
+        targets["hybrid"] += n - total
+    elif total > n:
+        overflow = total - n
+        for label in ("hybrid", "unknown", "cloud_required", "local_probable", "local_confident"):
+            if overflow == 0:
+                break
+            removable = min(overflow, max(0, targets[label] - 1))
+            targets[label] -= removable
+            overflow -= removable
+    return targets
+
+
+def sample_indices(
+    reals: list[dict],
+    preds: np.ndarray,
+    confs: np.ndarray,
+    n: int,
+    exclude_keys: set[tuple[str | None, str]],
+) -> list[int]:
+    targets = proportional_targets(n)
+    pool: dict[tuple[str, str], list[int]] = defaultdict(list)
+    eligible = set()
+
+    for index, prompt in enumerate(reals):
+        if prompt_key(prompt) in exclude_keys:
+            continue
+        eligible.add(index)
+        label = ID_TO_LABEL[int(preds[index])]
+        pool[(label, conf_bin(float(confs[index])))].append(index)
+
+    sampled_indices: list[int] = []
+    sampled_set: set[int] = set()
+
+    for label, count in targets.items():
+        bins = {cb: indices for (lbl, cb), indices in pool.items() if lbl == label}
+        if not bins:
+            continue
+        per_bin = max(1, count // max(1, len(bins)))
+        taken = 0
+        for cb, indices in sorted(bins.items()):
+            remaining = count - taken
+            if remaining <= 0:
+                break
+            candidates = [idx for idx in indices if idx not in sampled_set]
+            take = min(per_bin, len(candidates), remaining)
+            if take <= 0:
+                continue
+            chosen = random.sample(candidates, take)
+            sampled_indices.extend(chosen)
+            sampled_set.update(chosen)
+            taken += take
+
+        remaining = count - taken
+        if remaining > 0:
+            extras = [
+                idx
+                for (lbl, _), indices in pool.items()
+                if lbl == label
+                for idx in indices
+                if idx not in sampled_set
+            ]
+            chosen = random.sample(extras, min(remaining, len(extras)))
+            sampled_indices.extend(chosen)
+            sampled_set.update(chosen)
+
+    if len(sampled_indices) < n:
+        extras = [idx for idx in sorted(eligible) if idx not in sampled_set]
+        need = min(n - len(sampled_indices), len(extras))
+        if need > 0:
+            chosen = random.sample(extras, need)
+            sampled_indices.extend(chosen)
+            sampled_set.update(chosen)
+
+    return sampled_indices[:n]
+
+
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--real-prompts", type=Path, required=True)
     parser.add_argument("--model-dir", type=Path, required=True)
     parser.add_argument("--output", type=Path, default=Path("../label-data/real-gt-candidates.jsonl"))
     parser.add_argument("--n", type=int, default=100)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--exclude", type=Path)
+    parser.add_argument("--backend", choices=("lr", "mdeberta"), default="lr")
+    parser.add_argument("--serve-url", default="http://localhost:9001")
     args = parser.parse_args()
 
     random.seed(args.seed)
 
-    from sentence_transformers import SentenceTransformer
-    meta = json.load(open(args.model_dir / "metadata.json"))
-    clf = joblib.load(args.model_dir / "clf.joblib")
-    enc = SentenceTransformer(meta["encoder"])
-
-    reals = [json.loads(l) for l in args.real_prompts.read_text().splitlines() if l.strip()]
+    reals = load_jsonl(args.real_prompts)
     print(f"[sample] {len(reals)} real prompts loaded")
 
-    X = enc.encode([f"query: {p['prompt']}" for p in reals], convert_to_numpy=True, batch_size=32, show_progress_bar=False)
-    probs = clf.predict_proba(X)
-    preds = probs.argmax(axis=1)
+    prompts = [entry["prompt"] for entry in reals]
+    if args.backend == "lr":
+        preds, probs = predict_lr(args.model_dir, prompts)
+    else:
+        preds, probs = predict_mdeberta(prompts, args.serve_url)
     confs = probs.max(axis=1)
 
-    # Stratification keys
-    def conf_bin(c):
-        if c < 0.30: return "low"
-        if c < 0.50: return "mid"
-        if c < 0.70: return "high"
-        if c < 0.90: return "vhigh"
-        return "peak"
+    exclude_entries = load_jsonl(args.exclude)
+    exclude_keys = {prompt_key(entry) for entry in exclude_entries}
+    sampled_indices = sample_indices(reals, preds, confs, args.n, exclude_keys)
+    start_index = next_gt_index(exclude_entries)
 
-    def length_bin(L):
-        if L < 100: return "short"
-        if L < 500: return "medium"
-        if L < 2000: return "long"
-        return "xlong"
-
-    # Target distribution: 10 conf bins × 5 length bins × 5 labels
-    # Simplified: aim for proportional label + balanced conf
-    # Target per label (from v2 real corpus dist):
-    target_label_pct = {
-        "local_confident": 0.05,
-        "local_probable": 0.20,
-        "cloud_required": 0.23,
-        "hybrid": 0.38,
-        "unknown": 0.14,
-    }
-    target_label_count = {k: max(1, int(args.n * v)) for k, v in target_label_pct.items()}
-    total = sum(target_label_count.values())
-    if total < args.n:
-        target_label_count["hybrid"] += (args.n - total)
-
-    # Group candidates by (predicted label, conf bin)
-    pool: dict[tuple, list[int]] = defaultdict(list)
-    for i, p in enumerate(reals):
-        label = ID_TO_LABEL[int(preds[i])]
-        cb = conf_bin(float(confs[i]))
-        pool[(label, cb)].append(i)
-
-    # Sample per (label, bin) proportionally
-    sampled_indices = []
-    for label, count in target_label_count.items():
-        # Get bins for this label
-        bins = {cb: idxs for (lbl, cb), idxs in pool.items() if lbl == label}
-        if not bins:
-            continue
-        # Distribute count across bins as uniformly as possible
-        per_bin = max(1, count // max(1, len(bins)))
-        taken = 0
-        for cb, idxs in sorted(bins.items()):
-            take = min(per_bin, len(idxs), count - taken)
-            chosen = random.sample(idxs, take)
-            sampled_indices.extend(chosen)
-            taken += take
-            if taken >= count:
-                break
-        # Fill remaining from any bin for this label
-        remaining = count - taken
-        if remaining > 0:
-            all_idxs_for_label = [i for (lbl, _), idxs in pool.items() if lbl == label for i in idxs if i not in sampled_indices]
-            extras = random.sample(all_idxs_for_label, min(remaining, len(all_idxs_for_label)))
-            sampled_indices.extend(extras)
-
-    # Dedup
-    sampled_indices = list(dict.fromkeys(sampled_indices))[:args.n]
-
-    # Write output
     entries = []
-    for idx in sampled_indices:
-        p = reals[idx]
-        entries.append({
-            "id": f"gt-{len(entries):03d}",
-            "session_id": p.get("session_id"),
-            "prompt": p["prompt"],
-            "prompt_len": p.get("prompt_len", len(p["prompt"])),
-            "predicted_label": ID_TO_LABEL[int(preds[idx])],
-            "predicted_confidence": round(float(confs[idx]), 3),
-            "predicted_probs": {ID_TO_LABEL[i]: round(float(probs[idx][i]), 3) for i in range(5)},
-            "conf_bin": conf_bin(float(confs[idx])),
-            "length_bin": length_bin(len(p["prompt"])),
-            "gt_label": None,  # ← human annotator fills this in
-            "annotator_notes": None,
-        })
+    for offset, index in enumerate(sampled_indices):
+        prompt = reals[index]
+        entries.append(
+            {
+                "id": f"gt-{start_index + offset:03d}",
+                "session_id": prompt.get("session_id"),
+                "prompt": prompt["prompt"],
+                "prompt_len": prompt.get("prompt_len", len(prompt["prompt"])),
+                "predicted_label": ID_TO_LABEL[int(preds[index])],
+                "predicted_confidence": round(float(confs[index]), 3),
+                "predicted_probs": {
+                    ID_TO_LABEL[label_id]: round(float(probs[index][label_id]), 3)
+                    for label_id in range(len(ID_TO_LABEL))
+                },
+                "conf_bin": conf_bin(float(confs[index])),
+                "length_bin": length_bin(len(prompt["prompt"])),
+                "gt_label": None,
+                "annotator_notes": None,
+            }
+        )
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text("\n".join(json.dumps(e, ensure_ascii=False) for e in entries) + "\n")
+    args.output.write_text("\n".join(json.dumps(entry, ensure_ascii=False) for entry in entries) + "\n")
 
-    # Stats
-    from collections import Counter
-    dist = Counter(e["predicted_label"] for e in entries)
-    conf_dist = Counter(e["conf_bin"] for e in entries)
-    len_dist = Counter(e["length_bin"] for e in entries)
+    label_dist = Counter(entry["predicted_label"] for entry in entries)
+    conf_dist = Counter(entry["conf_bin"] for entry in entries)
+    len_dist = Counter(entry["length_bin"] for entry in entries)
 
     print(f"[sample] wrote {len(entries)} candidates → {args.output}")
-    print(f"[sample] predicted label dist: {dict(dist)}")
+    if args.exclude:
+        print(f"[sample] excluded {len(exclude_entries)} existing entries from {args.exclude}")
+    print(f"[sample] backend={args.backend}")
+    print(f"[sample] predicted label dist: {dict(label_dist)}")
     print(f"[sample] conf bin dist: {dict(conf_dist)}")
     print(f"[sample] length bin dist: {dict(len_dist)}")
 


### PR DESCRIPTION
## Summary

Parent: #639 / Sub-6: #671. **conservative extension**

human annotation 500+ の GT 収集 + calibration 再測定 + retrain 統合に必要な infrastructure scripts を用意。実際の human annotation (2-4 週) は外部作業のため本 PR の scope 外。

## 研究レポート

### 1. どんなもの？
- `sample_for_gt.py` を --n/--exclude/--backend 拡張 (既存 default 動作維持)
- annotator_kit.py (新規): per-annotator JSONL + markdown + shared README 生成
- kappa.py (新規): Cohen's/Fleiss' kappa + majority vote + pseudo-GT agreement (--test モード付き)
- calibrate_from_gt.py (新規): labeled GT vs mDeBERTa で ECE/MCE 再測定 (serve_url / direct model load)
- gt_to_corrections.py (新規): majority GT → retrain_cli.py corrections.jsonl 変換 (--only-disagreements)
- gt-labeling-runbook.md: 7 step 運用手順
- label-guide.md: 5 ラベル taxonomy 定義 (annotator 参照用)

### 2. 先行研究と比べてどこがすごい？
PR #655 時点では Opus 100 pseudo-GT のみで、hold-out ECE 0.2702 (n=20) の信頼性が低かった。本 PR は **human annotation を受け入れる pipeline を構造化**し、kappa ≥ 0.75 / ECE ≤ 0.10 の Gate を明確化。

### 3. 技術や手法の肝はどこ？
- **conservative extension**: sample_for_gt.py の default (n=100, backend=lr) は完全維持
- **localhost 固定**: /classify 呼び出しは `urlparse` で `127.0.0.1` / `localhost` のみ許可 (L1)
- **dedup**: `session_id` + prompt 先頭 200 文字で既存 GT と重複回避
- **id 連番**: 既存 max(gt-NNN) から続くので annotator 側の混乱なし
- **3+ annotator 自動 Fleiss' + majority vote**: 2 annotator なら Cohen だけで完結

### 4. どうやって有効だと検証した？
| 検証 | 結果 |
|---|---|
| `ast.parse` × 5 ファイル | PASS |
| `rg shell=True` | 0 件 |
| `kappa.py --test` | PASS (Cohen=1.0 完全一致 / Cohen<0.5 不一致 / Fleiss>0.4 部分一致) |
| `annotator_kit.py` with 3 annotators × 5 items | JSONL + MD + README 全生成 |
| `kappa.py` with synthetic 3 annotator (4 agree + 1 disagree) | Cohen 0.69/0.69/0.44, Fleiss 0.58, majority 5/5 |
| `gt_to_corrections.py --only-disagreements` filter | 0 disagreement → 0 件 (正しい) |
| `gt_to_corrections.py` full mode | 5 件出力、corrections.jsonl schema 準拠 |

### 5. 議論はある？
- **本 PR で未検証**: `sample_for_gt.py --help` は `joblib` が system python 未導入で失敗 (既存の top-level import、既 bug 保持、uv 経由なら動く)
- **本 PR で未検証**: `calibrate_from_gt.py` の実行テストは model weights (gitignored) が必要なため skip
- **Gate に達していない**: Cohen's kappa ≥ 0.75 / ECE ≤ 0.10 は real annotation 完了後にしか測定不能。本 PR は infrastructure のみ
- **follow-up 必須**: human annotator 確保 → 500 sampling 実行 → annotation → kappa 測定 → recalibrate → retrain は別 PR で実施

### 6. 次に読むべき論文は？
- Cohen (1960) "A coefficient of agreement for nominal scales" — kappa 原典
- Fleiss (1971) "Measuring nominal scale agreement among many raters"
- Guo et al. (2017) "On Calibration of Modern Neural Networks" — ECE/reliability diagram

## ドキュメント更新
- [x] gt-labeling-runbook.md 新規 (7 step 運用手順)
- [x] label-guide.md 新規 (taxonomy 参照、annotator 向け)
- [x] codex-brief-671.md (implementation spec 記録)
- [ ] SKILL.md 更新は不要

## 後続 Issue
**#671 自体は open 維持**。本 PR は infrastructure のみ。real annotation → kappa 測定 → retrain は同 Issue 内の次フェーズ。human annotator 確保後に別 PR で。

## Test Plan
- [x] `python3 ast.parse` × 5 ファイル — PASS
- [x] `rg shell=True` 検査 — 0 件
- [x] `kappa.py --test` — PASS
- [x] annotator_kit 合成データ (3 annotator × 5 items) — JSONL + MD + README 生成 PASS
- [x] kappa.py 合成 3 annotator → pairwise Cohen / Fleiss / majority vote — PASS
- [x] gt_to_corrections --only-disagreements filter — PASS
- [x] gt_to_corrections full mode — PASS
- [ ] sample_for_gt.py --help — FAIL (joblib not in system python; uv 経由で動く、既存 bug 保持)
- [ ] calibrate_from_gt.py 実行 — model weights 必要 (gitignored, untested)
- [ ] real 500-sample 生成 — follow-up
- [ ] real human annotation — follow-up (2-4 週)

## 分業
- **Claude**: spec (codex-brief-671.md 162行), task 分解, Codex delegation, review (7 files), 検証 (7 functional tests)
- **Codex (codex:rescue)**: 実装 (6 new + 1 modified, 987 insertions, 97 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)