### PR TITLE
docs(handoff): iter 3 refinements (constraints #1 #2 tightening)

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -184,8 +184,8 @@ on repo files) is FORBIDDEN until the role is consciously enacted.
 
 resume.md は次セッションが **resume.md だけ読んで ACT できる** よう self-sufficient であるべき。次の 5 制約を全て満たすこと:
 
-1. **Command surface explicitness**: Next Steps で言及する slash command (`/foo`) は必ず terminal-command equivalent (script path + args + env vars) と並記する。slash command は CC session scope なので cross-repo handoff で resolve しない可能性がある。
-2. **Path anchor explicitness**: 全 relative path に `<repo>/` または `<cwd>/` anchor を付ける。cwd ≠ work repo の cross-repo case では絶対パス推奨。
+1. **Command surface explicitness**: Next Steps で言及する slash command (`/foo`) は必ず terminal-command equivalent (script path + args + env vars) と並記する。slash command は CC session scope なので cross-repo handoff で resolve しない可能性がある。dispatch 系で prompt file を必要とする command は **prompt file path を明示** するか、または **「Coordinator が当該 task の brief を ADR-031 14-field template で composition」** sub-step を Next Steps に挿入する (どちらか必須)。空白の dispatch 指示は次セッションの discretionary fill-in を強制する (iter 2 verification で identified)。
+2. **Path anchor explicitness**: 全 path (relative も absolute も) に anchor を付ける。relative なら `<repo>/` `<cwd>/` `<workspace>/` 等の prefix、cross-repo case (cwd ≠ work repo) では絶対 path を推奨。**この制約は cross-references field にも適用** — ADR / requirement file / memory pointer を cite する場合、絶対 path または `<repo>/decisions/ADR-NNN.md` 形式の anchored path で記載する (iter 2 verification で "ADR-031 absolute path 未記載" として identified)。
 3. **Cross-repo cwd role declaration**: cwd ≠ work repo の場合、cwd の role を明示する: `passive base` (no commits) / `commit target` / `discard at end`。
 4. **Bounded protocol completeness**: 引用する bounded-iteration protocol (例: `≥3 ≤5 rounds, convergence = 2 consecutive sufficient`) は **success branch と cap-exceeded fallback の両方** を記載する。
 5. **Resource counter envelope**: consumption tally (Codex dispatches, token usage 等) は `{limit, window, carryover policy}` と並記する。tally だけでは次セッションの予算判断に使えない。


### PR DESCRIPTION
## Summary

Refines constraints #1 (Command surface) and #2 (Path anchor) of the resume.md self-sufficiency requirements based on **iter 2 verification subagent findings**.

## Empirical evidence (iter 3 input from iter 2 verification)

The iter 2 verification subagent (realistic-framing test on the iter-2-improved resume.md) achieved 6/6 ○ on critical role-enactment requirements but flagged two minor structural gaps:

### Finding 1: dispatch-with-prompt-file case not covered

Constraint #1 covered slash → shell translation but did not cover dispatch-style commands that need a prompt file. The iter 2 subagent was forced into discretionary fill-in: "I assume the prompt file should be written under the orchestrator repo's tmp/ or .claude/handoffs/ ... since this session's cwd is 'passive orchestration base'."

**Refinement**: dispatch-style commands MUST either pre-stage the prompt file path OR insert a "Coordinator composes brief per ADR-031 14-field template" sub-step into Next Steps.

### Finding 2: cross-references field not anchored

Constraint #2 covered structured_log path but could be read as "structured_log only". Cross-references (ADR / requirement / memory pointers) were cited as relative repo-paths which the iter 2 subagent flagged as needing absolute or anchored form.

**Refinement**: explicitly extend constraint #2 to cover cross-references field and any other path-bearing fields.

## Diff

2 lines changed in `.claude/skills/handoff/SKILL.md` — both are extensions to existing constraint wording (same theme as iter 1, artifact self-sufficiency).

## Iter 4 deferred (different theme — discovery infrastructure)

- `.injected` file lifecycle (archive on consumption)
- Multi-resume INDEX or `latest` pointer

Memory ledger entry: `~/.claude/projects/-Users-nirarin-work-agent-manifesto/memory/feedback_handoff_self_sufficiency.md`.

## Test plan

- [x] Iter 3 commit applied to constraints #1 #2 wording
- [ ] Iter 3 verification dispatch (post-merge or pre-merge): realistic-framing test expecting 0 minor findings
- [ ] If verification finds new gaps, iter 4 (different theme) handles them

## Compatibility

`compatible change` — documentation only. Refines existing constraint wording without breaking prior handoffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)