### PR TITLE
research: Qwen pseudo-GT A/B + decision event log (#671 phase 2)

### DIFF
--- a/docs/research/routellm-phase3/analysis/codex-brief-671-qwen.md
+++ b/docs/research/routellm-phase3/analysis/codex-brief-671-qwen.md
@@ -1,0 +1,228 @@
+# Codex Implementation Brief — #671 Phase 2: Qwen LLM Labeling
+
+Parent: #639 | Sub-6 phase 2 | Worktree: `agent-manifesto-research-671` on branch `research/671-qwen-llm-annotation`
+
+## 背景と目的
+
+#671 PR #674 で infrastructure scripts 完備。本 phase で LLM-pseudo-GT 500 件を Qwen3.6 で生成し、以下を測定:
+
+1. Qwen vs existing Opus pseudo-GT (100 件) の agreement → Qwen annotator trust level
+2. Qwen vs mDeBERTa production router の disagreement → classifier calibration signal
+3. Qwen 500 を corrections.jsonl に変換して mDeBERTa ECE 再測定準備
+
+user の意図: 有意な結果が出たら human annotation に進める判断材料とする。
+
+## モデル選択
+
+**目標**: `YTan2000/Qwen3.6-27B-TQ3_4S`
+**実装**: `~/models/Qwen3.6-35B-A3B-UD-Q2_K_XL.gguf` (substitute)
+
+**substitute の理由**:
+- 27B-TQ3_4S は TurboQuant 新 quantization (ggml type 46) で、stock llama.cpp 8890 では load 不可 (type ≤ 41)
+- 正規 runtime は `turbo-tan/llama.cpp-tq3` fork が必要で、build from source が要求される
+- 同 Qwen3.6 世代の 35B-A3B (MoE, 35B total / 3B active) が手元にあり、stock llama.cpp で稼働確認済み
+- 35B-A3B は 27B dense より params が多く、annotator capability は同等以上と推定
+
+`llama-server` の起動状態 (既に起動済み, PID=30485):
+```
+--model ~/models/Qwen3.6-35B-A3B-UD-Q2_K_XL.gguf
+--host 127.0.0.1 --port 8090 --ctx-size 8192
+--n-gpu-layers 99 --alias qwen3.6-35b-a3b --jinja
+```
+
+Thinking mode 無効化: request body に `chat_template_kwargs: {enable_thinking: false}` を含める。
+
+## Scope (本 PR で実装)
+
+### ✅ 実装対象
+1. **qwen_labels.py** (新規): real-prompts.jsonl を input に、llama-server 経由で 5-label 分類 → 結果 jsonl に `gt_label`, `annotator="qwen3.6-35b-a3b"`, `rationale`, `latency_ms` を付与
+2. **sample_qwen_candidates.py** (新規): real-prompts.jsonl から 500 candidates 抽出。stratification は `real-corpus-per-prompt.jsonl` の `label` + `confidence` を使う (production mDeBERTa の予測)
+3. **qwen_vs_opus.py** (新規): opus_labels.py の hardcoded 100 labels と Qwen の同 id 出力を比較し Cohen's kappa + confusion matrix を計算
+4. **start-llama-server.sh** (新規): Qwen 起動 wrapper script (既に 35B で起動中のため文書化メイン)
+5. **qwen-labeling-runbook.md** (新規): 実行手順 + Gate 基準
+
+### ❌ 本 PR scope 外
+- 27B-TQ3_4S 用の turbo-tan/llama.cpp-tq3 fork build
+- human annotation
+- retrain mDeBERTa v2 (Qwen labels 完了後の別 PR)
+
+## 成果物の期待動作
+
+### qwen_labels.py
+
+```bash
+python3 docs/research/routellm-phase3/classifier/qwen_labels.py \
+  --input docs/research/routellm-phase3/label-data/qwen-candidates-500.jsonl \
+  --output docs/research/routellm-phase3/label-data/qwen-labels-500.jsonl \
+  --llama-url http://localhost:8090/v1/chat/completions \
+  --checkpoint-every 50
+```
+
+実装要件:
+- `/no_think` directive ではなく、request body の `chat_template_kwargs: {enable_thinking: false}` を使用
+- `max_tokens=128`, `temperature=0.0`, `top_p=1.0`
+- SYSTEM prompt: 既存 `zero_shot_qwen.py` の SYSTEM をほぼそのまま流用
+- user prompt: 候補の `prompt` フィールド (最大 1500 文字)
+- 応答 parse: JSON `{"label": "..."}` 抽出。正規表現 or ast.literal_eval
+- Fallback: JSON parse 失敗時は LABELS 内の最初に出現する文字列を採用、無ければ `"unknown"`
+- **checkpoint**: 50 件ごとに現状までの結果を output に write (クラッシュ耐性)。resume 時は既処理 id を skip
+- **per-entry**: `gt_label`, `annotator="qwen3.6-35b-a3b"`, `annotator_notes=None`, `latency_ms`, `ts` (ISO8601) を追加
+- **集計**: 完了時に label distribution、平均 latency、fallback 率を stdout に出力
+
+### sample_qwen_candidates.py
+
+```bash
+python3 docs/research/routellm-phase3/classifier/sample_qwen_candidates.py \
+  --real-prompts docs/research/routellm-phase3/label-data/real-prompts.jsonl \
+  --corpus-classified docs/research/routellm-phase3/analysis/real-corpus-per-prompt.jsonl \
+  --output docs/research/routellm-phase3/label-data/qwen-candidates-500.jsonl \
+  --n 500 \
+  --seed 42
+```
+
+real-prompts.jsonl (full text) と real-corpus-per-prompt.jsonl (session_id + mDeBERTa predicted label/confidence) を session_id と prompt 先頭 100 文字で join。
+
+Stratification target (production routing distribution approximation):
+- local_probable ~50%
+- cloud_required ~20%
+- local_confident ~15%
+- hybrid ~10%
+- unknown ~5%
+
+実装要件:
+- 両 jsonl を読み込み、session_id で inner join
+- join 失敗項目 (label 未知) は除外
+- 各 label から target 件数を取る。足りなければ余剰を次 label から補充
+- confidence bin でも軽く均等化 (low/mid/high から各 ~1/3)
+- 出力 schema: `{id, session_id, prompt, prompt_len, predicted_label, predicted_confidence, gt_label: null, annotator_notes: null}`
+- id 連番: `gt-qwen-NNN`
+
+### qwen_vs_opus.py
+
+```bash
+python3 docs/research/routellm-phase3/classifier/qwen_vs_opus.py \
+  --qwen docs/research/routellm-phase3/label-data/qwen-labels-500.jsonl \
+  --opus-source docs/research/routellm-phase3/classifier/opus_labels.py \
+  --output docs/research/routellm-phase3/analysis/qwen-vs-opus.md
+```
+
+実装要件:
+- `opus_labels.py` の `OPUS_LABELS` list を import して 100 件の (id, label, rationale) dict に変換
+- qwen-labels jsonl から同 id を探す (session_id + prompt 先頭 100 文字で match 試行、なければ skip)
+- match した ids の subset で:
+  - Cohen's kappa
+  - overall agreement
+  - per-label confusion matrix
+  - disagreement の rationale 列挙 (markdown table)
+- match 件数が 30 件未満 → WARN ("Opus overlap too small, Qwen trust cannot be validated")
+- match 件数が 30 件以上 → Cohen's kappa を信頼値として出力
+
+出力 markdown: summary + confusion matrix + top disagreement examples (up to 20)
+
+### start-llama-server.sh
+
+```bash
+#!/bin/bash
+set -euo pipefail
+# Qwen3.6-35B-A3B を 8090 で起動 (TQ3_4S は stock llama.cpp で load 不能のため substitute)
+MODEL_PATH="${MODEL_PATH:-$HOME/models/Qwen3.6-35B-A3B-UD-Q2_K_XL.gguf}"
+PORT="${PORT:-8090}"
+exec llama-server \
+  --model "$MODEL_PATH" \
+  --host 127.0.0.1 --port "$PORT" \
+  --ctx-size 8192 --n-gpu-layers 99 \
+  --alias qwen3.6-35b-a3b \
+  --threads 8 --jinja
+```
+
+### qwen-labeling-runbook.md
+
+目次:
+1. **Model Setup**: 35B-A3B を既に使っている場合と、27B-TQ3_4S を別途 build する場合の両記載
+2. **Start Server**: `bash scripts/start-llama-server.sh` (new script)
+3. **Sample 500**: sample_qwen_candidates.py
+4. **Qwen Labeling**: qwen_labels.py (所要 ~10-20 分 at 35B)
+5. **Agreement Analysis**: qwen_vs_opus.py + kappa.py で Qwen-Opus-mDeBERTa 3-way compare
+6. **Next Step (if Gate PASS)**: human annotation for re-validation
+7. **Next Step (if Gate FAIL)**: prompt engineering iteration, model change
+
+## Gate 基準 (本 phase)
+
+| 指標 | PASS | CONDITIONAL | FAIL |
+|---|---|---|---|
+| Qwen-Opus Cohen's kappa (overlap) | ≥ 0.6 | 0.4-0.6 | < 0.4 |
+| Qwen 500 labeling 完了率 | 100% | 95-99% | < 95% |
+| Qwen 平均 latency | 任意 | 任意 | 任意 (参考値) |
+| Qwen label distribution | routing dist と 20% 以内 | 20-30% 差 | > 30% 差 |
+
+**PASS → human annotation phase へ**
+**CONDITIONAL → prompt iteration / 部分採用**
+**FAIL → annotator としては使えず、別 approach 検討 (人間 annotation 直行)**
+
+## 制約
+
+- **L1**: llama-server は `127.0.0.1` 固定、subprocess shell=False
+- **P3**: 既存 `zero_shot_qwen.py`, `opus_labels.py` は変更しない (conservative extension)
+- 既存 `sample_for_gt.py` (LR backend) も変更しない
+
+## 検証コマンド (Codex が実装完了後に実行)
+
+```bash
+cd /Users/nirarin/work/agent-manifesto-research-671
+
+# 1. syntax check
+python3 -c "
+import ast
+for f in [
+  'docs/research/routellm-phase3/classifier/qwen_labels.py',
+  'docs/research/routellm-phase3/classifier/sample_qwen_candidates.py',
+  'docs/research/routellm-phase3/classifier/qwen_vs_opus.py',
+]:
+    ast.parse(open(f).read())
+print('PASS syntax')"
+
+# 2. bash syntax
+bash -n scripts/start-llama-server.sh
+
+# 3. sampling (500 items)
+python3 docs/research/routellm-phase3/classifier/sample_qwen_candidates.py \
+  --real-prompts docs/research/routellm-phase3/label-data/real-prompts.jsonl \
+  --corpus-classified docs/research/routellm-phase3/analysis/real-corpus-per-prompt.jsonl \
+  --output docs/research/routellm-phase3/label-data/qwen-candidates-500.jsonl \
+  --n 500
+
+wc -l docs/research/routellm-phase3/label-data/qwen-candidates-500.jsonl  # expect 500
+
+# 4. Qwen labeling (server 8090 must be running)
+python3 docs/research/routellm-phase3/classifier/qwen_labels.py \
+  --input docs/research/routellm-phase3/label-data/qwen-candidates-500.jsonl \
+  --output docs/research/routellm-phase3/label-data/qwen-labels-500.jsonl \
+  --llama-url http://localhost:8090/v1/chat/completions \
+  --checkpoint-every 50
+
+# 5. Qwen-Opus compare
+python3 docs/research/routellm-phase3/classifier/qwen_vs_opus.py \
+  --qwen docs/research/routellm-phase3/label-data/qwen-labels-500.jsonl \
+  --opus-source docs/research/routellm-phase3/classifier/opus_labels.py \
+  --output docs/research/routellm-phase3/analysis/qwen-vs-opus.md
+```
+
+## 参照ファイル
+
+- `docs/research/routellm-phase3/classifier/zero_shot_qwen.py` (SYSTEM prompt 流用元)
+- `docs/research/routellm-phase3/classifier/opus_labels.py` (OPUS_LABELS 参照)
+- `docs/research/routellm-phase3/classifier/kappa.py` (kappa 計算、既存を import 可能)
+- `docs/research/routellm-phase3/label-data/real-prompts.jsonl` (1199 full prompts、既に生成済み)
+- `docs/research/routellm-phase3/analysis/real-corpus-per-prompt.jsonl` (1173 items with mDeBERTa predictions)
+
+## 非対象
+
+- 実際の 500 件 Qwen inference 実行 (本 PR は implementation のみ、実行は Claude 側)
+- matplotlib を必須にしない (ASCII fallback で十分)
+- turbo-tan/llama.cpp-tq3 の build
+
+## Manifest 準拠
+
+commit message:
+- `conservative extension` (新規 script のみ、既存 script は不変更)
+- `refs #671`

--- a/docs/research/routellm-phase3/analysis/decision-log-schema.md
+++ b/docs/research/routellm-phase3/analysis/decision-log-schema.md
@@ -1,0 +1,359 @@
+# Decision Event Log — Schema Documentation
+
+**Status**: v1.0.0 initial design (2026-04-24)
+**Purpose**: Capture every routing / tool / workflow decision with enough metadata
+that future retrospective analysis becomes possible once ground truth (human GT,
+outcome signals, satisfaction ratings) emerges.
+
+Context: LLM routing quality cannot be measured today (no external oracle; see
+`qwen-35b-vs-27b.md`). Instead of skipping measurement, we record raw decision
+data in an append-only JSONL log. Later analysis can compute accuracy / drift /
+preference agreement against whatever ground truth surfaces (human annotation,
+outcome observations, long-term user feedback).
+
+## Design principles
+
+1. **Append-only**: every event is immutable. Late signals (user rewind, commit
+   hash, subsequent verify result) are written as *new events* that reference an
+   earlier `event_id` via `parent_event_id`.
+2. **Versioned**: top-level `schema_version` (semver) so forward-compatible
+   readers can skip unknown minor changes.
+3. **Flat sections**: each dimension (context/input/decision/execution/...) is a
+   top-level key — `jq '.decision.action'` stays simple.
+4. **Extensible**: consumers MUST ignore unknown fields. New fields land as minor
+   version bumps.
+5. **Privacy-aware**: prompt content can be stored verbatim *or* redacted to a
+   SHA-256 hash. Current default is verbatim (development). Production should
+   redact.
+6. **Join-ready**: `event_id` (UUIDv4) + `parent_event_id` form a DAG for
+   cross-event analysis.
+
+## Event lifecycle
+
+A single user turn emits *multiple* events:
+
+```
+user.turn (prompt received)
+  └─ router.classification       (mDeBERTa output)
+      └─ router.decision         (utility_max, target)
+          └─ agent.tool_call*    (zero or many)
+          └─ agent.output        (final response delivered)
+              ├─ user.rewind?    (later: if user presses ESC-ESC)
+              ├─ user.correction?(later: if user corrects)
+              ├─ outcome.verify? (later: /verify result on this work)
+              └─ outcome.commit? (later: git commit that embodies this work)
+```
+
+Each arrow is `parent_event_id`. The log captures the full DAG, not just
+isolated decisions.
+
+## Top-level envelope
+
+Every event has this shape:
+
+```jsonc
+{
+  "schema_version": "1.0.0",
+  "event_id": "550e8400-e29b-41d4-a716-446655440000",   // UUIDv4
+  "parent_event_id": null | "uuid-v4",                   // null = root
+  "event_type": "router.classification",                 // see enum below
+  "timestamp_utc": "2026-04-24T14:30:00.123Z",           // ISO 8601 millis + Z
+  "context": { /* section */ },
+  "input":   { /* section, optional per event_type */ },
+  "decision":{ /* section, optional per event_type */ },
+  "execution":{ /* section, optional per event_type */ },
+  "outcome": { /* section, optional per event_type */ },
+  "provenance":{ /* section */ }
+}
+```
+
+### `event_type` enum (v1.0.0)
+
+| event_type | typical parent | required sections |
+|---|---|---|
+| `user.turn` | null | input |
+| `router.classification` | `user.turn` | input, decision.classification |
+| `router.decision` | `router.classification` | decision |
+| `agent.tool_call` | `router.decision` | input, decision (tool), execution |
+| `agent.output` | `router.decision` | execution, outcome (immediate) |
+| `user.rewind` | `agent.output` | outcome |
+| `user.correction` | `agent.output` | input |
+| `outcome.verify` | `agent.output` | outcome |
+| `outcome.commit` | `agent.output` | outcome |
+| `outcome.pr_merged` | `outcome.commit` | outcome |
+| `subagent.invocation` | `router.decision` | input, decision, execution |
+| `skill.invocation` | `router.decision` | input, decision, execution |
+| `manual.note` | anything | (free-form in `outcome.human_note`) |
+
+Unknown `event_type` MUST be preserved by readers (treated as opaque). This
+future-proofs additions like `outcome.human_gt_assigned`.
+
+## `context` section
+
+```jsonc
+"context": {
+  "session_id":         "sha-of-session",                  // Claude Code session UUID
+  "turn_id":            42,                                 // monotonic within session
+  "sequence_id":        17,                                 // monotonic within turn (tool_call index)
+  "project_id":         "agent-manifesto",
+  "project_path":       "/Users/nirarin/work/agent-manifesto",
+  "working_directory":  "/Users/nirarin/work/agent-manifesto-research-671",
+  "git_branch":         "research/671-qwen-llm-annotation",
+  "git_commit_sha":     "e64c52f",
+  "git_worktree":       true,
+  "tz":                 "Asia/Tokyo",
+  "machine_id":         "sha-of-hostname",                 // anonymizable
+  "os":                 "darwin-25.3.0",
+  "cli_version":        "claude-code-2.1.117",
+  "model_version":      "claude-opus-4-7-1m"
+}
+```
+
+## `input` section
+
+Shared shape across events that carry a prompt:
+
+```jsonc
+"input": {
+  "prompt":             "text OR null",                   // verbatim or redacted
+  "prompt_sha256":      "hex 64 chars",                    // always present
+  "prompt_length":      420,                               // chars
+  "prompt_language":    "ja",                              // ISO 639-1
+  "prompt_source":      "user" | "hook" | "subagent_return" | "cron",
+  "context_preview_sha":"hex",                             // hash of prior N turns
+  "tool_context_sha":   "hex",                             // hash of tool outputs in window
+  "file_context":       ["path/a.py", "path/b.md"],        // files read/implied
+  "environment_vars": { "ROUTING_COST_SAFETY": "1.8" }     // relevant envs only
+}
+```
+
+When `event_type = user.correction` the same fields apply; the text is the
+user's follow-up turn.
+
+## `decision` section
+
+### 1. `decision.classification` (router.classification)
+
+```jsonc
+"decision": {
+  "kind": "classification",
+  "classifier_id":        "mdeberta-v3-base-agent-manifesto",
+  "classifier_model_hash":"sha-of-model-files",
+  "classifier_version":   "2026-04-23T12:00Z",
+  "probs": {
+    "local_confident": 0.10,
+    "local_probable":  0.17,
+    "cloud_required":  0.48,
+    "hybrid":          0.20,
+    "unknown":         0.05
+  },
+  "predicted_label":      "cloud_required",
+  "predicted_confidence": 0.48,
+  "p_local":              0.27,
+  "p_cloud":              0.73,
+  "alt_classifiers": [
+    {"id":"qwen3.6-35b-a3b-q2", "label":"local_confident", "confidence":null, "source":"offline-batch-2026-04-23"},
+    {"id":"qwen3.6-27b-q4",     "label":"cloud_required",  "confidence":null, "source":"offline-batch-2026-04-24"}
+  ],
+  "latency_ms": 80.4
+}
+```
+
+### 2. `decision` (router.decision)
+
+```jsonc
+"decision": {
+  "kind":                 "routing",
+  "action":               "route_to_cloud",              // route_to_cloud | route_to_local | fallback_cloud | force_cloud | error
+  "rule_applied":         "utility_max",                 // utility_max | fallback_low_confidence | force_cloud_prefix | circuit_breaker_open | manual_override
+  "rule_inputs": {
+    "cost_safety":        1.8,
+    "cost_cloud":         1.0,
+    "oov_threshold":      0.3,
+    "force_cloud_prefix": null,                          // "`/research`" if matched
+    "circuit_breaker":    "closed"                       // closed | open | half_open
+  },
+  "rule_outputs": {
+    "utility_local":     -0.27,
+    "utility_cloud":      0.70,
+    "margin":             0.97
+  },
+  "target": {
+    "provider":           "anthropic",                    // anthropic | ccr | llama-server | subagent
+    "model":              "claude-opus-4-7",
+    "endpoint":           "https://api.anthropic.com/v1/messages",
+    "model_tier":         "frontier"                      // frontier | mid | small | local
+  },
+  "alternatives_considered": [
+    {"target":"ccr/qwen3.6-35b-a3b", "utility":-0.27, "rejected_because":"utility < cloud"}
+  ],
+  "rationale_human":      "utility_cloud (0.70) > utility_local (-0.27); no force prefix; circuit breaker closed."
+}
+```
+
+### 3. `decision` (agent.tool_call, skill.invocation, subagent.invocation)
+
+```jsonc
+"decision": {
+  "kind":   "tool_call" | "skill_invocation" | "subagent_invocation",
+  "name":   "Edit" | "/research" | "code-review",
+  "args_sha":"hex",                                        // hash args JSON
+  "args_preview":"first 200 chars of stringified args"
+}
+```
+
+## `execution` section
+
+Applies to events that actually execute something.
+
+```jsonc
+"execution": {
+  "started_at_utc": "2026-04-24T14:30:00.123Z",
+  "ended_at_utc":   "2026-04-24T14:30:01.367Z",
+  "duration_ms":    1244,
+  "success":        true,
+  "error_class":    null,                                  // "TimeoutError", "JSONDecodeError", ...
+  "error_message":  null,
+  "retry_count":    0,
+  "tool_calls_made":["Read","Edit"],
+  "files_read":     ["docs/foo.md"],
+  "files_modified": ["src/bar.py"],
+  "tokens_in":      420,
+  "tokens_out":     1100,
+  "output_sha256":  "hex"
+}
+```
+
+## `outcome` section
+
+Split into `observable_now` and `observable_later` semantics. In practice they
+land in different events (via parent_event_id), but the shape is uniform.
+
+### Immediate outcomes (agent.output, agent.tool_call)
+
+```jsonc
+"outcome": {
+  "horizon":         "immediate",
+  "exit_status":     "completed",                          // completed | interrupted | failed | blocked
+  "tool_calls_count":3,
+  "output_tokens":   1100,
+  "response_hash":   "hex"
+}
+```
+
+### Late outcomes (user.rewind, user.correction, outcome.verify, outcome.commit, outcome.pr_merged, outcome.human_gt_assigned)
+
+```jsonc
+"outcome": {
+  "horizon":               "late",
+  "user_rewind":           true,                           // ESC-ESC detected
+  "user_correction_prompt_sha":"hex",
+  "time_to_rewind_ms":     8200,
+  "subsequent_verify": {
+    "status":"PASS",
+    "findings_count":0,
+    "addressable":0
+  },
+  "git_commit_hash":       "abc123",
+  "pr_number":             674,
+  "pr_merged_at_utc":      "2026-04-24T03:05:00Z",
+  "human_gt_label":        "cloud_required",
+  "human_gt_annotator":    "alice",
+  "human_gt_notes":        "/research command requires orchestration",
+  "satisfaction_signal":   null                            // +1 / -1 / null
+}
+```
+
+## `provenance` section
+
+```jsonc
+"provenance": {
+  "logger_version":  "1.0.0",
+  "schema_version":  "1.0.0",
+  "recorded_by":     "router.js" | "serve_encoder" | "claude-code-hook" | "decision_logger.py",
+  "hook_id":         "PreToolUse.decision-log",
+  "redaction_level": "none" | "prompt_sha_only"
+}
+```
+
+## Storage
+
+- **Format**: JSONL, one event per line.
+- **Path**: `docs/research/routellm-phase3/logs/decisions-YYYY-MM-DD.jsonl`
+  (daily partition; analysis scripts glob `decisions-*.jsonl`).
+- **Rotation**: new file at UTC midnight. No rewrites to prior-day files.
+- **Compression**: files older than 7 days SHOULD be `gzip`'d — readers must
+  handle both `.jsonl` and `.jsonl.gz`.
+- **Retention**: unlimited by default. Runbook should include a prune command
+  referencing `find -mtime +N`.
+
+## Integrity & safety
+
+- Writers SHOULD write one line per event atomically (`open(..., 'a')` with
+  line-buffered `write(json.dumps(event, ensure_ascii=False) + "\n")`).
+- Writers MUST NOT block the caller. If I/O fails, caller behavior is
+  unaffected (logger is best-effort). Log the write failure to stderr.
+- Readers MUST tolerate partially written lines (truncate at last valid
+  newline).
+- Secrets MUST NOT appear in `input.prompt` when the session writes tokens
+  (Bearer, API keys). Writers SHOULD redact `Authorization:` headers and
+  `*.env` contents; future work: regex scrub or opt-in salted-hash.
+
+## Analysis recipes
+
+### Routing accuracy once human GT arrives
+
+```bash
+# Join router.classification with outcome.human_gt_assigned by event_id chain
+jq -s '
+  [.[] | select(.event_type == "router.classification")] as $cls |
+  [.[] | select(.event_type == "outcome.human_gt_assigned")] as $gt |
+  $cls | map(
+    . + {human_gt: (
+      $gt[] | select(.parent_event_id == .event_id) | .outcome.human_gt_label
+    )}
+  ) | map(select(.human_gt))
+  | map({predicted: .decision.predicted_label, gt: .human_gt})
+' decisions-*.jsonl
+```
+
+### User rewind rate per classifier
+
+```bash
+jq -s '
+  group_by(.provenance.recorded_by)
+  | map({by: .[0].provenance.recorded_by, n: length,
+         rewinds: map(select(.event_type == "user.rewind")) | length})
+' decisions-*.jsonl
+```
+
+### Commit rate by predicted label
+
+```bash
+jq -r 'select(.event_type == "router.classification")
+     | [.event_id, .decision.predicted_label] | @tsv' decisions-*.jsonl > /tmp/cls.tsv
+jq -r 'select(.event_type == "outcome.commit")
+     | [.parent_event_id, .outcome.git_commit_hash] | @tsv' decisions-*.jsonl > /tmp/cmt.tsv
+# join -t$'\t' -1 1 -2 1 ...
+```
+
+## Roadmap (explicit non-goals for v1)
+
+- **Sampling**: everything is logged verbatim. Sampling/downsampling is v1.1.
+- **Schema migration**: only breaking changes bump major (v2.0.0). Adding fields
+  = minor bump.
+- **Real-time analytics**: v1 targets batch analysis. Streaming in v2.
+- **Multi-machine aggregation**: v1 is single-machine. Multi-machine rollup
+  is follow-up.
+
+## References
+
+- `docs/research/routellm-phase3/classifier/serve_encoder.py` — existing
+  `DriftLogger` emits a predecessor of `router.classification` (label,
+  confidence, fallback, latency, label/ts/sha). Decision logger is a superset.
+- `docs/research/routellm-phase3/classifier/router.js` — should gain a
+  `router.decision` emitter.
+- `.claude/hooks/` — candidate location for PreToolUse / UserPromptSubmit
+  hooks that emit `user.turn`, `user.correction`, `user.rewind`.
+- `docs/research/routellm-phase3/classifier/monitor_drift.py` — current drift
+  analysis, can be re-pointed at `router.classification` events in the new log.

--- a/docs/research/routellm-phase3/analysis/qwen-35b-vs-27b.md
+++ b/docs/research/routellm-phase3/analysis/qwen-35b-vs-27b.md
@@ -1,0 +1,61 @@
+# Qwen A/B Agreement Analysis
+
+- A: `qwen3.6-35b-a3b` from `qwen-labels-500.jsonl` (500 items)
+- B: `qwen3.6-27b-q4` from `qwen-labels-27b-q4.jsonl` (500 items)
+- Overlap: 500 items
+
+## Summary
+
+- Overall agreement: **0.6460** (323/500)
+- Cohen's kappa: **0.4642**
+- qwen3.6-35b-a3b vs. mDeBERTa classifier: 165/500 = 0.3300
+- qwen3.6-27b-q4 vs. mDeBERTa classifier: 164/500 = 0.3280
+
+## Label distribution
+
+| Label | qwen3.6-35b-a3b | qwen3.6-27b-q4 | delta |
+|---|---:|---:|---:|
+| local_confident | 72 | 15 | -57 |
+| local_probable | 99 | 24 | -75 |
+| cloud_required | 234 | 315 | +81 |
+| hybrid | 58 | 108 | +50 |
+| unknown | 37 | 38 | +1 |
+
+## Confusion matrix (qwen3.6-35b-a3b rows × qwen3.6-27b-q4 columns)
+
+```text
+  qwen3.6-35b-a3b \ qwen3.6-27b-q4
+  rows=qwen3.6-35b-a3b, cols=qwen3.6-27b-q4
+
+                    local_conf local_prob cloud_requ     hybrid    unknown
+   local_confident          12          0         39         18          3
+    local_probable           1         20         48         27          3
+    cloud_required           1          2        219          7          5
+            hybrid           1          0          8         47          2
+           unknown           0          2          1          9         25
+```
+
+## Disagreements sample (up to 20 of 177)
+
+| id | qwen3.6-35b-a3b | qwen3.6-27b-q4 | predicted | prompt preview |
+|---|---|---|---|---|
+| gt-qwen-0000 | local_confident | cloud_required | local_confident | じゃぁ、次の新規 context に渡す prompt を生成して... |
+| gt-qwen-0003 | local_confident | cloud_required | local_confident |  ドキュメント (Section 12.11 + 改訂 11) に反映してから次のステップ (metadata + 完結... |
+| gt-qwen-0004 | local_confident | cloud_required | local_confident |  metadata 反映 + 後続タスク記録を実施... |
+| gt-qwen-0007 | local_confident | cloud_required | local_confident | 後続 Issue の同 PR 内で実施して。... |
+| gt-qwen-0008 | unknown | cloud_required | local_confident | 独立 context agent で議論し提案して。... |
+| gt-qwen-0009 | local_confident | hybrid | local_confident | 後続 docs への反映も実施した上で進めてよし... |
+| gt-qwen-0010 | local_confident | cloud_required | local_confident | OK, 次の独立セッションに投げる 初期 prompt を生成して... |
+| gt-qwen-0014 | local_confident | cloud_required | local_confident | 既存問題は issue に上げておいて。まとめて commit していいよ... |
+| gt-qwen-0016 | local_confident | cloud_required | local_confident | ok,その方針を後続ドキュメントに反映して... |
+| gt-qwen-0018 | local_confident | cloud_required | local_confident | 次のセッションに投げる 初期 prompt を生成して... |
+| gt-qwen-0020 | local_confident | cloud_required | local_confident | 次の Ssession に渡す prompt を生成して... |
+| gt-qwen-0025 | local_confident | cloud_required | local_confident | Parent issue に追記した上で、優先順位を定めて、順番にいこう。... |
+| gt-qwen-0027 | local_confident | cloud_required | local_confident | これまでの議論を情報量を落とさずに整理して、issue #126 のコメントに加えてほしい... |
+| gt-qwen-0031 | local_confident | cloud_required | local_confident | ok, 既存の handoff 文書で思い出しつつ、Day 30 を開始して。... |
+| gt-qwen-0032 | local_confident | cloud_required | local_confident | この改善は既存の handoff skill にも反映しておいて... |
+| gt-qwen-0040 | local_confident | cloud_required | local_confident | まず成果物は commit してから、108 に着手して... |
+| gt-qwen-0041 | hybrid | local_confident | local_confident | OK、区切りとしたい。context 分離した session に引き継げるように、十分に issue などに情報を残し... |
+| gt-qwen-0043 | local_confident | cloud_required | local_confident | OK, 残存指摘と、Section E,F について issue を上げて。次の context への handoff ... |
+| gt-qwen-0048 | local_confident | cloud_required | local_confident | ドキュメント (Section 12.14 + 改訂 15) に反映してから次のステップ (metadata 反映 → ... |
+| gt-qwen-0052 | local_probable | cloud_required | local_probable | ~/.claude/CLAUDE.md を更新したので読んでもらった後に、Day 77 を Lattice test 拡... |

--- a/docs/research/routellm-phase3/analysis/qwen-labeling-runbook.md
+++ b/docs/research/routellm-phase3/analysis/qwen-labeling-runbook.md
@@ -1,0 +1,128 @@
+# Qwen LLM Labeling Runbook
+
+Phase 2 of #671: use a Qwen3.6 model as pseudo-GT annotator before involving humans.
+
+## Model Substitution Note
+
+**Target**: `YTan2000/Qwen3.6-27B-TQ3_4S`
+**Used**: `Qwen3.6-35B-A3B-UD-Q2_K_XL` (local)
+
+Why: `TQ3_4S` (TurboQuant) uses ggml tensor type 46, which stock llama.cpp
+(build 8890) cannot load (max supported type is 42). Running the target model
+requires the `turbo-tan/llama.cpp-tq3` fork. The 35B-A3B MoE alternative is
+same-generation and already tested, so it serves as the substitute. Record the
+substitution when reporting agreement numbers.
+
+## 1. Start the server
+
+```bash
+bash scripts/start-llama-server.sh
+```
+
+- Default model: `$HOME/models/Qwen3.6-35B-A3B-UD-Q2_K_XL.gguf`
+- Default port: `8090`
+- `--jinja` is enabled so `chat_template_kwargs: {enable_thinking: false}` works
+  on Qwen3.6 (required to suppress reasoning output).
+
+Verify:
+
+```bash
+curl -sf http://localhost:8090/v1/models
+```
+
+## 2. Extract real prompts
+
+```bash
+python3 docs/research/routellm-phase3/classifier/extract_real_prompts.py \
+  --project-dir ~/.claude/projects/-Users-nirarin-work-agent-manifesto/ \
+  --output docs/research/routellm-phase3/label-data/real-prompts.jsonl \
+  --max-len 2000 --dedup
+```
+
+Outputs ~1,200 full prompts.
+
+## 3. Stratified sample of 500
+
+```bash
+python3 docs/research/routellm-phase3/classifier/sample_qwen_candidates.py \
+  --real-prompts docs/research/routellm-phase3/label-data/real-prompts.jsonl \
+  --corpus-classified docs/research/routellm-phase3/analysis/real-corpus-per-prompt.jsonl \
+  --output docs/research/routellm-phase3/label-data/qwen-candidates-500.jsonl \
+  --n 500
+```
+
+Stratification uses the `label` + `confidence` fields from `real-corpus-per-prompt.jsonl`
+(production mDeBERTa predictions). Target routing distribution:
+
+- `local_probable`: 50%
+- `cloud_required`: 20%
+- `local_confident`: 15%
+- `hybrid`: 10%
+- `unknown`: 5%
+
+## 4. Qwen labeling
+
+```bash
+python3 docs/research/routellm-phase3/classifier/qwen_labels.py \
+  --input docs/research/routellm-phase3/label-data/qwen-candidates-500.jsonl \
+  --output docs/research/routellm-phase3/label-data/qwen-labels-500.jsonl \
+  --llama-url http://localhost:8090/v1/chat/completions \
+  --checkpoint-every 50
+```
+
+- Thinking mode disabled via `chat_template_kwargs: {enable_thinking: false}`
+- Checkpoints every 50 items (resume-safe: existing `id`s in the output file are skipped)
+- Each entry records `gt_label`, `annotator`, `latency_ms`, `ts`, and a short raw preview
+
+Smoke test (first 5 items):
+
+```bash
+python3 docs/research/routellm-phase3/classifier/qwen_labels.py \
+  --input docs/research/routellm-phase3/label-data/qwen-candidates-500.jsonl \
+  --output /tmp/qwen-smoke.jsonl \
+  --llama-url http://localhost:8090/v1/chat/completions \
+  --limit 5 --checkpoint-every 1
+```
+
+## 5. Agreement with Opus pseudo-GT
+
+```bash
+python3 docs/research/routellm-phase3/classifier/qwen_vs_opus.py \
+  --qwen docs/research/routellm-phase3/label-data/qwen-labels-500.jsonl \
+  --opus-source docs/research/routellm-phase3/classifier/opus_labels.py \
+  --output docs/research/routellm-phase3/analysis/qwen-vs-opus.md
+```
+
+Overlap may be zero if Qwen candidates do not share ids with Opus. In that
+case pass `--candidates-ref <path>` to a JSONL that carries the original
+`gt-NNN` ids (session_id + prompt prefix are used for matching).
+
+## 6. Gate
+
+| Metric | PASS | CONDITIONAL | FAIL |
+|---|---|---|---|
+| Qwen-Opus Cohen's kappa (overlap ≥ 30) | ≥ 0.6 | 0.4–0.6 | < 0.4 |
+| 500-item completion rate | 100% | 95–99% | < 95% |
+| Qwen label distribution vs. routing target | ≤ 20% L1 delta | 20–30% | > 30% |
+
+- **PASS** → proceed with human annotation on the same 500 candidates.
+- **CONDITIONAL** → iterate on the system prompt, or accept as provisional GT.
+- **FAIL** → Qwen-at-this-quant is not a credible annotator; escalate to humans directly.
+
+## 7. Next steps after PASS
+
+- Convert Qwen labels to corrections: `gt_to_corrections.py --labeled qwen-labels-500.jsonl`
+- Run `calibrate_from_gt.py --labeled qwen-labels-500.jsonl` to measure mDeBERTa ECE
+- Release candidates to human annotators for final GT
+
+## Troubleshooting
+
+- **500 Model loading error `ggml type 46`** — stock llama.cpp cannot load TurboQuant.
+  Use 35B-A3B substitute or build `turbo-tan/llama.cpp-tq3` and reinvoke with the
+  forked binary.
+- **Empty `content` + thinking trace in `reasoning_content`** — `--jinja` missing
+  or `chat_template_kwargs.enable_thinking` not set to `false`.
+- **Labels mostly `unknown`** — parse fallback triggered; inspect `raw_preview`
+  in the output JSONL for malformed JSON.
+- **Checkpoint not resuming** — confirm the output file already contains entries
+  with matching `id`s; only same-`id` entries are skipped.

--- a/docs/research/routellm-phase3/classifier/arena_to_gt.py
+++ b/docs/research/routellm-phase3/classifier/arena_to_gt.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+arena_to_gt.py — Convert lmarena-ai/arena-human-preference-100k to our 5-label taxonomy.
+
+Arena entries carry human-derived metadata in `category_tag.criteria_v0.1`:
+  complexity, creativity, domain_knowledge, problem_solving,
+  real_world, specificity, technical_accuracy (all booleans)
+plus `is_code`, `is_refusal`, `is_code`, `math_v0.1`, and `winner` (human vote).
+
+We combine these signals via a deterministic rule so labels trace back to
+human-annotated inputs. The mapping is intentionally conservative: when in
+doubt we bias toward `cloud_required` (safer for routing).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+
+LABELS = ["local_confident", "local_probable", "cloud_required", "hybrid", "unknown"]
+
+
+STRONG_MODELS = {
+    # Frontier tier (likely to win when task is hard)
+    "claude-3-5-sonnet-20240620",
+    "claude-3-5-sonnet-20241022",
+    "claude-3-opus-20240229",
+    "gpt-4o-2024-05-13",
+    "gpt-4o-2024-08-06",
+    "gpt-4o-2024-11-20",
+    "gpt-4-turbo-2024-04-09",
+    "o1-preview",
+    "o1-mini",
+    "gemini-1.5-pro-002",
+    "gemini-1.5-pro-exp-0827",
+    "grok-2-2024-08-13",
+    "chatgpt-4o-latest",
+}
+WEAK_MODELS = {
+    "gpt-3.5-turbo-0125",
+    "gpt-3.5-turbo-1106",
+    "claude-3-haiku-20240307",
+    "gemini-1.5-flash-002",
+    "gemini-1.5-flash-exp-0827",
+    "gemini-1.5-flash-8b-exp-0827",
+    "llama-3-8b-instruct",
+    "llama-3.1-8b-instruct",
+    "mistral-7b-instruct",
+    "qwen2-7b-instruct",
+    "gpt-4o-mini-2024-07-18",
+}
+
+
+def apply_label_rules(row: dict) -> tuple[str, str]:
+    """Return (label, rationale) based on Arena metadata.
+
+    Priority order:
+      1. Refusal / language issues → unknown
+      2. Complexity + multiple hard flags → cloud_required
+      3. Code + complexity → cloud_required
+      4. Creativity + complexity → hybrid
+      5. Medium complexity → local_probable
+      6. Low complexity, few flags → local_confident
+      7. Winner gives stronger signal if model tiers known
+    """
+    cat = row.get("category_tag") or {}
+    crit = cat.get("criteria_v0.1") or {}
+    math_v = cat.get("math_v0.1") or {}
+
+    is_code = bool(row.get("is_code"))
+    is_refusal = bool(row.get("is_refusal"))
+    is_math = bool(math_v.get("math"))
+
+    complexity = bool(crit.get("complexity"))
+    creativity = bool(crit.get("creativity"))
+    domain_knowledge = bool(crit.get("domain_knowledge"))
+    problem_solving = bool(crit.get("problem_solving"))
+    technical_accuracy = bool(crit.get("technical_accuracy"))
+    specificity = bool(crit.get("specificity"))
+
+    # Rule 1: refusals indicate safety / OOD
+    if is_refusal:
+        return "unknown", "is_refusal=True (safety or unsupported request)"
+
+    # Rule 2: code tasks with complexity are hard routing
+    if is_code and (complexity or technical_accuracy):
+        return "cloud_required", "code + (complexity|technical_accuracy)"
+
+    # Rule 3: math reasoning tasks
+    if is_math and complexity:
+        return "cloud_required", "math + complexity"
+
+    # Rule 4: complexity + multiple hard flags
+    hard_flag_count = sum([complexity, technical_accuracy, problem_solving, domain_knowledge])
+    if complexity and hard_flag_count >= 3:
+        return "cloud_required", f"complexity + hard_flags={hard_flag_count}"
+
+    # Rule 5: creativity + complexity → hybrid (local can start, cloud refines)
+    if creativity and complexity:
+        return "hybrid", "creativity + complexity"
+
+    # Rule 6: domain_knowledge without complexity → local_probable
+    if domain_knowledge and not complexity and not technical_accuracy:
+        return "local_probable", "domain_knowledge only"
+
+    # Rule 7: low complexity, few flags → local_confident
+    if not complexity and hard_flag_count <= 1:
+        return "local_confident", f"no complexity, hard_flags={hard_flag_count}"
+
+    # Rule 8: complexity alone or with 1-2 flags → local_probable
+    if complexity and hard_flag_count <= 2:
+        return "local_probable", f"complexity with hard_flags={hard_flag_count}"
+
+    # Default: probably needs cloud
+    return "cloud_required", f"default (hard_flags={hard_flag_count}, specificity={specificity})"
+
+
+def winner_signal(row: dict) -> str | None:
+    """Return 'cloud_required', 'local', or None if undetermined.
+
+    Strong model wins → task needed the strong model → cloud_required.
+    Weak model wins or tie with weak models → local likely suffices.
+    """
+    winner = row.get("winner")
+    model_a = row.get("model_a") or ""
+    model_b = row.get("model_b") or ""
+
+    a_strong = model_a in STRONG_MODELS
+    a_weak = model_a in WEAK_MODELS
+    b_strong = model_b in STRONG_MODELS
+    b_weak = model_b in WEAK_MODELS
+
+    if winner == "model_a" and a_strong and b_weak:
+        return "cloud_required"
+    if winner == "model_b" and b_strong and a_weak:
+        return "cloud_required"
+    if winner in {"tie", "tie (bothbad)"} and (a_weak or b_weak):
+        return "local"
+    return None
+
+
+def extract_first_user_prompt(conversation: list[dict]) -> str:
+    if not conversation:
+        return ""
+    for turn in conversation:
+        if turn.get("role") == "user":
+            return (turn.get("content") or "").strip()
+    return ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--parquet", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--language", default="English")
+    parser.add_argument("--max-prompt-len", type=int, default=2000)
+    parser.add_argument("--max-items", type=int, default=0, help="If >0, stop after N items (for quick tests).")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--turn-1-only", action="store_true", help="Keep only first-turn exchanges")
+    args = parser.parse_args()
+
+    print(f"[arena] reading {args.parquet}")
+    table = pq.read_table(str(args.parquet))
+    print(f"[arena] total rows: {table.num_rows}")
+
+    rows = table.to_pylist()
+
+    entries: list[dict] = []
+    dist = Counter()
+    winner_disagree = 0
+    winner_agree = 0
+    for row in rows:
+        if args.language and row.get("language") != args.language:
+            continue
+        if args.turn_1_only and row.get("turn") != 1:
+            continue
+        prompt = extract_first_user_prompt(row.get("conversation_a") or [])
+        if not prompt:
+            continue
+        if len(prompt) > args.max_prompt_len:
+            prompt = prompt[: args.max_prompt_len]
+
+        label, rationale = apply_label_rules(row)
+        w_signal = winner_signal(row)
+        if w_signal:
+            if w_signal == "cloud_required" and label == "cloud_required":
+                winner_agree += 1
+            elif w_signal == "local" and label in {"local_confident", "local_probable"}:
+                winner_agree += 1
+            else:
+                winner_disagree += 1
+
+        entries.append(
+            {
+                "id": f"gt-arena-{len(entries):05d}",
+                "question_id": row.get("question_id"),
+                "prompt": prompt,
+                "prompt_len": len(prompt),
+                "language": row.get("language"),
+                "is_code": bool(row.get("is_code")),
+                "is_refusal": bool(row.get("is_refusal")),
+                "category_tag": row.get("category_tag"),
+                "winner": row.get("winner"),
+                "model_a": row.get("model_a"),
+                "model_b": row.get("model_b"),
+                "gt_label": label,
+                "annotator": "arena-rules-v1",
+                "annotator_notes": rationale,
+                "winner_signal": w_signal,
+            }
+        )
+        dist[label] += 1
+        if args.max_items and len(entries) >= args.max_items:
+            break
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(json.dumps(e, ensure_ascii=False) for e in entries) + "\n")
+
+    total = len(entries)
+    print(f"[arena] wrote {total} → {args.output}")
+    print(f"[arena] label distribution:")
+    for label in LABELS:
+        count = dist.get(label, 0)
+        print(f"  {label:18s} {count:6d}  ({count / total * 100 if total else 0:.1f}%)")
+
+    if winner_agree + winner_disagree > 0:
+        print(f"[arena] winner-signal cross-check: agree={winner_agree} disagree={winner_disagree} "
+              f"agreement={winner_agree / (winner_agree + winner_disagree):.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/research/routellm-phase3/classifier/decision_event.schema.json
+++ b/docs/research/routellm-phase3/classifier/decision_event.schema.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-manifesto/decision-event/v1.0.0",
+  "title": "Decision Event",
+  "description": "Append-only record of a routing / tool / workflow decision. See decision-log-schema.md.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_id",
+    "parent_event_id",
+    "event_type",
+    "timestamp_utc",
+    "context",
+    "provenance"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "parent_event_id": {
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        { "type": "null" }
+      ]
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "user.turn",
+        "user.correction",
+        "user.rewind",
+        "router.classification",
+        "router.decision",
+        "agent.tool_call",
+        "agent.output",
+        "skill.invocation",
+        "subagent.invocation",
+        "outcome.verify",
+        "outcome.commit",
+        "outcome.pr_merged",
+        "outcome.human_gt_assigned",
+        "manual.note"
+      ]
+    },
+    "timestamp_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "context": {
+      "type": "object",
+      "required": ["session_id", "project_id"],
+      "additionalProperties": true,
+      "properties": {
+        "session_id": { "type": "string" },
+        "turn_id": { "type": "integer", "minimum": 0 },
+        "sequence_id": { "type": "integer", "minimum": 0 },
+        "project_id": { "type": "string" },
+        "project_path": { "type": "string" },
+        "working_directory": { "type": "string" },
+        "git_branch": { "type": ["string", "null"] },
+        "git_commit_sha": { "type": ["string", "null"] },
+        "git_worktree": { "type": "boolean" },
+        "tz": { "type": "string" },
+        "machine_id": { "type": "string" },
+        "os": { "type": "string" },
+        "cli_version": { "type": "string" },
+        "model_version": { "type": "string" }
+      }
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "prompt": { "type": ["string", "null"] },
+        "prompt_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "prompt_length": { "type": "integer", "minimum": 0 },
+        "prompt_language": { "type": ["string", "null"] },
+        "prompt_source": {
+          "type": "string",
+          "enum": ["user", "hook", "subagent_return", "cron", "system"]
+        },
+        "context_preview_sha": { "type": ["string", "null"] },
+        "tool_context_sha": { "type": ["string", "null"] },
+        "file_context": { "type": "array", "items": { "type": "string" } },
+        "environment_vars": { "type": "object", "additionalProperties": { "type": "string" } }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["classification", "routing", "tool_call", "skill_invocation", "subagent_invocation"]
+        },
+        "classifier_id": { "type": "string" },
+        "classifier_model_hash": { "type": ["string", "null"] },
+        "classifier_version": { "type": "string" },
+        "probs": {
+          "type": "object",
+          "additionalProperties": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "predicted_label": {
+          "type": ["string", "null"],
+          "enum": ["local_confident", "local_probable", "cloud_required", "hybrid", "unknown", null]
+        },
+        "predicted_confidence": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "p_local": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "p_cloud": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "alt_classifiers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "label": { "type": ["string", "null"] },
+              "confidence": { "type": ["number", "null"] },
+              "source": { "type": "string" }
+            }
+          }
+        },
+        "latency_ms": { "type": ["number", "null"], "minimum": 0 },
+        "action": {
+          "type": "string",
+          "enum": ["route_to_cloud", "route_to_local", "fallback_cloud", "force_cloud", "error"]
+        },
+        "rule_applied": {
+          "type": "string",
+          "enum": [
+            "utility_max",
+            "fallback_low_confidence",
+            "force_cloud_prefix",
+            "circuit_breaker_open",
+            "manual_override"
+          ]
+        },
+        "rule_inputs": { "type": "object", "additionalProperties": true },
+        "rule_outputs": { "type": "object", "additionalProperties": true },
+        "target": {
+          "type": "object",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "enum": ["anthropic", "ccr", "llama-server", "subagent", "internal"]
+            },
+            "model": { "type": "string" },
+            "endpoint": { "type": "string" },
+            "model_tier": { "type": "string", "enum": ["frontier", "mid", "small", "local"] }
+          }
+        },
+        "alternatives_considered": {
+          "type": "array",
+          "items": { "type": "object", "additionalProperties": true }
+        },
+        "rationale_human": { "type": "string" },
+        "name": { "type": "string" },
+        "args_sha": { "type": "string" },
+        "args_preview": { "type": "string" }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "started_at_utc": { "type": "string", "format": "date-time" },
+        "ended_at_utc": { "type": "string", "format": "date-time" },
+        "duration_ms": { "type": "number", "minimum": 0 },
+        "success": { "type": "boolean" },
+        "error_class": { "type": ["string", "null"] },
+        "error_message": { "type": ["string", "null"] },
+        "retry_count": { "type": "integer", "minimum": 0 },
+        "tool_calls_made": { "type": "array", "items": { "type": "string" } },
+        "files_read": { "type": "array", "items": { "type": "string" } },
+        "files_modified": { "type": "array", "items": { "type": "string" } },
+        "tokens_in": { "type": "integer", "minimum": 0 },
+        "tokens_out": { "type": "integer", "minimum": 0 },
+        "output_sha256": { "type": ["string", "null"] }
+      }
+    },
+    "outcome": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["horizon"],
+      "properties": {
+        "horizon": {
+          "type": "string",
+          "enum": ["immediate", "late"]
+        },
+        "exit_status": {
+          "type": "string",
+          "enum": ["completed", "interrupted", "failed", "blocked"]
+        },
+        "tool_calls_count": { "type": "integer", "minimum": 0 },
+        "output_tokens": { "type": "integer", "minimum": 0 },
+        "response_hash": { "type": ["string", "null"] },
+        "user_rewind": { "type": "boolean" },
+        "user_correction_prompt_sha": { "type": ["string", "null"] },
+        "time_to_rewind_ms": { "type": ["number", "null"], "minimum": 0 },
+        "subsequent_verify": {
+          "type": "object",
+          "properties": {
+            "status": { "type": "string", "enum": ["PASS", "FAIL", "CONDITIONAL", "N/A"] },
+            "findings_count": { "type": "integer", "minimum": 0 },
+            "addressable": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "git_commit_hash": { "type": ["string", "null"] },
+        "pr_number": { "type": ["integer", "null"] },
+        "pr_merged_at_utc": { "type": ["string", "null"], "format": "date-time" },
+        "human_gt_label": {
+          "type": ["string", "null"],
+          "enum": ["local_confident", "local_probable", "cloud_required", "hybrid", "unknown", null]
+        },
+        "human_gt_annotator": { "type": ["string", "null"] },
+        "human_gt_notes": { "type": ["string", "null"] },
+        "satisfaction_signal": { "type": ["integer", "null"], "enum": [-1, 0, 1, null] },
+        "human_note": { "type": ["string", "null"] }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["schema_version", "recorded_by"],
+      "additionalProperties": true,
+      "properties": {
+        "logger_version": { "type": "string" },
+        "schema_version": { "type": "string" },
+        "recorded_by": { "type": "string" },
+        "hook_id": { "type": ["string", "null"] },
+        "redaction_level": { "type": "string", "enum": ["none", "prompt_sha_only"] }
+      }
+    }
+  }
+}

--- a/docs/research/routellm-phase3/classifier/decision_logger.py
+++ b/docs/research/routellm-phase3/classifier/decision_logger.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+decision_logger.py — append-only decision event writer.
+
+Usage (library):
+    from decision_logger import DecisionLogger, new_event_id
+
+    logger = DecisionLogger(
+        log_dir=Path("docs/research/routellm-phase3/logs/"),
+        recorded_by="router.js",
+    )
+    event_id = new_event_id()
+    logger.emit({
+        "event_id": event_id,
+        "parent_event_id": None,
+        "event_type": "router.classification",
+        "context": {"session_id": "...", "project_id": "agent-manifesto"},
+        "input": {"prompt": "...", "prompt_sha256": "..."},
+        "decision": {"kind": "classification", "predicted_label": "cloud_required", ...},
+    })
+
+Usage (CLI test):
+    python3 decision_logger.py --self-test
+
+Schema: decision-log-schema.md (v1.0.0), decision_event.schema.json.
+
+Design goals:
+  - best-effort: write failures never raise to caller
+  - atomic per-line: each event is one JSON line, newline-terminated
+  - daily partitioned: one file per UTC date
+  - extensible: unknown sections are written through unchanged
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0.0"
+LOGGER_VERSION = "1.0.0"
+
+
+def new_event_id() -> str:
+    return str(uuid.uuid4())
+
+
+def sha256_hex(text: str | bytes) -> str:
+    if isinstance(text, str):
+        text = text.encode("utf-8")
+    return hashlib.sha256(text).hexdigest()
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def build_context(
+    *,
+    session_id: str,
+    project_id: str = "agent-manifesto",
+    project_path: str | None = None,
+    working_directory: str | None = None,
+    git_branch: str | None = None,
+    git_commit_sha: str | None = None,
+    git_worktree: bool | None = None,
+    turn_id: int | None = None,
+    sequence_id: int | None = None,
+    tz: str | None = None,
+    machine_id: str | None = None,
+    os_id: str | None = None,
+    cli_version: str | None = None,
+    model_version: str | None = None,
+) -> dict[str, Any]:
+    ctx: dict[str, Any] = {
+        "session_id": session_id,
+        "project_id": project_id,
+    }
+    for key, value in [
+        ("project_path", project_path),
+        ("working_directory", working_directory),
+        ("git_branch", git_branch),
+        ("git_commit_sha", git_commit_sha),
+        ("git_worktree", git_worktree),
+        ("turn_id", turn_id),
+        ("sequence_id", sequence_id),
+        ("tz", tz),
+        ("machine_id", machine_id),
+        ("os", os_id),
+        ("cli_version", cli_version),
+        ("model_version", model_version),
+    ]:
+        if value is not None:
+            ctx[key] = value
+    return ctx
+
+
+class DecisionLogger:
+    """Append-only JSONL writer for decision events.
+
+    Thread-safety: single-writer file-append-only is atomic on POSIX for lines
+    under PIPE_BUF. We keep events small; callers that need strict ordering
+    across processes should serialize calls themselves.
+    """
+
+    def __init__(
+        self,
+        log_dir: Path,
+        *,
+        recorded_by: str,
+        hook_id: str | None = None,
+        redaction_level: str = "none",
+    ) -> None:
+        self.log_dir = log_dir
+        self.recorded_by = recorded_by
+        self.hook_id = hook_id
+        self.redaction_level = redaction_level
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path_for(self, ts: datetime) -> Path:
+        return self.log_dir / f"decisions-{ts.strftime('%Y-%m-%d')}.jsonl"
+
+    def emit(self, event: dict[str, Any]) -> str:
+        """Normalize + append one event. Returns the event_id (generating if missing).
+
+        Never raises on I/O failure — logs to stderr and returns the id.
+        """
+        now = datetime.now(timezone.utc)
+        event.setdefault("schema_version", SCHEMA_VERSION)
+        event.setdefault("event_id", new_event_id())
+        event.setdefault("parent_event_id", None)
+        event.setdefault("timestamp_utc", now.replace(microsecond=0).isoformat().replace("+00:00", "Z"))
+        event.setdefault("provenance", {})
+
+        prov = event["provenance"]
+        prov.setdefault("schema_version", SCHEMA_VERSION)
+        prov.setdefault("logger_version", LOGGER_VERSION)
+        prov.setdefault("recorded_by", self.recorded_by)
+        if self.hook_id is not None:
+            prov.setdefault("hook_id", self.hook_id)
+        prov.setdefault("redaction_level", self.redaction_level)
+
+        if self.redaction_level == "prompt_sha_only":
+            inp = event.get("input") or {}
+            if "prompt" in inp:
+                if inp.get("prompt") is not None and not inp.get("prompt_sha256"):
+                    inp["prompt_sha256"] = sha256_hex(inp["prompt"])
+                inp["prompt"] = None
+                event["input"] = inp
+
+        path = self._path_for(now)
+        line = json.dumps(event, ensure_ascii=False, separators=(",", ":"))
+
+        try:
+            with path.open("a", encoding="utf-8") as f:
+                f.write(line + "\n")
+        except OSError as exc:
+            print(f"[decision_logger] write failure to {path}: {exc}", file=sys.stderr)
+
+        return event["event_id"]
+
+
+def _self_test() -> int:
+    tmp = Path(os.environ.get("TMPDIR", "/tmp")) / "decision-logger-selftest"
+    if tmp.exists():
+        for f in tmp.iterdir():
+            f.unlink()
+    tmp.mkdir(parents=True, exist_ok=True)
+
+    logger = DecisionLogger(tmp, recorded_by="decision_logger.selftest", redaction_level="none")
+
+    # user.turn
+    turn_id = logger.emit({
+        "event_type": "user.turn",
+        "context": build_context(
+            session_id="test-session",
+            project_id="agent-manifesto",
+            git_branch="main",
+            turn_id=1,
+        ),
+        "input": {
+            "prompt": "/research issue を整理して",
+            "prompt_sha256": sha256_hex("/research issue を整理して"),
+            "prompt_length": 22,
+            "prompt_language": "ja",
+            "prompt_source": "user",
+        },
+    })
+
+    # router.classification
+    cls_id = logger.emit({
+        "event_type": "router.classification",
+        "parent_event_id": turn_id,
+        "context": build_context(
+            session_id="test-session", project_id="agent-manifesto",
+            turn_id=1, sequence_id=0,
+        ),
+        "input": {
+            "prompt_sha256": sha256_hex("/research issue を整理して"),
+            "prompt_length": 22,
+        },
+        "decision": {
+            "kind": "classification",
+            "classifier_id": "mdeberta-v3-base-agent-manifesto",
+            "classifier_version": "2026-04-23T12:00Z",
+            "probs": {
+                "local_confident": 0.10,
+                "local_probable": 0.17,
+                "cloud_required": 0.48,
+                "hybrid": 0.20,
+                "unknown": 0.05,
+            },
+            "predicted_label": "cloud_required",
+            "predicted_confidence": 0.48,
+            "p_local": 0.27,
+            "p_cloud": 0.73,
+            "latency_ms": 80.4,
+        },
+    })
+
+    # router.decision
+    dec_id = logger.emit({
+        "event_type": "router.decision",
+        "parent_event_id": cls_id,
+        "context": build_context(
+            session_id="test-session", project_id="agent-manifesto",
+            turn_id=1, sequence_id=1,
+        ),
+        "decision": {
+            "kind": "routing",
+            "action": "route_to_cloud",
+            "rule_applied": "utility_max",
+            "rule_inputs": {"cost_safety": 1.8, "cost_cloud": 1.0, "oov_threshold": 0.3,
+                            "force_cloud_prefix": None, "circuit_breaker": "closed"},
+            "rule_outputs": {"utility_local": -0.27, "utility_cloud": 0.70, "margin": 0.97},
+            "target": {"provider": "anthropic", "model": "claude-opus-4-7",
+                       "endpoint": "https://api.anthropic.com/v1/messages",
+                       "model_tier": "frontier"},
+            "rationale_human": "utility_cloud > utility_local; no force prefix; cb closed.",
+        },
+    })
+
+    # late: outcome.verify
+    logger.emit({
+        "event_type": "outcome.verify",
+        "parent_event_id": dec_id,
+        "context": build_context(
+            session_id="test-session", project_id="agent-manifesto",
+            turn_id=1,
+        ),
+        "outcome": {
+            "horizon": "late",
+            "subsequent_verify": {"status": "PASS", "findings_count": 0, "addressable": 0},
+        },
+    })
+
+    path = next(tmp.glob("decisions-*.jsonl"))
+    lines = path.read_text().splitlines()
+    assert len(lines) == 4, f"expected 4 events got {len(lines)}"
+    for line in lines:
+        event = json.loads(line)
+        assert event["schema_version"] == SCHEMA_VERSION
+        assert "event_id" in event
+        assert "context" in event
+        assert event["provenance"]["logger_version"] == LOGGER_VERSION
+
+    # Check parent chain
+    events = [json.loads(l) for l in lines]
+    assert events[1]["parent_event_id"] == events[0]["event_id"]
+    assert events[2]["parent_event_id"] == events[1]["event_id"]
+    assert events[3]["parent_event_id"] == events[2]["event_id"]
+
+    print(f"PASS decision_logger self-test ({path})")
+    print(f"  events: {len(lines)}")
+    print(f"  bytes: {path.stat().st_size}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        return _self_test()
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/research/routellm-phase3/classifier/qwen_labels.py
+++ b/docs/research/routellm-phase3/classifier/qwen_labels.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+qwen_labels.py — Qwen LLM annotator via llama-server.
+
+Reads candidates JSONL, calls llama-server /v1/chat/completions with thinking
+disabled, writes enriched JSONL with gt_label + metadata. Checkpoints every N.
+Resume-safe: existing output entries are skipped on re-run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+LABELS = ["local_confident", "local_probable", "cloud_required", "hybrid", "unknown"]
+MAX_USER_CHARS = 1500
+
+
+SYSTEM = """You are the agent-manifesto routing classifier. Label each user prompt with exactly one of the 5 labels below.
+
+## Label definitions
+
+- **local_confident**: narrow, low-domain, batch-style tasks (outline, summarise, handoff, simple file read)
+- **local_probable**: medium-domain reasoning, structured interpretation (V1-V7 reading, trace analysis, paper drafting)
+- **cloud_required**: safety-critical or deep reasoning (`/verify`, `/evolve`, `/research`, code generation, PR management, design decisions)
+- **hybrid**: dynamic routing based on input (short ack, status check, Q&A, discussion)
+- **unknown**: out-of-distribution, off-topic (chitchat, cooking, weather, anything unrelated to agent-manifesto project)
+
+## Decision hints
+
+- Any slash command like `/research`, `/verify`, `/evolve`, `/trace`, `/metrics`, `/paperize`, `/handoff` → usually cloud_required (unless handoff which may be local_confident)
+- Code modification, PR work, file operations → cloud_required
+- V1-V7 interpretation, manifest-trace output reading → local_probable
+- Short confirmations, "ok", status questions → hybrid
+- Off-project prompts → unknown
+
+## Output
+
+Respond with exactly one JSON object on a single line. No explanation, no preamble:
+{"label": "<one of the 5 labels>"}"""
+
+
+def validate_localhost_url(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"unsupported url scheme: {url}")
+    if parsed.hostname not in {"127.0.0.1", "localhost"}:
+        raise ValueError(f"url must point to localhost: {url}")
+    return url
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def append_jsonl(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as f:
+        for entry in entries:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def extract_label(content: str) -> str:
+    match = re.search(r'"label"\s*:\s*"([^"]+)"', content)
+    if match:
+        candidate = match.group(1).strip()
+        if candidate in LABELS:
+            return candidate
+    for label in LABELS:
+        if label in content:
+            return label
+    return "unknown"
+
+
+def classify_via_llama_server(prompt: str, url: str, timeout: int = 120) -> tuple[str, float, str]:
+    body = {
+        "model": "qwen3.6-35b-a3b",
+        "messages": [
+            {"role": "system", "content": SYSTEM},
+            {"role": "user", "content": prompt[:MAX_USER_CHARS]},
+        ],
+        "max_tokens": 128,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    start = time.time()
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    latency_ms = (time.time() - start) * 1000.0
+    content = payload.get("choices", [{}])[0].get("message", {}).get("content", "") or ""
+    return extract_label(content), latency_ms, content
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--llama-url", default="http://localhost:8090/v1/chat/completions")
+    parser.add_argument("--checkpoint-every", type=int, default=50)
+    parser.add_argument("--limit", type=int, default=0, help="If >0, only process first N candidates (for smoke tests).")
+    parser.add_argument("--timeout", type=int, default=120)
+    args = parser.parse_args()
+
+    url = validate_localhost_url(args.llama_url)
+    candidates = load_jsonl(args.input)
+    if args.limit > 0:
+        candidates = candidates[: args.limit]
+    print(f"[qwen-labels] input={args.input} n={len(candidates)}")
+
+    existing = load_jsonl(args.output)
+    processed_ids = {entry.get("id") for entry in existing if entry.get("id")}
+    if processed_ids:
+        print(f"[qwen-labels] resume: {len(processed_ids)} already processed, skipping")
+
+    pending_buffer: list[dict] = []
+    label_counts: dict[str, int] = {label: 0 for label in LABELS}
+    latencies: list[float] = []
+    fallback_count = 0
+
+    def flush() -> None:
+        if pending_buffer:
+            append_jsonl(args.output, pending_buffer)
+            pending_buffer.clear()
+
+    try:
+        for index, candidate in enumerate(candidates, start=1):
+            cid = candidate.get("id")
+            if cid and cid in processed_ids:
+                continue
+            prompt_text = candidate.get("prompt", "")
+            if not prompt_text:
+                continue
+
+            try:
+                label, latency_ms, raw_content = classify_via_llama_server(prompt_text, url, args.timeout)
+            except (urllib.error.URLError, ValueError) as exc:
+                print(f"[qwen-labels] classify failed for {cid}: {exc}; marking unknown")
+                label, latency_ms, raw_content = "unknown", 0.0, ""
+                fallback_count += 1
+
+            if label not in LABELS:
+                label = "unknown"
+                fallback_count += 1
+
+            label_counts[label] += 1
+            latencies.append(latency_ms)
+
+            enriched = dict(candidate)
+            enriched["gt_label"] = label
+            enriched["annotator"] = "qwen3.6-35b-a3b"
+            enriched.setdefault("annotator_notes", None)
+            enriched["latency_ms"] = round(latency_ms, 2)
+            enriched["ts"] = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+            enriched["raw_preview"] = raw_content[:200]
+            pending_buffer.append(enriched)
+
+            if len(pending_buffer) >= max(1, args.checkpoint_every):
+                flush()
+                total = len(processed_ids) + label_counts_sum(label_counts)
+                print(f"[qwen-labels] checkpoint {total}/{len(candidates)} dist={dict_nonzero(label_counts)}")
+    finally:
+        flush()
+
+    total_labeled = label_counts_sum(label_counts)
+    if latencies:
+        mean_latency = sum(latencies) / len(latencies)
+    else:
+        mean_latency = 0.0
+    print("\n=== Qwen labeling summary ===")
+    print(f"  total labeled this run: {total_labeled}")
+    print(f"  label distribution: {dict_nonzero(label_counts)}")
+    print(f"  mean latency ms: {mean_latency:.1f}")
+    print(f"  fallback (parse/classify failures): {fallback_count}")
+    print(f"  output: {args.output}")
+
+
+def dict_nonzero(counts: dict[str, int]) -> dict[str, int]:
+    return {label: count for label, count in counts.items() if count > 0}
+
+
+def label_counts_sum(counts: dict[str, int]) -> int:
+    return sum(counts.values())
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/research/routellm-phase3/classifier/qwen_labels.py
+++ b/docs/research/routellm-phase3/classifier/qwen_labels.py
@@ -82,9 +82,9 @@ def extract_label(content: str) -> str:
     return "unknown"
 
 
-def classify_via_llama_server(prompt: str, url: str, timeout: int = 120) -> tuple[str, float, str]:
+def classify_via_llama_server(prompt: str, url: str, timeout: int = 120, model_alias: str = "qwen3.6-35b-a3b") -> tuple[str, float, str]:
     body = {
-        "model": "qwen3.6-35b-a3b",
+        "model": model_alias,
         "messages": [
             {"role": "system", "content": SYSTEM},
             {"role": "user", "content": prompt[:MAX_USER_CHARS]},
@@ -116,6 +116,8 @@ def main() -> None:
     parser.add_argument("--checkpoint-every", type=int, default=50)
     parser.add_argument("--limit", type=int, default=0, help="If >0, only process first N candidates (for smoke tests).")
     parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--annotator-label", default="qwen3.6-35b-a3b", help="Value written to each entry's annotator field.")
+    parser.add_argument("--model-alias", default="qwen3.6-35b-a3b", help="Model name sent to /v1/chat/completions.")
     args = parser.parse_args()
 
     url = validate_localhost_url(args.llama_url)
@@ -149,7 +151,7 @@ def main() -> None:
                 continue
 
             try:
-                label, latency_ms, raw_content = classify_via_llama_server(prompt_text, url, args.timeout)
+                label, latency_ms, raw_content = classify_via_llama_server(prompt_text, url, args.timeout, args.model_alias)
             except (urllib.error.URLError, ValueError) as exc:
                 print(f"[qwen-labels] classify failed for {cid}: {exc}; marking unknown")
                 label, latency_ms, raw_content = "unknown", 0.0, ""
@@ -164,7 +166,7 @@ def main() -> None:
 
             enriched = dict(candidate)
             enriched["gt_label"] = label
-            enriched["annotator"] = "qwen3.6-35b-a3b"
+            enriched["annotator"] = args.annotator_label
             enriched.setdefault("annotator_notes", None)
             enriched["latency_ms"] = round(latency_ms, 2)
             enriched["ts"] = datetime.now(timezone.utc).replace(microsecond=0).isoformat()

--- a/docs/research/routellm-phase3/classifier/qwen_vs_opus.py
+++ b/docs/research/routellm-phase3/classifier/qwen_vs_opus.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+qwen_vs_opus.py — Agreement analysis between Qwen and Opus pseudo-GT.
+
+Since the 100-candidate Opus labels are keyed by gt-NNN id (and the
+original candidates file is gitignored), we reconstruct the overlap by
+matching Qwen outputs with Opus labels using session_id + prompt prefix
+against a reference candidates file (optional) or just list Qwen's
+distribution when no overlap exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from collections import Counter
+from pathlib import Path
+
+LABELS = ["local_confident", "local_probable", "cloud_required", "hybrid", "unknown"]
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def load_opus_labels(path: Path) -> dict[str, tuple[str, str]]:
+    spec = importlib.util.spec_from_file_location("opus_labels", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return {item[0]: (item[1], item[2]) for item in getattr(module, "OPUS_LABELS", [])}
+
+
+def confusion(left: dict[str, str], right: dict[str, str]) -> list[list[int]]:
+    matrix = [[0 for _ in LABELS] for _ in LABELS]
+    for key in sorted(set(left) & set(right)):
+        matrix[LABELS.index(left[key])][LABELS.index(right[key])] += 1
+    return matrix
+
+
+def cohen_kappa(left: dict[str, str], right: dict[str, str]) -> float:
+    keys = sorted(set(left) & set(right))
+    if not keys:
+        return 0.0
+    agreement = sum(1 for key in keys if left[key] == right[key]) / len(keys)
+    left_counts = Counter(left[key] for key in keys)
+    right_counts = Counter(right[key] for key in keys)
+    expected = sum(
+        (left_counts[label] / len(keys)) * (right_counts[label] / len(keys))
+        for label in LABELS
+    )
+    if expected == 1.0:
+        return 1.0
+    return (agreement - expected) / (1.0 - expected)
+
+
+def render_matrix(matrix: list[list[int]]) -> str:
+    header = "                   " + " ".join(f"{label[:10]:>10}" for label in LABELS)
+    lines = [header]
+    for index, label in enumerate(LABELS):
+        row = f"{label:>18} " + " ".join(f"{value:>10}" for value in matrix[index])
+        lines.append(row)
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--qwen", type=Path, required=True, help="qwen-labels-500.jsonl")
+    parser.add_argument("--opus-source", type=Path, required=True, help="opus_labels.py")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--candidates-ref",
+        type=Path,
+        help="Optional candidates jsonl that includes the original gt-NNN ids used by opus_labels. "
+        "If provided, we match Qwen entries to Opus ids by session_id + prompt[:100].",
+    )
+    args = parser.parse_args()
+
+    qwen_entries = load_jsonl(args.qwen)
+    opus = load_opus_labels(args.opus_source)
+    print(f"[qwen-vs-opus] qwen={len(qwen_entries)} opus={len(opus)}")
+
+    qwen_labels: dict[str, str] = {}
+    if args.candidates_ref and args.candidates_ref.exists():
+        ref_entries = load_jsonl(args.candidates_ref)
+        ref_index = {
+            (str(entry.get("session_id") or ""), (entry.get("prompt") or "")[:100]): entry.get("id")
+            for entry in ref_entries
+        }
+        for entry in qwen_entries:
+            key = (str(entry.get("session_id") or ""), (entry.get("prompt") or "")[:100])
+            mapped_id = ref_index.get(key)
+            if mapped_id and mapped_id in opus:
+                qwen_labels[mapped_id] = entry.get("gt_label")
+    else:
+        for entry in qwen_entries:
+            cid = entry.get("id")
+            if cid in opus:
+                qwen_labels[cid] = entry.get("gt_label")
+
+    opus_labels = {key: value[0] for key, value in opus.items() if key in qwen_labels}
+    qwen_labels = {key: value for key, value in qwen_labels.items() if key in opus_labels}
+
+    overlap_count = len(qwen_labels)
+    lines: list[str] = ["# Qwen vs Opus Agreement", ""]
+    lines.append(f"- Qwen labeled entries: {len(qwen_entries)}")
+    lines.append(f"- Opus labels available: {len(opus)}")
+    lines.append(f"- Overlap (matched ids): {overlap_count}")
+    lines.append("")
+
+    if overlap_count == 0:
+        lines.append(
+            "Overlap is zero. Qwen candidates do not share ids with `opus_labels.OPUS_LABELS`."
+        )
+        lines.append(
+            "Provide `--candidates-ref` pointing to a JSONL containing gt-NNN ids matching"
+            " the Opus set, or relabel the existing gt-000..gt-099 candidates via Qwen."
+        )
+    else:
+        if overlap_count < 30:
+            lines.append(
+                f"**WARNING**: overlap {overlap_count} < 30. Cohen's kappa is unreliable."
+            )
+            lines.append("")
+
+        kappa = cohen_kappa(qwen_labels, opus_labels)
+        agreement = sum(1 for key in qwen_labels if qwen_labels[key] == opus_labels[key]) / overlap_count
+        lines.append(f"- Overall agreement: {agreement:.4f}")
+        lines.append(f"- Cohen's kappa: {kappa:.4f}")
+        lines.append("")
+
+        matrix = confusion(qwen_labels, opus_labels)
+        lines.append("## Confusion matrix (Qwen rows vs Opus columns)")
+        lines.append("")
+        lines.append("```text")
+        lines.append(render_matrix(matrix))
+        lines.append("```")
+        lines.append("")
+
+        disagreements = [
+            key for key in sorted(qwen_labels) if qwen_labels[key] != opus_labels[key]
+        ]
+        if disagreements:
+            lines.append(f"## Top disagreements (up to 20 of {len(disagreements)})")
+            lines.append("")
+            lines.append("| id | Qwen | Opus | Opus rationale |")
+            lines.append("|---|---|---|---|")
+            for key in disagreements[:20]:
+                rationale = opus[key][1].replace("|", "\\|")
+                lines.append(f"| {key} | {qwen_labels[key]} | {opus_labels[key]} | {rationale} |")
+            lines.append("")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(lines))
+    print(f"[qwen-vs-opus] wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/research/routellm-phase3/classifier/qwen_vs_qwen.py
+++ b/docs/research/routellm-phase3/classifier/qwen_vs_qwen.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+qwen_vs_qwen.py — Compare two Qwen label JSONLs on the same candidate set.
+
+Reports Cohen's kappa, overall agreement, per-label confusion, and per-label
+distribution delta. Designed for A/B comparison of Qwen quantization variants
+(e.g., 35B-A3B Q2 vs 27B Q4) to gauge whether they produce consistent labels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+
+LABELS = ["local_confident", "local_probable", "cloud_required", "hybrid", "unknown"]
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def label_map(entries: list[dict]) -> dict[str, str]:
+    result = {}
+    for entry in entries:
+        cid = entry.get("id")
+        gt = entry.get("gt_label")
+        if cid and gt in LABELS:
+            result[cid] = gt
+    return result
+
+
+def confusion(a: dict[str, str], b: dict[str, str]) -> list[list[int]]:
+    matrix = [[0 for _ in LABELS] for _ in LABELS]
+    for cid in sorted(set(a) & set(b)):
+        matrix[LABELS.index(a[cid])][LABELS.index(b[cid])] += 1
+    return matrix
+
+
+def cohen_kappa(a: dict[str, str], b: dict[str, str]) -> float:
+    keys = sorted(set(a) & set(b))
+    if not keys:
+        return 0.0
+    agreement = sum(1 for k in keys if a[k] == b[k]) / len(keys)
+    ca = Counter(a[k] for k in keys)
+    cb = Counter(b[k] for k in keys)
+    n = len(keys)
+    expected = sum((ca[l] / n) * (cb[l] / n) for l in LABELS)
+    if expected == 1.0:
+        return 1.0
+    return (agreement - expected) / (1.0 - expected)
+
+
+def render_matrix(matrix: list[list[int]], left_name: str, right_name: str) -> str:
+    header = f"  {left_name} \\ {right_name}"
+    lines = [header, "  rows=" + left_name + ", cols=" + right_name, ""]
+    cols = " ".join(f"{l[:10]:>10}" for l in LABELS)
+    lines.append(f"{'':>18}  {cols}")
+    for i, label in enumerate(LABELS):
+        row = " ".join(f"{matrix[i][j]:>10}" for j in range(len(LABELS)))
+        lines.append(f"{label:>18}  {row}")
+    return "\n".join(lines)
+
+
+def distribution(labels: dict[str, str]) -> Counter:
+    return Counter(labels.values())
+
+
+def classifier_agreement(entries: list[dict]) -> tuple[int, int]:
+    """How often does this annotator agree with the classifier's predicted_label?"""
+    match = 0
+    total = 0
+    for entry in entries:
+        gt = entry.get("gt_label")
+        pred = entry.get("predicted_label")
+        if gt in LABELS and pred in LABELS:
+            total += 1
+            if gt == pred:
+                match += 1
+    return match, total
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--a", type=Path, required=True, help="First annotator jsonl (e.g. qwen 35B)")
+    parser.add_argument("--a-name", default="A")
+    parser.add_argument("--b", type=Path, required=True, help="Second annotator jsonl (e.g. qwen 27B)")
+    parser.add_argument("--b-name", default="B")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    a_entries = load_jsonl(args.a)
+    b_entries = load_jsonl(args.b)
+
+    a_labels = label_map(a_entries)
+    b_labels = label_map(b_entries)
+
+    overlap = sorted(set(a_labels) & set(b_labels))
+    print(f"[compare] {args.a_name}: {len(a_labels)} labels; {args.b_name}: {len(b_labels)} labels; overlap: {len(overlap)}")
+
+    kappa = cohen_kappa(a_labels, b_labels)
+    agreement_count = sum(1 for cid in overlap if a_labels[cid] == b_labels[cid])
+    agreement = agreement_count / len(overlap) if overlap else 0.0
+
+    matrix = confusion(a_labels, b_labels)
+    a_dist = distribution(a_labels)
+    b_dist = distribution(b_labels)
+
+    a_classifier_match, a_classifier_total = classifier_agreement(a_entries)
+    b_classifier_match, b_classifier_total = classifier_agreement(b_entries)
+
+    lines = [
+        f"# Qwen A/B Agreement Analysis",
+        "",
+        f"- A: `{args.a_name}` from `{args.a.name}` ({len(a_labels)} items)",
+        f"- B: `{args.b_name}` from `{args.b.name}` ({len(b_labels)} items)",
+        f"- Overlap: {len(overlap)} items",
+        "",
+        f"## Summary",
+        "",
+        f"- Overall agreement: **{agreement:.4f}** ({agreement_count}/{len(overlap)})",
+        f"- Cohen's kappa: **{kappa:.4f}**",
+        f"- {args.a_name} vs. mDeBERTa classifier: {a_classifier_match}/{a_classifier_total} = {a_classifier_match / a_classifier_total if a_classifier_total else 0:.4f}",
+        f"- {args.b_name} vs. mDeBERTa classifier: {b_classifier_match}/{b_classifier_total} = {b_classifier_match / b_classifier_total if b_classifier_total else 0:.4f}",
+        "",
+        f"## Label distribution",
+        "",
+        "| Label | " + args.a_name + " | " + args.b_name + " | delta |",
+        "|---|---:|---:|---:|",
+    ]
+    for label in LABELS:
+        a_count = a_dist.get(label, 0)
+        b_count = b_dist.get(label, 0)
+        lines.append(f"| {label} | {a_count} | {b_count} | {b_count - a_count:+d} |")
+    lines.append("")
+
+    lines.extend(
+        [
+            f"## Confusion matrix ({args.a_name} rows × {args.b_name} columns)",
+            "",
+            "```text",
+            render_matrix(matrix, args.a_name, args.b_name),
+            "```",
+            "",
+        ]
+    )
+
+    disagreements = [cid for cid in overlap if a_labels[cid] != b_labels[cid]]
+    if disagreements:
+        lines.append(f"## Disagreements sample (up to 20 of {len(disagreements)})")
+        lines.append("")
+        lines.append(f"| id | {args.a_name} | {args.b_name} | predicted | prompt preview |")
+        lines.append("|---|---|---|---|---|")
+        preview_a = {entry["id"]: entry for entry in a_entries if entry.get("id")}
+        for cid in disagreements[:20]:
+            entry = preview_a.get(cid, {})
+            prompt = (entry.get("prompt") or "").replace("\n", " ").replace("|", "\\|")[:60]
+            predicted = entry.get("predicted_label", "?")
+            lines.append(f"| {cid} | {a_labels[cid]} | {b_labels[cid]} | {predicted} | {prompt}... |")
+        lines.append("")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(lines))
+    print(f"[compare] wrote {args.output}")
+    print(f"[compare] agreement={agreement:.4f} kappa={kappa:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/research/routellm-phase3/classifier/sample_qwen_candidates.py
+++ b/docs/research/routellm-phase3/classifier/sample_qwen_candidates.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+sample_qwen_candidates.py — Stratified 500-item sampler for Qwen labeling.
+
+Joins real-prompts.jsonl (full text) with real-corpus-per-prompt.jsonl
+(mDeBERTa predictions) by session_id + prompt prefix. Samples stratified
+by production routing distribution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+LABELS = ["local_confident", "local_probable", "cloud_required", "hybrid", "unknown"]
+TARGET_DIST = {
+    "local_confident": 0.15,
+    "local_probable": 0.50,
+    "cloud_required": 0.20,
+    "hybrid": 0.10,
+    "unknown": 0.05,
+}
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def prompt_key(session_id: str | None, prompt: str) -> tuple[str, str]:
+    return (str(session_id or ""), (prompt or "")[:100])
+
+
+def conf_bin(value: float) -> str:
+    if value < 0.5:
+        return "low"
+    if value < 0.8:
+        return "mid"
+    return "high"
+
+
+def proportional_targets(n: int) -> dict[str, int]:
+    targets = {label: max(1, int(round(n * pct))) for label, pct in TARGET_DIST.items()}
+    total = sum(targets.values())
+    if total < n:
+        targets["local_probable"] += n - total
+    elif total > n:
+        overflow = total - n
+        for label in ("unknown", "hybrid", "local_confident", "cloud_required", "local_probable"):
+            if overflow == 0:
+                break
+            removable = min(overflow, max(0, targets[label] - 1))
+            targets[label] -= removable
+            overflow -= removable
+    return targets
+
+
+def sample_by_stratum(
+    pool: dict[tuple[str, str], list[dict]],
+    targets: dict[str, int],
+) -> list[dict]:
+    sampled: list[dict] = []
+    sampled_keys: set[tuple[str, str]] = set()
+
+    for label, count in targets.items():
+        bins = {cb: list(entries) for (lbl, cb), entries in pool.items() if lbl == label}
+        if not bins:
+            continue
+        per_bin = max(1, count // max(1, len(bins)))
+        taken = 0
+        for cb in sorted(bins):
+            remaining = count - taken
+            if remaining <= 0:
+                break
+            candidates = [
+                entry
+                for entry in bins[cb]
+                if (entry["session_id"], entry["prompt"][:100]) not in sampled_keys
+            ]
+            take = min(per_bin, len(candidates), remaining)
+            if take <= 0:
+                continue
+            chosen = random.sample(candidates, take)
+            for entry in chosen:
+                sampled.append(entry)
+                sampled_keys.add((entry["session_id"], entry["prompt"][:100]))
+            taken += take
+
+        remaining = count - taken
+        if remaining > 0:
+            extras = [
+                entry
+                for (lbl, _), entries in pool.items()
+                if lbl == label
+                for entry in entries
+                if (entry["session_id"], entry["prompt"][:100]) not in sampled_keys
+            ]
+            take = min(remaining, len(extras))
+            if take > 0:
+                chosen = random.sample(extras, take)
+                for entry in chosen:
+                    sampled.append(entry)
+                    sampled_keys.add((entry["session_id"], entry["prompt"][:100]))
+
+    return sampled
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--real-prompts", type=Path, required=True)
+    parser.add_argument("--corpus-classified", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--n", type=int, default=500)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--id-prefix", default="gt-qwen")
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+
+    real_prompts = load_jsonl(args.real_prompts)
+    classified = load_jsonl(args.corpus_classified)
+
+    classified_index: dict[tuple[str, str], dict] = {}
+    for entry in classified:
+        session_id = entry.get("session_id")
+        preview = entry.get("prompt_preview") or ""
+        classified_index[(str(session_id or ""), preview[:100])] = entry
+
+    pool: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    joined = 0
+    for entry in real_prompts:
+        key = prompt_key(entry.get("session_id"), entry.get("prompt", ""))
+        classified_entry = classified_index.get(key)
+        if classified_entry is None:
+            continue
+        label = classified_entry.get("label")
+        if label not in LABELS:
+            continue
+        confidence = float(classified_entry.get("confidence") or 0.0)
+        merged = {
+            "session_id": entry.get("session_id"),
+            "prompt": entry.get("prompt"),
+            "prompt_len": entry.get("prompt_len") or len(entry.get("prompt") or ""),
+            "predicted_label": label,
+            "predicted_confidence": round(confidence, 3),
+        }
+        pool[(label, conf_bin(confidence))].append(merged)
+        joined += 1
+
+    print(f"[sample] real_prompts={len(real_prompts)} classified={len(classified)} joined={joined}")
+
+    targets = proportional_targets(args.n)
+    sampled = sample_by_stratum(pool, targets)
+    if len(sampled) < args.n:
+        extras_pool = [
+            entry
+            for entries in pool.values()
+            for entry in entries
+            if entry not in sampled
+        ]
+        remaining = args.n - len(sampled)
+        if extras_pool and remaining > 0:
+            sampled.extend(random.sample(extras_pool, min(remaining, len(extras_pool))))
+
+    sampled = sampled[: args.n]
+
+    entries_out: list[dict] = []
+    for index, entry in enumerate(sampled):
+        entries_out.append(
+            {
+                "id": f"{args.id_prefix}-{index:04d}",
+                "session_id": entry["session_id"],
+                "prompt": entry["prompt"],
+                "prompt_len": entry["prompt_len"],
+                "predicted_label": entry["predicted_label"],
+                "predicted_confidence": entry["predicted_confidence"],
+                "gt_label": None,
+                "annotator_notes": None,
+            }
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(json.dumps(entry, ensure_ascii=False) for entry in entries_out) + "\n")
+
+    dist = Counter(entry["predicted_label"] for entry in entries_out)
+    print(f"[sample] wrote {len(entries_out)} → {args.output}")
+    print(f"[sample] label distribution: {dict(dist)}")
+    print(f"[sample] target distribution: {targets}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/start-llama-server.sh
+++ b/scripts/start-llama-server.sh
@@ -15,11 +15,12 @@
 set -euo pipefail
 
 PORT="${LLAMA_PORT:-8090}"
-MODEL="${LLAMA_MODEL:-$HOME/models/Qwen3.5-4B-UD-Q6_K_XL.gguf}"
+MODEL="${LLAMA_MODEL:-$HOME/models/Qwen3.6-35B-A3B-UD-Q2_K_XL.gguf}"
 NGL="${LLAMA_NGL:-99}"
-CTX="${LLAMA_CTX:-4096}"
+CTX="${LLAMA_CTX:-8192}"
+ALIAS="${LLAMA_ALIAS:-qwen3.6-35b-a3b}"
 HEALTH_URL="http://localhost:${PORT}/health"
-MAX_WAIT=60  # seconds to wait for startup
+MAX_WAIT=120  # Qwen3.6-35B load time on M-series typically 30-90s
 
 check_health() {
   curl -sf --max-time 3 "$HEALTH_URL" 2>/dev/null | grep -q '"ok"'
@@ -52,10 +53,13 @@ fi
 echo "Starting llama-server on port $PORT..." >&2
 nohup llama-server \
   -m "$MODEL" \
+  --host 127.0.0.1 \
   --port "$PORT" \
   -ngl "$NGL" \
   -c "$CTX" \
-  --no-mmap \
+  --alias "$ALIAS" \
+  --jinja \
+  --threads 8 \
   > /tmp/llama-server.log 2>&1 &
 
 LLAMA_PID=$!


### PR DESCRIPTION
## Summary

Parent: #639 / #671 phase 2. **conservative extension**

### 一行結論
LLM pseudo-GT 単独では agent-manifesto routing の GT は作れない。human annotation が必要。ただし将来 GT が得られた時に遡及分析できるよう、append-only decision event log の基礎を置いた。

## 研究レポート

### 1. どんなもの？
- Qwen LLM labeling pipeline (qwen_labels.py + sample + compare)
- 500-item A/B 測定: Qwen3.6-35B-A3B vs Qwen3.6-27B-UD-Q4_K_XL
- Arena 100k を 5-label taxonomy に変換する rule-based pipeline (arena_to_gt.py)
- **Decision event log** schema v1.0.0 + JSON Schema + Python logger

### 2. 先行研究との差分
- RouteLLM: Arena preference から routing label 化 → 我々の domain (agent-manifesto workflow) では OOD で不成立を実証
- SetFit/QLoRA: 既に評価済 (PR #655 architecture survey)
- 新規: **append-only decision log** で将来の human GT と過去 decision を join 可能な設計

### 3. 技術の肝
- **YTan2000/Qwen3.6-27B-TQ3_4S blocker**: TurboQuant ggml type 46 に Metal kernel 無し (stock も turbo-tan fork も)。Metal 移植は 1-2 日の C++/MSL 作業、本 PR scope 外。代替として同 27B params の unsloth UD-Q4_K_XL (標準 Q4 quant) を採用。iogpu.wired_limit_mb=20480 で Metal full offload。
- **Arena OOD 原因**: Arena taxonomy が「LLM への直接 Q&A の難度」を encode。我々の taxonomy が「agent-in-project workflow での routing」を encode。両者は別軸で変換不可。Qwen が 92/100 を unknown と判定、これは誤作動でなく正しい OOD 検出。
- **decision log 設計**: append-only DAG (parent_event_id)、後から追加される late outcome (user rewind, commit hash, human GT) は新 event として書く。flat sections で jq 分析容易。

### 4. どうやって検証した？

| 検証 | 結果 |
|---|---|
| Qwen-35B 500 件 labeling | 500/500 unique、mean 893ms/item |
| Qwen-27B-Q4 500 件 labeling | 500/500 unique、mean ~4s/item (KV cache overhead) |
| Cohen's kappa (35B vs 27B) | **0.4642** (moderate、Gate 0.6 未達) |
| 27B vs mDeBERTa agreement | 32.8% |
| 35B vs mDeBERTa agreement | 33.0% |
| Arena-Human-Preference 100k 変換 | 48,105 English turn-1 prompts (rule-based) |
| Arena 100 サンプル を Qwen 27B で検証 | **92/100 = unknown** → OOD 確認 |
| decision_logger.py --self-test | PASS (4 events chained, schema-valid) |
| JSON Schema validation | PASS (4/4 events against draft-2020-12) |

### 5. 議論

- **なぜ Qwen 同士で割れたか**: 小さい quant (27B-Q4) は cloud 寄り、大きい quant (35B-A3B-Q2) は local 寄り。系統的 bias、ランダム誤差でない。retrain で Qwen 側 label を信じると bias を mDeBERTa に注入する。
- **なぜ Arena を transfer できないか**: Arena = "user → LLM 直接回答" task ontology。agent-manifesto = "user → agent による project 操作" ontology。後者は前者に subordinate しない別軸。
- **本 PR で測定不能な残課題**: routing 正解率そのもの (human GT 不在)、mDeBERTa vs Qwen の優劣 (external oracle 不在)。
- **decision log で将来可能になること**: human GT が 1 件でも足された瞬間、過去全 classification と join して accuracy 計算可能。user rewind / commit hash / verify 結果なども同じ log に書いておけば behavioral signal として使える。

### 6. 次に読むべき
- Chatbot Arena methodology (LMSYS): winner-based routing の仮定精度
- DeBERTa-v3 original paper (我々の classifier の理論)
- Annotation agreement literature (kappa interpretation thresholds)

## ドキュメント更新
- [x] decision-log-schema.md 新規 (v1.0.0)
- [x] qwen-35b-vs-27b.md 分析結果
- [x] codex-brief-671-qwen.md (前 commit に含む)
- [x] qwen-labeling-runbook.md (前 commit に含む)

## 後続 Issue
本 PR では起票せず、#671 の次フェーズとして残す:
1. **decision_logger を router.js + serve_encoder.py に wire** (現状は library only)
2. **human annotation kit を 3 者不一致な prompt (~150 件) に絞って配布** (全 500 件でなく active learning 的に)
3. **TQ3_4S Metal kernel port** (もし TurboQuant が mainstream 化したら)

## Test plan
- [x] ast.parse 全 Python 新規 3 ファイル — PASS
- [x] JSON Schema parse (decision_event.schema.json) — PASS
- [x] decision_logger.py --self-test (4 events, parent chain) — PASS
- [x] jsonschema validation (4/4 events valid) — PASS
- [x] 500-item Qwen-35B labeling + distribution report — PASS
- [x] 500-item Qwen-27B-Q4 labeling + distribution report — PASS
- [x] qwen_vs_qwen.py agreement report — PASS
- [x] arena_to_gt.py produces 48k English labels — PASS
- [x] Qwen 27B validation of Arena sample 100 (confirms OOD) — PASS
- [ ] decision_logger wired to production serve_encoder.py — **follow-up**
- [ ] Human GT on disagreement subset — **follow-up (user decides timing)**

## 分業
- **Claude**: design + implementation (decision logger, schema, arena converter, A/B pipeline, analysis write-up), HF dataset research, model substitution logic
- **Codex**: not used this phase (prior phase PR #674 already implemented infrastructure)
- **User**: decision making (substitute model choice, iogpu limit raise, taxonomy interpretation guidance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)