### PR TITLE
feat(verify): wire outcome.verify decision-log emit (#676)

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -299,6 +299,42 @@ echo '{"epoch":'$(date +%s)',"files":["file1","file2",...],"verdict":"PASS","eva
 
 **FAIL の場合:** トークンを書き込まない。修正後に再度 /verify を実行する。
 
+#### 並行: decision log への `outcome.verify` emit
+
+P2 トークン書き込みと同時に、`decision_event v1.0.0` の `outcome.verify` を
+append-only ログに emit する。これにより後続の retrospective 分析で
+「どの commit/work に対し、どの evaluator が、どの結果を出したか」が結合可能になる。
+
+verdict が **PASS / FAIL / CONDITIONAL** いずれの場合も emit する（FAIL でも
+トークンは書かないが verify が走った事実は記録）。Best-effort: 失敗しても
+production path をブロックしない（`|| true`）。
+
+```bash
+# PASS / FAIL / CONDITIONAL いずれでも実行
+# files / verdict / evaluator / k_rounds / findings_count は実検証結果に置き換える
+jq -c -n \
+  --argjson files '["file1","file2"]' \
+  --arg verdict "PASS" \
+  --arg evaluator "subagent/claude" \
+  --argjson evaluator_independent false \
+  --argjson k_rounds 1 \
+  --arg pass_rate "1/1" \
+  --argjson findings_count 0 \
+  --argjson addressable 0 \
+  --arg risk_level "moderate" \
+  '$ARGS.named' \
+  | bash "$CLAUDE_PROJECT_DIR/scripts/decision-log-emit.sh" outcome.verify >/dev/null 2>&1 || true
+```
+
+emit script は `outcome.verify` event_type を認識し、payload を以下に展開する:
+
+- `execution.files_modified` ← `files`（検証対象パス）
+- `execution.evaluator` ← `evaluator`（`subagent/claude` / `logprob/qwen` / `human` 等）
+- `execution.evaluator_independent` ← `evaluator_independent`
+- `execution.k_rounds` / `execution.pass_rate` / `execution.risk_level`
+- `outcome.horizon` ← `"late"`（後続結合の合図）
+- `outcome.subsequent_verify` ← `{status, findings_count, addressable}`
+
 ### D10 接続: 検証結果の構造化
 
 D10（構造永続性）: 検証結果はエージェント消滅後も構造に残る。

--- a/docs/research/routellm-phase3/analysis/decision-log-schema.md
+++ b/docs/research/routellm-phase3/analysis/decision-log-schema.md
@@ -264,6 +264,55 @@ land in different events (via parent_event_id), but the shape is uniform.
 }
 ```
 
+### `outcome.verify` event (Skill-driven)
+
+Emitted by `.claude/skills/verify/SKILL.md` Step 5 in parallel with the
+P2 token write to `.claude/metrics/p2-verified.jsonl`. Captures the verifier
+identity, K-round configuration, and the verdict for retrospective routing
+analysis (e.g. "did cloud-routed turns produce code that passed verify more
+often than locally-routed turns?").
+
+Invocation contract (skill writes this payload to stdin):
+
+```jsonc
+{
+  "files":                ["path/a", "path/b"],   // verified file paths
+  "verdict":              "PASS",                  // PASS | FAIL | CONDITIONAL | N/A
+  "evaluator":            "subagent/claude",       // subagent/claude | logprob/qwen | ollama/<m> | api/<provider> | human
+  "evaluator_independent": false,                  // matches VerificationIndependence
+  "k_rounds":             1,
+  "pass_rate":            "1/1",                   // optional, defaults from k_rounds when verdict=PASS
+  "findings_count":       0,
+  "addressable":          0,                       // findings count that worker can address now
+  "risk_level":           "moderate"               // optional: low | moderate | high | critical
+}
+```
+
+Resulting envelope sections:
+
+```jsonc
+"execution": {
+  "files_modified":        ["path/a", "path/b"],
+  "evaluator":             "subagent/claude",
+  "evaluator_independent": false,
+  "k_rounds":              1,
+  "pass_rate":             "1/1",
+  "risk_level":            "moderate"
+},
+"outcome": {
+  "horizon":               "late",
+  "subsequent_verify": {
+    "status":              "PASS",
+    "findings_count":      0,
+    "addressable":         0
+  }
+}
+```
+
+Best-effort, append-only, never blocks the verify step. The skill emits on
+PASS, FAIL, and CONDITIONAL alike — the verify *event* is what the log
+captures, and the verdict is a field within it.
+
 ## `provenance` section
 
 ```jsonc

--- a/docs/research/routellm-phase3/classifier/tests/test_decision_log_integration.py
+++ b/docs/research/routellm-phase3/classifier/tests/test_decision_log_integration.py
@@ -85,13 +85,24 @@ def drive_all_emitters(log_dir: Path) -> list[dict]:
     )
     assert rc == 0, f"node invocation failed rc={rc} err={err}"
 
-    # 3. decision-log-emit.sh: 4 hook event types
+    # 3. decision-log-emit.sh: 5 hook event types (4 lifecycle + 1 skill-driven)
     sh_script = REPO_ROOT / "scripts" / "decision-log-emit.sh"
     for event_type, payload in [
         ("user.turn", {"prompt": "/test the hook"}),
         ("agent.tool_call", {"tool_name": "Edit", "tool_input": {"file_path": "x.py"}}),
         ("agent.tool_call_complete", {"tool_name": "Edit", "tool_response": {"error": None}}),
         ("agent.output", {"exit_status": "completed"}),
+        ("outcome.verify", {
+            "files": ["docs/example.md", "scripts/example.sh"],
+            "verdict": "PASS",
+            "evaluator": "subagent/claude",
+            "evaluator_independent": False,
+            "k_rounds": 1,
+            "pass_rate": "1/1",
+            "findings_count": 0,
+            "addressable": 0,
+            "risk_level": "moderate",
+        }),
     ]:
         rc, out, err = run_subprocess(
             ["bash", str(sh_script), event_type],
@@ -181,9 +192,102 @@ def main() -> int:
         assert "agent.tool_call" in observed_types, "hook did not emit agent.tool_call"
         assert "agent.tool_call_complete" in observed_types, "hook did not emit agent.tool_call_complete"
         assert "outcome.commit" in observed_types, "git post-commit hook did not emit"
+        assert "outcome.verify" in observed_types, "hook did not emit outcome.verify"
+
+        verify_events = [e for e in events if e.get("event_type") == "outcome.verify"]
+        assert verify_events, "no outcome.verify event found"
+        ve = verify_events[0]
+        assert ve.get("execution", {}).get("evaluator") == "subagent/claude", \
+            f"unexpected evaluator: {ve.get('execution', {}).get('evaluator')}"
+        assert ve.get("execution", {}).get("evaluator_independent") is False, \
+            "evaluator_independent should be False"
+        assert ve.get("execution", {}).get("k_rounds") == 1
+        assert ve.get("execution", {}).get("pass_rate") == "1/1", \
+            f"unexpected pass_rate: {ve.get('execution', {}).get('pass_rate')}"
+        assert ve.get("execution", {}).get("risk_level") == "moderate", \
+            f"unexpected risk_level: {ve.get('execution', {}).get('risk_level')}"
+        assert ve.get("outcome", {}).get("horizon") == "late"
+        sv = ve.get("outcome", {}).get("subsequent_verify", {})
+        assert sv.get("status") == "PASS", f"unexpected status: {sv.get('status')}"
+        assert sv.get("findings_count") == 0
+        assert sv.get("addressable") == 0
+        assert ve.get("execution", {}).get("files_modified") == [
+            "docs/example.md",
+            "scripts/example.sh",
+        ]
+
+        run_outcome_verify_negative_paths()
 
         print(f"\nPASS integration: {len(events)} events, 4 emitters, schema-valid")
         return 0
+    finally:
+        shutil.rmtree(log_dir, ignore_errors=True)
+
+
+def _emit_verify(payload: dict, log_dir: Path) -> dict:
+    """Drive decision-log-emit.sh outcome.verify with payload, return parsed event."""
+    sh_script = REPO_ROOT / "scripts" / "decision-log-emit.sh"
+    env = {
+        **os.environ,
+        "DECISION_LOG_DIR": str(log_dir),
+        "DECISION_LOG_REDACTION": "none",
+        "CLAUDE_SESSION_ID": "verify-negative-paths",
+        "CLAUDE_PROJECT_DIR": str(REPO_ROOT),
+    }
+    rc, out, err = run_subprocess(
+        ["bash", str(sh_script), "outcome.verify"],
+        env=env,
+        stdin=json.dumps(payload),
+    )
+    assert rc == 0, f"emit rc={rc} err={err}"
+    files = sorted(glob.glob(str(log_dir / "decisions-*.jsonl")))
+    last = json.loads(open(files[-1]).read().strip().splitlines()[-1])
+    return last
+
+
+def run_outcome_verify_negative_paths() -> None:
+    """T-1: cover non-PASS verdicts, invalid inputs, edge field types."""
+    log_dir = Path(tempfile.mkdtemp(prefix="decision-log-verify-neg-"))
+    try:
+        ev = _emit_verify({
+            "files": ["a.py"], "verdict": "FAIL", "evaluator": "subagent/claude",
+            "evaluator_independent": False, "k_rounds": 1, "findings_count": 3, "addressable": 1,
+        }, log_dir)
+        assert ev["outcome"]["subsequent_verify"]["status"] == "FAIL"
+        assert ev["outcome"]["subsequent_verify"]["findings_count"] == 3
+        assert ev["outcome"]["subsequent_verify"]["addressable"] == 1
+        assert "pass_rate" not in ev["execution"], \
+            f"FAIL verdict should not auto-default pass_rate, got {ev['execution'].get('pass_rate')}"
+
+        ev = _emit_verify({
+            "files": ["b.py"], "verdict": "CONDITIONAL", "evaluator": "logprob/qwen",
+            "evaluator_independent": True, "k_rounds": 3, "pass_rate": "2/3",
+            "findings_count": 1, "addressable": 0,
+        }, log_dir)
+        assert ev["outcome"]["subsequent_verify"]["status"] == "CONDITIONAL"
+        assert ev["execution"]["k_rounds"] == 3
+        assert ev["execution"]["pass_rate"] == "2/3"
+        assert ev["execution"]["evaluator_independent"] is True
+
+        ev = _emit_verify({
+            "files": [], "verdict": "garbage_value", "evaluator": "human",
+            "evaluator_independent": True, "k_rounds": 1,
+        }, log_dir)
+        assert ev["outcome"]["subsequent_verify"]["status"] == "N/A", \
+            f"unknown verdict should map to N/A, got {ev['outcome']['subsequent_verify']['status']}"
+        assert ev["execution"]["files_modified"] == []
+        assert ev["outcome"]["subsequent_verify"]["findings_count"] == 0
+
+        ev = _emit_verify({
+            "evaluator": "api/openrouter", "evaluator_independent": True, "k_rounds": 1,
+        }, log_dir)
+        assert ev["outcome"]["subsequent_verify"]["status"] == "N/A", \
+            "missing verdict should map to N/A"
+        assert ev["execution"]["files_modified"] == []
+        assert "risk_level" not in ev["execution"], \
+            "risk_level absent in payload should be omitted from execution"
+
+        print("PASS outcome.verify negative paths (4 sub-cases)")
     finally:
         shutil.rmtree(log_dir, ignore_errors=True)
 

--- a/scripts/decision-log-emit.sh
+++ b/scripts/decision-log-emit.sh
@@ -19,6 +19,9 @@
 #     }
 #   }
 #
+# Skill-driven invocation (e.g. from .claude/skills/verify/SKILL.md):
+#   echo "$payload_json" | bash scripts/decision-log-emit.sh outcome.verify
+#
 # Environment overrides:
 #   DECISION_LOG_DIR        — destination (default: <repo>/docs/research/routellm-phase3/logs)
 #   DECISION_LOG_REDACTION  — "none" | "prompt_sha_only" (default: prompt_sha_only)
@@ -119,6 +122,34 @@ elif event_type == "agent.output":
     outcome_section = {
         "horizon": "immediate",
         "exit_status": payload.get("exit_status", "completed"),
+    }
+elif event_type == "outcome.verify":
+    files = payload.get("files") or []
+    evaluator = payload.get("evaluator") or "subagent/claude"
+    evaluator_independent = bool(payload.get("evaluator_independent", False))
+    k_rounds = int(payload.get("k_rounds", 1) or 1)
+    pass_rate = payload.get("pass_rate") or (f"{k_rounds}/{k_rounds}" if str(payload.get("verdict") or "").upper() == "PASS" else None)
+    risk_level = payload.get("risk_level")
+    execution_section = {
+        "files_modified": list(files) if isinstance(files, list) else [],
+        "evaluator": evaluator,
+        "evaluator_independent": evaluator_independent,
+        "k_rounds": k_rounds,
+    }
+    if pass_rate is not None:
+        execution_section["pass_rate"] = pass_rate
+    if risk_level is not None:
+        execution_section["risk_level"] = risk_level
+    verdict_raw = str(payload.get("verdict") or "N/A").upper()
+    status = verdict_raw if verdict_raw in {"PASS", "FAIL", "CONDITIONAL", "N/A"} else "N/A"
+    subsequent_verify = {
+        "status": status,
+        "findings_count": int(payload.get("findings_count", 0) or 0),
+        "addressable": int(payload.get("addressable", payload.get("addressable_count", 0)) or 0),
+    }
+    outcome_section = {
+        "horizon": "late",
+        "subsequent_verify": subsequent_verify,
     }
 
 envelope = {


### PR DESCRIPTION
## Summary

- Closes the verify-step blind spot in the decision log: `/verify` invocations now emit `outcome.verify` events alongside the existing `p2-verified.jsonl` token write.
- `scripts/decision-log-emit.sh` gains a new `outcome.verify` branch that maps payload fields (`files`, `verdict`, `evaluator`, `evaluator_independent`, `k_rounds`, `pass_rate`, `findings_count`, `addressable`, `risk_level`) into the `execution` + `outcome.subsequent_verify` schema sections.
- `.claude/skills/verify/SKILL.md` Step 5 gains a parallel emit block; worker emits on PASS / FAIL / CONDITIONAL alike — the verify *event* is what the log captures; the verdict is a field within it.
- `decision-log-schema.md` now documents `outcome.verify` payload contract + envelope shape explicitly.

## Why now

Existing decision log captures `user.turn → router.* → agent.tool_call* → outcome.commit`, but verify was a blind spot. Once human GT arrives (#677), joining verify verdicts to commit / rewind outcomes will reveal whether risk-level routing matches downstream truth.

Conservative extension, refs #676 — additive only:
- New `outcome.verify` branch in emit script; existing `user.turn` / `agent.*` / `agent.output` branches untouched.
- New section in SKILL.md after Step 5; existing P2 token format unchanged.
- New event documentation in schema doc; existing sections unchanged.

## Test plan

- [x] Integration test extended: 8 events / 4 emitters / 5 hook event types, schema-valid (jsonschema 4.26.0).
- [x] Negative-path coverage added (T-1 fix from verifier round 1):
  - FAIL verdict → no auto-default `pass_rate`, `subsequent_verify.status` = "FAIL".
  - CONDITIONAL verdict → explicit `pass_rate`, `evaluator_independent` propagates.
  - Invalid verdict (`"garbage_value"`) → `status` = "N/A".
  - Missing `verdict` field → `status` = "N/A", absent `risk_level` not emitted.
- [x] Independent verifier subagent K=2 (CONDITIONAL → PASS after T-1 fix). Findings_count: 0.
- [x] Dogfood: this PR's own verify run was emitted via the new path to `docs/research/routellm-phase3/logs/decisions-2026-04-25.jsonl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)