### PR TITLE
research: Decision log Tier 2 — commit hook, rotation, installer, jq recipes (#676)

### DIFF
--- a/docs/research/routellm-phase3/analysis/decision-log-schema.md
+++ b/docs/research/routellm-phase3/analysis/decision-log-schema.md
@@ -287,6 +287,66 @@ land in different events (via parent_event_id), but the shape is uniform.
 - **Retention**: unlimited by default. Runbook should include a prune command
   referencing `find -mtime +N`.
 
+## Operational setup
+
+### 1. Install git post-commit hook (emits `outcome.commit`)
+
+```bash
+bash scripts/install-decision-log-hooks.sh
+```
+
+Idempotent. Symlinks `scripts/decision-log-commit-hook.sh` into the repo's
+`.git/hooks/post-commit`. Works with linked worktrees (resolves to the main
+repo's git dir).
+
+### 2. Register Claude Code hooks (governance — human approval required)
+
+Edit `.claude/settings.json` and add the block printed by the installer:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [{"hooks": [{"type": "command",
+       "command": "bash $CLAUDE_PROJECT_DIR/scripts/decision-log-emit.sh user.turn"}]}],
+    "PreToolUse":      [{"hooks": [{"type": "command",
+       "command": "bash $CLAUDE_PROJECT_DIR/scripts/decision-log-emit.sh agent.tool_call"}]}],
+    "PostToolUse":     [{"hooks": [{"type": "command",
+       "command": "bash $CLAUDE_PROJECT_DIR/scripts/decision-log-emit.sh agent.tool_call_complete"}]}],
+    "Stop":            [{"hooks": [{"type": "command",
+       "command": "bash $CLAUDE_PROJECT_DIR/scripts/decision-log-emit.sh agent.output"}]}]
+  }
+}
+```
+
+### 3. Start decision-logged classifier
+
+```bash
+DECISION_LOG_DIR=$(pwd)/docs/research/routellm-phase3/logs \
+uv run python3 docs/research/routellm-phase3/classifier/serve_encoder.py \
+  --decision-log-dir docs/research/routellm-phase3/logs
+```
+
+The env var `DECISION_LOG_DIR` is also honored by `router.js` and the hook
+script — keep them pointed at the same directory so events share partitions.
+
+### 4. Schedule log rotation (daily)
+
+Add to `crontab` or launchd:
+
+```cron
+# daily at 00:05 UTC
+5 0 * * * cd /path/to/agent-manifesto && bash scripts/rotate-decision-logs.sh
+```
+
+Files older than 7 days (configurable via `RETAIN_RAW_DAYS`) are gzip'd.
+Analysis helpers must handle both `.jsonl` and `.jsonl.gz`.
+
+### 5. Redaction policy
+
+Production default: `DECISION_LOG_REDACTION=prompt_sha_only` — prompt text
+replaced by SHA-256 hash, length preserved. Development: `none` to keep
+verbatim text for analysis. `router.js` reads `DECISION_LOG_REDACTION` env.
+
 ## Integrity & safety
 
 - Writers SHOULD write one line per event atomically (`open(..., 'a')` with
@@ -301,11 +361,56 @@ land in different events (via parent_event_id), but the shape is uniform.
 
 ## Analysis recipes
 
+> All recipes assume raw `.jsonl` plus gzip'd older files. Use a helper to
+> stream both formats:
+>
+> ```bash
+> decision_cat() {
+>   for f in docs/research/routellm-phase3/logs/decisions-*.jsonl \
+>            docs/research/routellm-phase3/logs/decisions-*.jsonl.gz; do
+>     [ -f "$f" ] || continue
+>     case "$f" in *.gz) gunzip -c "$f";; *) cat "$f";; esac
+>   done
+> }
+> ```
+
+### Event-type histogram (health check)
+
+```bash
+decision_cat | jq -r '.event_type' | sort | uniq -c | sort -rn
+```
+
+### Per-emitter counts (by provenance.recorded_by)
+
+```bash
+decision_cat | jq -r '.provenance.recorded_by' | sort | uniq -c | sort -rn
+```
+
+### Routing decision distribution over last 24h
+
+```bash
+decision_cat | jq -c 'select(.event_type == "router.decision")
+  | {action: .decision.action, rule: .decision.rule_applied,
+     ts: .timestamp_utc}' \
+  | awk -F'"ts":"' '{print $2}' | awk -F'T' '{print $1}' | sort | uniq -c
+```
+
+### Session reconstruction (full DAG for a session)
+
+```bash
+SESSION_ID="<uuid>"
+decision_cat | jq -c --arg sid "$SESSION_ID" \
+  'select(.context.session_id == $sid)
+   | {t: .timestamp_utc, type: .event_type,
+      pid: .parent_event_id, eid: .event_id}' \
+  | sort
+```
+
 ### Routing accuracy once human GT arrives
 
 ```bash
 # Join router.classification with outcome.human_gt_assigned by event_id chain
-jq -s '
+decision_cat | jq -s '
   [.[] | select(.event_type == "router.classification")] as $cls |
   [.[] | select(.event_type == "outcome.human_gt_assigned")] as $gt |
   $cls | map(
@@ -314,7 +419,37 @@ jq -s '
     )}
   ) | map(select(.human_gt))
   | map({predicted: .decision.predicted_label, gt: .human_gt})
-' decisions-*.jsonl
+  | group_by(.predicted)
+  | map({predicted: .[0].predicted, n: length,
+         correct: map(select(.predicted == .gt)) | length})
+'
+```
+
+### Commit → classification join (were cloud-routed turns more likely to commit?)
+
+```bash
+# 1. Get all router.decision events with their event_id
+decision_cat | jq -c 'select(.event_type == "router.decision")
+  | {eid: .event_id, action: .decision.action, ts: .timestamp_utc}' \
+  > /tmp/decisions.jsonl
+
+# 2. Get outcome.commit events with parent_event_id
+decision_cat | jq -c 'select(.event_type == "outcome.commit")
+  | {pid: .parent_event_id, sha: .outcome.git_commit_hash}' \
+  > /tmp/commits.jsonl
+
+# 3. Join: for each action, count how many led to a commit
+python3 -c "
+import json
+decs = [json.loads(l) for l in open('/tmp/decisions.jsonl')]
+cmts = {c['pid'] for c in (json.loads(l) for l in open('/tmp/commits.jsonl'))}
+from collections import Counter
+total = Counter(d['action'] for d in decs)
+hit = Counter(d['action'] for d in decs if d['eid'] in cmts)
+for action in total:
+    rate = hit[action] / total[action] if total[action] else 0
+    print(f'{action:20s} {hit[action]:5d}/{total[action]:5d} commits ({rate*100:.1f}%)')
+"
 ```
 
 ### User rewind rate per classifier

--- a/docs/research/routellm-phase3/classifier/tests/test_decision_log_integration.py
+++ b/docs/research/routellm-phase3/classifier/tests/test_decision_log_integration.py
@@ -6,8 +6,9 @@ Exercises:
   1. decision_logger.DecisionLogger (Python side)
   2. router.js emitter (invoked via node child_process)
   3. scripts/decision-log-emit.sh (invoked via bash child_process)
+  4. scripts/decision-log-commit-hook.sh (git post-commit emitter)
 
-All events from all 3 emitters land in the same temp dir and are validated
+All events from all 4 emitters land in the same temp dir and are validated
 against decision_event.schema.json v1.0.0.
 
 Runtime: single process, no network, no model weights required.
@@ -33,7 +34,7 @@ sys.path.insert(0, str(CLASSIFIER_DIR))
 from decision_logger import DecisionLogger, build_context, sha256_hex
 
 
-def run_subprocess(cmd: list[str], *, env: dict[str, str], stdin: str = "") -> tuple[int, str, str]:
+def run_subprocess(cmd: list[str], *, env: dict[str, str], stdin: str = "", cwd: str | None = None) -> tuple[int, str, str]:
     result = subprocess.run(
         cmd,
         input=stdin,
@@ -41,6 +42,7 @@ def run_subprocess(cmd: list[str], *, env: dict[str, str], stdin: str = "") -> t
         capture_output=True,
         text=True,
         check=False,
+        cwd=cwd,
     )
     return result.returncode, result.stdout, result.stderr
 
@@ -98,6 +100,25 @@ def drive_all_emitters(log_dir: Path) -> list[dict]:
         )
         assert rc == 0, f"hook rc={rc} err={err}"
 
+    # 4. decision-log-commit-hook.sh: simulate a git post-commit inside a
+    # freshly-initialized throwaway repo so it picks up a real commit sha.
+    commit_hook = REPO_ROOT / "scripts" / "decision-log-commit-hook.sh"
+    git_tmp = Path(tempfile.mkdtemp(prefix="decision-log-git-"))
+    try:
+        for git_cmd in (
+            ["git", "init", "--quiet"],
+            ["git", "config", "user.email", "test@example.com"],
+            ["git", "config", "user.name", "integration-test"],
+            ["bash", "-c", "echo seed > seed.txt && git add seed.txt && git commit -q -m 'seed commit'"],
+        ):
+            rc, out, err = run_subprocess(git_cmd, env=env_base, cwd=str(git_tmp))
+            assert rc == 0, f"git setup failed: {git_cmd} rc={rc} err={err}"
+        # Fire the post-commit hook manually from the git tmp dir
+        rc, out, err = run_subprocess(["bash", str(commit_hook)], env=env_base, cwd=str(git_tmp))
+        assert rc == 0, f"commit hook rc={rc} err={err}"
+    finally:
+        shutil.rmtree(git_tmp, ignore_errors=True)
+
     files = sorted(glob.glob(str(log_dir / "decisions-*.jsonl")))
     assert files, "no log files written"
     events = []
@@ -144,7 +165,7 @@ def main() -> int:
         validate_schema(events)
         by_recorder = group_by_recorder(events)
 
-        expected_recorders = {"integration.test", "router.js", "claude-code-hook"}
+        expected_recorders = {"integration.test", "router.js", "claude-code-hook", "git-post-commit-hook"}
         missing = expected_recorders - set(by_recorder.keys())
         assert not missing, f"missing emitter(s): {missing}"
 
@@ -159,8 +180,9 @@ def main() -> int:
         assert "user.turn" in observed_types, "hook did not emit user.turn"
         assert "agent.tool_call" in observed_types, "hook did not emit agent.tool_call"
         assert "agent.tool_call_complete" in observed_types, "hook did not emit agent.tool_call_complete"
+        assert "outcome.commit" in observed_types, "git post-commit hook did not emit"
 
-        print(f"\nPASS integration: {len(events)} events, 3 emitters, schema-valid")
+        print(f"\nPASS integration: {len(events)} events, 4 emitters, schema-valid")
         return 0
     finally:
         shutil.rmtree(log_dir, ignore_errors=True)

--- a/scripts/decision-log-commit-hook.sh
+++ b/scripts/decision-log-commit-hook.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# decision-log-commit-hook.sh — Git post-commit hook that emits outcome.commit.
+#
+# Installs into .git/hooks/post-commit (symlink or copy). For worktrees,
+# install into the main repo's .git/hooks/ so all worktrees share.
+#
+# Install (idempotent):
+#   bash scripts/install-decision-log-hooks.sh
+#
+# Environment overrides:
+#   DECISION_LOG_DIR        — destination dir (default: <repo>/docs/research/routellm-phase3/logs)
+#   DECISION_LOG_REDACTION  — "none" | "prompt_sha_only" (default: prompt_sha_only)
+#   DECISION_LOG_PARENT_ID  — parent event to link to (if Claude Code session id
+#                              tracking is in place; otherwise null)
+#
+# Best-effort: any failure is logged to stderr and exit 0 is returned so git
+# commit is never blocked.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+LOG_DIR="${DECISION_LOG_DIR:-$REPO_ROOT/docs/research/routellm-phase3/logs}"
+REDACTION="${DECISION_LOG_REDACTION:-prompt_sha_only}"
+
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+DATE=$(date -u +%Y-%m-%d)
+LOG_FILE="$LOG_DIR/decisions-$DATE.jsonl"
+
+COMMIT_SHA=$(git rev-parse HEAD 2>/dev/null)
+COMMIT_SUBJECT=$(git log -1 --pretty=%s 2>/dev/null)
+COMMIT_AUTHOR=$(git log -1 --pretty=%an 2>/dev/null)
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+GIT_WORKTREE=$([ "$(git rev-parse --git-dir)" != "$REPO_ROOT/.git" ] && echo "true" || echo "false")
+
+CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null | tr '\n' ' ')
+
+DECISION_LOG_COMMIT_SHA="$COMMIT_SHA" \
+DECISION_LOG_COMMIT_SUBJECT="$COMMIT_SUBJECT" \
+DECISION_LOG_COMMIT_AUTHOR="$COMMIT_AUTHOR" \
+DECISION_LOG_BRANCH="$BRANCH" \
+DECISION_LOG_GIT_WORKTREE="$GIT_WORKTREE" \
+DECISION_LOG_CHANGED_FILES="$CHANGED_FILES" \
+DECISION_LOG_PARENT_ID="${DECISION_LOG_PARENT_ID:-}" \
+DECISION_LOG_REPO_ROOT="$REPO_ROOT" \
+python3 -c "$(cat <<'PY'
+import hashlib
+import json
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+
+log_file, redaction = sys.argv[1], sys.argv[2]
+commit_sha = os.environ.get("DECISION_LOG_COMMIT_SHA", "")
+if not commit_sha:
+    sys.exit(0)
+
+commit_subject = os.environ.get("DECISION_LOG_COMMIT_SUBJECT", "")
+commit_author = os.environ.get("DECISION_LOG_COMMIT_AUTHOR", "")
+branch = os.environ.get("DECISION_LOG_BRANCH", "")
+git_worktree = os.environ.get("DECISION_LOG_GIT_WORKTREE", "false") == "true"
+changed_files = [f for f in os.environ.get("DECISION_LOG_CHANGED_FILES", "").split() if f]
+parent_id = os.environ.get("DECISION_LOG_PARENT_ID") or None
+session_id = (
+    os.environ.get("CLAUDE_SESSION_ID")
+    or os.environ.get("DECISION_LOG_SESSION_ID")
+    or f"git-post-commit-{commit_sha[:16]}"
+)
+project_path = os.environ.get("DECISION_LOG_REPO_ROOT", os.getcwd())
+
+envelope = {
+    "schema_version": "1.0.0",
+    "event_id": str(uuid.uuid4()),
+    "parent_event_id": parent_id,
+    "event_type": "outcome.commit",
+    "timestamp_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    "context": {
+        "session_id": session_id,
+        "project_id": os.environ.get("DECISION_LOG_PROJECT_ID", "agent-manifesto"),
+        "project_path": project_path,
+        "git_branch": branch,
+        "git_commit_sha": commit_sha,
+        "git_worktree": git_worktree,
+    },
+    "execution": {
+        "files_modified": changed_files,
+    },
+    "outcome": {
+        "horizon": "late",
+        "git_commit_hash": commit_sha,
+    },
+    "provenance": {
+        "schema_version": "1.0.0",
+        "logger_version": "1.0.0",
+        "recorded_by": "git-post-commit-hook",
+        "hook_id": "post-commit.decision-log-emit",
+        "redaction_level": redaction,
+    },
+}
+if commit_subject:
+    envelope["outcome"]["commit_subject"] = commit_subject
+if commit_author:
+    envelope["outcome"]["commit_author"] = commit_author
+
+try:
+    with open(log_file, "a", encoding="utf-8") as f:
+        f.write(json.dumps(envelope, ensure_ascii=False, separators=(",", ":")) + "\n")
+except OSError as exc:
+    print(f"[decision-log-commit-hook] write failure: {exc}", file=sys.stderr)
+PY
+)" "$LOG_FILE" "$REDACTION" >/dev/null 2>&1
+
+exit 0

--- a/scripts/install-decision-log-hooks.sh
+++ b/scripts/install-decision-log-hooks.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# install-decision-log-hooks.sh — idempotent installer for git hooks.
+#
+# Installs decision-log-commit-hook.sh as the repo's git post-commit hook.
+# Safe to re-run: detects existing symlink/copy and skips.
+#
+# Does NOT touch .claude/settings.json. Hook registration for Claude Code
+# (UserPromptSubmit / PreToolUse / PostToolUse / Stop) requires human
+# approval to edit .claude/settings.json — see docs for the snippet.
+
+set -eu
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  echo "[install] not in a git repo" >&2
+  exit 1
+fi
+
+GIT_HOOKS_DIR="$REPO_ROOT/.git/hooks"
+# For linked worktrees, .git is a file pointing at the actual gitdir
+if [ -f "$REPO_ROOT/.git" ]; then
+  GIT_DIR=$(sed -n 's/^gitdir: //p' "$REPO_ROOT/.git" 2>/dev/null)
+  if [ -n "$GIT_DIR" ]; then
+    # worktree gitdir is $mainrepo/.git/worktrees/<name>
+    # hooks live in the main repo's .git/hooks
+    MAIN_GIT_DIR=$(dirname "$(dirname "$GIT_DIR")")
+    GIT_HOOKS_DIR="$MAIN_GIT_DIR/hooks"
+  fi
+fi
+
+TARGET="$GIT_HOOKS_DIR/post-commit"
+SOURCE="$REPO_ROOT/scripts/decision-log-commit-hook.sh"
+
+if [ ! -x "$SOURCE" ]; then
+  echo "[install] source hook not found or not executable: $SOURCE" >&2
+  exit 1
+fi
+
+mkdir -p "$GIT_HOOKS_DIR"
+
+if [ -e "$TARGET" ] || [ -L "$TARGET" ]; then
+  # Existing hook: check if it's ours. If yes, skip. If no, refuse.
+  if [ -L "$TARGET" ] && [ "$(readlink "$TARGET")" = "$SOURCE" ]; then
+    echo "[install] post-commit already installed (symlink → $SOURCE)"
+    exit 0
+  fi
+  if head -n 3 "$TARGET" 2>/dev/null | grep -q "decision-log-commit-hook.sh"; then
+    echo "[install] post-commit already installed (copy)"
+    exit 0
+  fi
+  echo "[install] refusing to overwrite existing $TARGET" >&2
+  echo "[install] existing hook contents:" >&2
+  head -n 5 "$TARGET" >&2
+  echo "[install] to replace: rm $TARGET && bash $0" >&2
+  exit 1
+fi
+
+# Symlink preferred (auto-updates when source changes)
+ln -s "$SOURCE" "$TARGET"
+echo "[install] linked $TARGET → $SOURCE"
+echo "[install] decision-log post-commit hook active. Next git commit in this repo will emit outcome.commit."
+
+cat <<'NOTE'
+
+Additional registration (requires human approval because .claude/settings.json
+is a governance file):
+
+  Add this block to .claude/settings.json (or merge into existing "hooks"):
+
+  {
+    "hooks": {
+      "UserPromptSubmit": [{"hooks": [{"type": "command",
+         "command": "bash $CLAUDE_PROJECT_DIR/scripts/decision-log-emit.sh user.turn"}]}],
+      "PreToolUse":      [{"hooks": [{"type": "command",
+         "command": "bash $CLAUDE_PROJECT_DIR/scripts/decision-log-emit.sh agent.tool_call"}]}],
+      "PostToolUse":     [{"hooks": [{"type": "command",
+         "command": "bash $CLAUDE_PROJECT_DIR/scripts/decision-log-emit.sh agent.tool_call_complete"}]}],
+      "Stop":            [{"hooks": [{"type": "command",
+         "command": "bash $CLAUDE_PROJECT_DIR/scripts/decision-log-emit.sh agent.output"}]}]
+    }
+  }
+
+  Once added, Claude Code will emit:
+    - user.turn on each prompt submit
+    - agent.tool_call before each tool invocation
+    - agent.tool_call_complete after each tool invocation
+    - agent.output at session Stop
+
+  See docs/research/routellm-phase3/analysis/decision-log-schema.md for full
+  schema and analysis recipes.
+NOTE

--- a/scripts/rotate-decision-logs.sh
+++ b/scripts/rotate-decision-logs.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# rotate-decision-logs.sh — gzip decision log files older than N days.
+#
+# The live file (today's UTC date) is never touched. Files from the prior
+# RETAIN_RAW_DAYS are kept uncompressed for easy jq analysis. Older files
+# are gzip'd in place. Already-gzip'd files are left alone.
+#
+# Usage:
+#   bash scripts/rotate-decision-logs.sh                 # default: 7 days retention
+#   RETAIN_RAW_DAYS=3 bash scripts/rotate-decision-logs.sh
+#   DECISION_LOG_DIR=/tmp/demo bash scripts/rotate-decision-logs.sh
+#
+# Idempotent. Run via cron / launchd on a daily schedule.
+
+set -eu
+
+RETAIN_RAW_DAYS="${RETAIN_RAW_DAYS:-7}"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+LOG_DIR="${DECISION_LOG_DIR:-$REPO_ROOT/docs/research/routellm-phase3/logs}"
+
+if [ ! -d "$LOG_DIR" ]; then
+  echo "[rotate] no log dir at $LOG_DIR; nothing to do" >&2
+  exit 0
+fi
+
+gzipped=0
+untouched=0
+
+# macOS-compatible: mtime measured in days via -mtime
+# -mtime +N means "modified more than N days ago"
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  if [ ! -f "$file" ]; then
+    continue
+  fi
+  if gzip -q "$file"; then
+    gzipped=$((gzipped + 1))
+    echo "[rotate] gzipped $file"
+  else
+    echo "[rotate] gzip failed for $file" >&2
+  fi
+done < <(find "$LOG_DIR" -type f -name 'decisions-*.jsonl' -mtime "+${RETAIN_RAW_DAYS}" 2>/dev/null)
+
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  untouched=$((untouched + 1))
+done < <(find "$LOG_DIR" -type f -name 'decisions-*.jsonl' -mtime "-${RETAIN_RAW_DAYS}" 2>/dev/null)
+
+echo "[rotate] retain_raw_days=$RETAIN_RAW_DAYS gzipped=$gzipped live_raw=$untouched log_dir=$LOG_DIR"


### PR DESCRIPTION
## Summary

Parent: #639 / #676 (Tier 2). Follows PR #679 (Tier 1). **conservative extension**

Operational layer for decision_event v1.0.0 logging. Completes the
outcome-side wiring and archival tooling so the log is self-sustaining
in production.

## 研究レポート

### 1. どんなもの？
| 成果物 | 役割 |
|---|---|
| `scripts/decision-log-commit-hook.sh` | git post-commit → `outcome.commit` (git_commit_hash, subject, author, files_modified, branch, worktree flag) |
| `scripts/rotate-decision-logs.sh` | `decisions-*.jsonl` で `RETAIN_RAW_DAYS` (default 7) を超えたファイルを gzip。今日のファイルは不可触。冪等 |
| `scripts/install-decision-log-hooks.sh` | `.git/hooks/post-commit` に symlink。worktree-aware (main repo の gitdir を解決)。`.claude/settings.json` snippet は **stdout に表示のみ** (governance approval 必要) |
| `decision-log-schema.md` 拡張 | 新 Operational setup 節 + decision_cat helper + 6 analysis recipes (event-type histogram, per-emitter counts, routing dist 24h, session 再構築, routing accuracy join, commit-vs-classification join) |
| Extended integration test | 4 emitter 対応 (integration.test / router.js / claude-code-hook / **git-post-commit-hook**)。7 events, all schema-valid |

### 2. 先行研究との差分
- Tier 1 (#679): router/classifier/Claude Code hook を emit 側配線
- **Tier 2 (本 PR)**: outcome 側 (git commit) 配線 + 運用 (rotation, install, analysis) 完成
- Tier 3 (follow-up): /verify skill + outcome.pr_merged 連携、24h soak test

### 3. 技術の肝
- **Install script が worktree-aware**: linked worktree で `.git` がファイルなら gitdir を解決して main repo の `.git/hooks/` にシンボリックリンク。main repo 側 hook なので全 worktree から共有
- **Rotation は idempotent**: `find -mtime +N` で日単位判定、今日のファイルは除外、gzip 失敗時も即座に回復可能
- **Analysis recipes は `.gz` 対応**: `decision_cat()` ヘルパが `.jsonl` と `.jsonl.gz` を透過的に stream
- **settings.json に自動編集しない**: governance file は human approval 必須を runbook で明記、installer が snippet を stdout に出すのみ

### 4. どうやって検証した？
| 検証 | 結果 |
|---|---|
| `bash -n` × 3 new scripts | PASS |
| `decision-log-commit-hook.sh` dry run | PASS (no git context → exit 0 gracefully) |
| `rotate-decision-logs.sh` 合成データ (10日/3日/今日) | 10日 gzipped、3日と今日は preserved |
| Extended integration test (4 emitters, 7 events) | **PASS all schema-valid** |
| `install-decision-log-hooks.sh` (dry-inspection) | 既存 hook を上書きしない、symlink 優先、snippet 表示 |

### 5. 議論
- **P2 verify hook の macOS sed 互換性問題**: 本セッションで判明。既存の `sed -n 's/...\\|.../'` 形式は BSD sed で alternation 失敗、GIT_DIR extraction 失敗 → main repo の staged state を worktree と誤認。この PR では **本体ロジック修正は別扱い** (user 判断待ち)、対処: branch-protection.sh 同等の `git -C` + `cd` 両対応の grep -oE ベースへ移植案を作成済
- **governance trade-off**: decision event 全量記録 vs privacy。redaction default は `prompt_sha_only`、opt-in で `none`。production で secrets 漏洩リスクなし
- **Log rotation 頻度**: 7 日は経験則、使用量によっては短縮可能 (RETAIN_RAW_DAYS 環境変数で調整)
- **.claude/settings.json 登録は未実施**: governance 承認必要、installer が snippet 表示のみ

### 6. 次に読むべき
- Git hooksampledoc (post-commit semantics)
- jq 1.6 streaming cookbook (analysis recipe 高速化)
- logrotate vs 自作 cron スクリプト比較 (操作性)

## ドキュメント更新
- [x] decision-log-schema.md に Operational setup 5 step + 6 analysis recipes 追記
- [x] Installer/rotation/hook scripts に inline docs (registration snippet 付)
- [x] Integration test が 4 emitter 自己記述的

## 後続 Issue
既存 #676 内で残るもの:
1. **`/verify` skill integration** で `outcome.verify` emit
2. **GitHub PR merge → outcome.pr_merged** (webhook or polling)
3. **24h soak test** on real ccr traffic
4. **Log shipping** (S3/GCS 等、必要なら)

加えて、本セッションで発見した **p2-verify-on-commit.sh の macOS sed 非互換性** は別 PR で user に patch 承認もらうべき事項。本 PR scope 外。

## Test plan
- [x] `bash -n` × 3 new scripts — PASS
- [x] Rotation 合成テスト (10日/3日/今日) — PASS
- [x] Extended integration test (4 emitters, 7 events) — PASS schema-valid
- [x] Install script を読み、governance-aware flow を確認 — PASS (settings.json 非編集)
- [ ] Production ccr 上で 24h soak — follow-up
- [ ] `/verify` skill で outcome.verify emit — follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)