### PR TITLE
fix(active-learning): gt_label priority in extract_label (#677)

### DIFF
--- a/docs/research/routellm-phase3/classifier/compute_disagreement_tiers.py
+++ b/docs/research/routellm-phase3/classifier/compute_disagreement_tiers.py
@@ -80,8 +80,18 @@ def load_label_jsonl(path: Path, label_field: str = "label") -> dict[str, dict]:
 
 
 def extract_label(entry: dict) -> Optional[str]:
-    """Return the model's label, falling back across known field names."""
-    for field in ("label", "predicted_label", "gt_label"):
+    """Return the model's label, falling back across known field names.
+
+    Priority: gt_label → label → predicted_label.
+
+    Rationale: Qwen output JSONL preserves the input's `predicted_label`
+    (mDeBERTa's call) AND adds its own `gt_label` (Qwen's call). For a Qwen
+    file we want the Qwen label, so `gt_label` must win. For a candidates
+    file with `gt_label: null` (not yet annotated), the None falls through
+    (isinstance check) and `predicted_label` is returned — preserving the
+    mDeBERTa-only path.
+    """
+    for field in ("gt_label", "label", "predicted_label"):
         v = entry.get(field)
         if isinstance(v, str) and v in VALID_LABELS:
             return v

--- a/docs/research/routellm-phase3/classifier/tests/test_compute_disagreement_tiers.py
+++ b/docs/research/routellm-phase3/classifier/tests/test_compute_disagreement_tiers.py
@@ -96,12 +96,30 @@ def test_classify_tier_missing_model() -> None:
 
 
 def test_extract_label_field_fallbacks() -> None:
+    # Single-field cases
     assert mod.extract_label({"label": "local_confident"}) == "local_confident"
     assert mod.extract_label({"predicted_label": "cloud_required"}) == "cloud_required"
     assert mod.extract_label({"gt_label": "hybrid"}) == "hybrid"
     assert mod.extract_label({"label": "invalid_label"}) is None
     assert mod.extract_label({}) is None
-    print("PASS extract_label field fallbacks (5 sub-cases)")
+
+    # Priority: gt_label wins over predicted_label.
+    # Qwen output preserves input's `predicted_label` (mDeBERTa) AND adds its
+    # own `gt_label` (Qwen). Reading a Qwen file must surface the Qwen label.
+    qwen_style = {"gt_label": "cloud_required", "predicted_label": "hybrid"}
+    assert mod.extract_label(qwen_style) == "cloud_required", \
+        "gt_label must win over predicted_label for Qwen-style records"
+
+    # Candidates-style: gt_label=null → fall through to predicted_label
+    candidates_style = {"gt_label": None, "predicted_label": "local_probable"}
+    assert mod.extract_label(candidates_style) == "local_probable", \
+        "null gt_label must fall through to predicted_label"
+
+    # `label` middle priority: present + no gt_label → wins over predicted_label
+    middle = {"label": "unknown", "predicted_label": "hybrid"}
+    assert mod.extract_label(middle) == "unknown"
+
+    print("PASS extract_label field fallbacks (8 sub-cases)")
 
 
 def test_compute_tiers_end_to_end() -> None:


### PR DESCRIPTION
Small priority fix for compute_disagreement_tiers.py: when reading a Qwen output file (which carries both `gt_label` from Qwen and a passthrough `predicted_label` from mDeBERTa), the old order surfaced mDeBERTa instead of Qwen. New order `gt_label → label → predicted_label`. Candidates files (`gt_label: null`) still fall through to `predicted_label` via the isinstance guard.

3 new test sub-cases verify the priority chain end-to-end. Independent verifier K=1 → PASS.

Discovered while ingesting real label data for #677 step 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)